### PR TITLE
[QA-2325] Fix test result notification failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ commands:
           working_directory: integration-tests
           name: Slack notification on dev branch only
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
+            if [ "$CIRCLE_NODE_INDEX" -eq 0 ]; then
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
@@ -227,15 +227,6 @@ jobs:
             fi
       - run: yarn run build
       - run: yarn eslint --max-warnings=0 .
-      - run: yarn workspaces foreach --exclude terra-integration-tests run test --coverage --maxWorkers=2 --passWithNoTests
-      - store_artifacts:
-          path: test-report/index.html
-      - run: yarn check-types
-      - save_cache:
-          key: deps-{{ .Branch }}-{{ checksum ".pnp.cjs" }}
-          paths:
-            - .yarn/unplugged
-            - node_modules/.cache
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
       - store_artifacts:
           path: build.tgz
@@ -292,10 +283,6 @@ workflows:
     jobs:
       - build
       - integration-tests-pr-staging:
-          <<: *filter-pr-branch
-          requires:
-            - build
-      - deploy-pr:
           <<: *filter-pr-branch
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,19 +197,13 @@ commands:
           destination: results
       - run:
           working_directory: integration-tests
-          name: Run wait-for-job-finish script on dev branch only
-          command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
-              bash ../.circleci/wait-for-job-finish.sh
-            fi
-          when: always
-      - run:
-          working_directory: integration-tests
           name: Slack notification on dev branch only
           command: |
             if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
+              bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
+          no_output_timeout: 35m
           when: always
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ commands:
               bash ../.circleci/wait-for-job-finish.sh
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
-          no_output_timeout: 35m
+          no_output_timeout: 30m
           when: always
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,13 +197,19 @@ commands:
           destination: results
       - run:
           working_directory: integration-tests
+          name: Run wait-for-job-finish script on dev branch only
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
+              bash ../.circleci/wait-for-job-finish.sh
+            fi
+          when: always
+      - run:
+          working_directory: integration-tests
           name: Slack notification on dev branch only
           command: |
-            if [ "$CIRCLE_NODE_INDEX" -eq 0 ]; then
-              bash ../.circleci/wait-for-job-finish.sh
+            if [ "$CIRCLE_NODE_INDEX" -eq 0 ] && [ "$CIRCLE_BRANCH" = "dev" ]; then
               node --require ../.pnp.cjs ./slack/notify-circleci-test-results.js
             fi
-          no_output_timeout: 30m
           when: always
 
 jobs:
@@ -227,6 +233,15 @@ jobs:
             fi
       - run: yarn run build
       - run: yarn eslint --max-warnings=0 .
+      - run: yarn workspaces foreach --exclude terra-integration-tests run test --coverage --maxWorkers=2 --passWithNoTests
+      - store_artifacts:
+          path: test-report/index.html
+      - run: yarn check-types
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum ".pnp.cjs" }}
+          paths:
+            - .yarn/unplugged
+            - node_modules/.cache
       - run: tar -czf build.tgz .gcloudignore app.yaml build config
       - store_artifacts:
           path: build.tgz
@@ -283,6 +298,10 @@ workflows:
     jobs:
       - build
       - integration-tests-pr-staging:
+          <<: *filter-pr-branch
+          requires:
+            - build
+      - deploy-pr:
           <<: *filter-pr-branch
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ commands:
             JEST_JUNIT_OUTPUT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/junit"
             SCREENSHOT_DIR: "<< parameters.log_dir >>/<< parameters.env >>/test-results/failure-screenshots"
             ENVIRONMENT: << parameters.env >>
-          no_output_timeout: 30m
+          no_output_timeout: 45m
           command: |
             mkdir -p ${SCREENSHOT_DIR}
             TESTS_TO_RUN=$(yarn run jest --listTests | sed "s|$(pwd)/||")

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -18,7 +18,6 @@ while [ "$counter" -le 1800 ]; do
     exit 0
   fi
 
-  echo "Checking job status: Waiting for parallel running nodes to finish. Waited $counter seconds."
   sleep 30
   counter=$(($counter + 30))
 done

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 counter=0
 
 # Wait up to 30 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 2000 ]; do
+while [ "$counter" -le 1800 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '[.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
@@ -18,9 +18,9 @@ while [ "$counter" -le 2000 ]; do
     exit 0
   fi
 
-  echo "Checking status from NODE_INDEX #$CIRCLE_NODE_INDEX: Waiting for parallel running nodes to finish. Waited $counter seconds."
-  sleep 10
-  counter=$(($counter + 10))
+  echo "Checking job status: Waiting for parallel running nodes to finish. Waited $counter seconds."
+  sleep 30
+  counter=$(($counter + 30))
 done
 
 echo "Waited total $counter seconds"

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -8,8 +8,8 @@ set -eo pipefail
 
 counter=0
 
-# Wait up to 25 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
-while [ "$counter" -le 1500 ]; do
+# Wait up to 30 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
+while [ "$counter" -le 2000 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
   job_running_nodes_count=$(echo "$job_detail" | jq -r '[.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
@@ -18,6 +18,7 @@ while [ "$counter" -le 1500 ]; do
     exit 0
   fi
 
+  echo "Checking status from NODE_INDEX #$CIRCLE_NODE_INDEX: Waiting for parallel running nodes to finish. Waited $counter seconds."
   sleep 10
   counter=$(($counter + 10))
 done

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -13,12 +13,14 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     throw new Error('**  ERROR: Missing CircleCI build number. Failed to fetch CircleCI job artifacts.');
   }
 
-  // For more arguments and details of the response, see: https://circleci.com/docs/api/v2/index.html#operation/getJobArtifacts
-  const apiUrlRoot = 'https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui';
+  // The v1.1 artifacts API does not need token, so we use it instead.
+  const apiUrlRoot = 'https://circleci.com/api/v1.1/project/github/DataBiosphere/terra-ui';
   try {
     // Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
     const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`);
-    const { items } = await response.json();
+    const resp = await response.json();
+    console.log(`artifacts resp: ${resp}`);
+    const { items } = resp;
     const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items);
     return _.map('url', testSummaryArtifacts);
   } catch (e) {

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -27,8 +27,8 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     const response = await fetch(`${apiUrlRoot}/${buildNum}/artifacts`);
     checkStatus(response);
 
-    const responseJson = await response.json();
-    const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), responseJson);
+    const items = await response.json();
+    const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items);
     return _.map('url', testSummaryArtifacts);
   } catch (error) {
     console.error(`** ERROR fetching CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`);
@@ -56,6 +56,7 @@ const getFailedTestNames = (aggregatedResults) => {
  */
 const getFailedTestNamesFromArtifacts = async () => {
   const urls = await fetchJobArtifacts();
+  console.log(`Build artifacts URLs: \n${urls.map((url) => `* ${url}`).join('\n')}\n`);
   return _.flatten(
     await Promise.all(
       _.map(async (url) => {

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -30,7 +30,7 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     const testSummaryArtifacts = _.filter(_.flow(_.get('path'), _.includes('tests-summary')), items);
     return _.map('url', testSummaryArtifacts);
   } catch (error) {
-    console.error(`** ERROR fetching CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`);
+    console.error(`** ERROR fetching CircleCI artifacts for JOB_BUILD_NUM: ${buildNum}`);
     console.error(error);
     throw error;
   }

--- a/integration-tests/slack/circleci-utils.js
+++ b/integration-tests/slack/circleci-utils.js
@@ -20,7 +20,6 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
     throw new Error('**  ERROR: Missing CircleCI build number. Failed to fetch CircleCI job artifacts.');
   }
 
-  // The v1.1 artifacts API does not need token, so we use it instead.
   const apiUrlRoot = 'https://circleci.com/api/v1.1/project/github/DataBiosphere/terra-ui';
   try {
     // Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
@@ -33,7 +32,6 @@ const fetchJobArtifacts = async ({ buildNum = process.env.CIRCLE_BUILD_NUM } = {
   } catch (error) {
     console.error(`** ERROR fetching CircleCI JOB_BUILD_NUM: ${buildNum} artifacts.`);
     console.error(error);
-    console.error(`HTTP error response body: ${await error.response.text()}`);
     throw error;
   }
 };


### PR DESCRIPTION
[QA-2325](https://broadworkbench.atlassian.net/browse/QA-2325)

## Summary of changes:
CircleCI v2 GET /artifacts endpoint required token for validation. Response from calling /artifacts endpoint was 

```
{
  "message": "You must log in first"
}
```
Use older v1.1. API to get job artifacts because v1.1 API remains public and does not require a token for authentication.


[QA-2325]: https://broadworkbench.atlassian.net/browse/QA-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ