### PR TITLE
fix wait-for-job-finish script

### DIFF
--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -15,8 +15,8 @@ counter=0
 while [ "$counter" -le 1800 ]; do
   # Find number of nodes in running
   job_detail=$(curl -s "$BASE_URL/$CIRCLE_BUILD_NUM")
-  nodes=$(echo "$job_detail" | jq -r '.steps[] | select(.name=="Running UI integration tests")')
-  running_nodes_count=$(echo "$nodes" | jq -r '[.actions[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
+  ui_test_step=$(echo "$job_detail" | jq -r '.steps[] | select(.name=="Running UI integration tests")')
+  running_nodes_count=$(echo "$ui_test_step" | jq -r '[.actions[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
   
   if [ "$running_nodes_count" -eq 0 ]; then
     exit 0

--- a/.circleci/wait-for-job-finish.sh
+++ b/.circleci/wait-for-job-finish.sh
@@ -6,15 +6,19 @@ set -o nounset
 # Use the error status of the first failure, rather than that of the last item in a pipeline. Also fail explicitly on any exit code.
 set -eo pipefail
 
+# Because terra-ui is a public repository on GitHub, API token is not required. See: https://circleci.com/docs/oss#security
+BASE_URL="https://circleci.com/api/v1.1/project/github/DataBiosphere/terra-ui"
+
 counter=0
 
 # Wait up to 30 minutes for job to finish. A job can run on multiple nodes: parallelism > 1
 while [ "$counter" -le 1800 ]; do
   # Find number of nodes in running
-  job_detail=$(curl -s "https://circleci.com/api/v2/project/github/DataBiosphere/terra-ui/job/$CIRCLE_BUILD_NUM")
-  job_running_nodes_count=$(echo "$job_detail" | jq -r '[.parallel_runs[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
-
-  if [ "$job_running_nodes_count" -eq 0 ]; then
+  job_detail=$(curl -s "$BASE_URL/$CIRCLE_BUILD_NUM")
+  nodes=$(echo "$job_detail" | jq -r '.steps[] | select(.name=="Running UI integration tests")')
+  running_nodes_count=$(echo "$nodes" | jq -r '[.actions[] | select(.status == "running") | select(.index != '"$CIRCLE_NODE_INDEX"')] | length')
+  
+  if [ "$running_nodes_count" -eq 0 ]; then
     exit 0
   fi
 


### PR DESCRIPTION
`wait-for-job-finished.sh` script failed last night with error `jq: error (at <stdin>:1): Cannot iterate over null (null)`.

Failed CircleCI [workflow](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/24119/workflows/d248ca1f-87a3-4555-93fa-c606b1ab8123/jobs/80901).

Same reason and change as in [PR 4878](https://github.com/DataBiosphere/terra-ui/pull/4878), the`wait-for-job-finished.sh` also needs to be updated to use v1.1 API. Without a bearer token, the V2 GET job detail endpoint seems to work during the day time but fails in the night time.
