### PR TITLE
[WX-1643] Fix Input/Output Display Bug

### DIFF
--- a/src/workflows-app/SubmissionDetails.test.js
+++ b/src/workflows-app/SubmissionDetails.test.js
@@ -1302,9 +1302,9 @@ describe('Submission Details page', () => {
           .getAllByRole('cell')
           .map((el) => el.textContent);
 
-      expect(getRowContent(1)).toEqual(['fetch_sra_to_bam.\nSRA_ID', 'SRR13379731']);
-      expect(getRowContent(2)).toEqual(['fetch_sra_to_bam.\nmachine_mem_gb', '']);
-      expect(getRowContent(3)).toEqual(['fetch_sra_to_bam.\ndocker', 'quay.io/broadinstitute/ncbi-tools:2.10.7.10']);
+      expect(getRowContent(1)).toEqual(['Fetch_SRA_to_BAM.SRA_ID', 'SRR13379731']);
+      expect(getRowContent(2)).toEqual(['Fetch_SRA_to_BAM.machine_mem_gb', '']);
+      expect(getRowContent(3)).toEqual(['Fetch_SRA_to_BAM.docker', 'quay.io/broadinstitute/ncbi-tools:2.10.7.10']);
     }
   });
 
@@ -1395,18 +1395,18 @@ describe('Submission Details page', () => {
       const headers = within(rows[0]).getAllByRole('columnheader');
       expect(headers).toHaveLength(2);
 
-      expect(getRowContent(1)).toEqual(['fetch_sra_to_bam.\nsra_metadata', 'SRR13379731.json']);
-      expect(getRowContent(2)).toEqual(['fetch_sra_to_bam.\nreads_ubam', 'SRR13379731.bam']);
-      expect(getRowContent(3)).toEqual(['fetch_sra_to_bam.\nbiosample_accession', 'kljkl2kj']);
-      expect(getRowContent(4)).toEqual(['fetch_sra_to_bam.\nsample_geo_loc', 'USA']);
-      expect(getRowContent(5)).toEqual(['fetch_sra_to_bam.\nsample_collection_date', '2020-11-30']);
-      expect(getRowContent(6)).toEqual(['fetch_sra_to_bam.\nsequencing_center', 'SEQ_CENTER']);
-      expect(getRowContent(7)).toEqual(['fetch_sra_to_bam.\nsequencing_platform', 'PLATFORM COMPANY']);
-      expect(getRowContent(8)).toEqual(['fetch_sra_to_bam.\nlibrary_id', 'ST-VALUE-2012556126']);
-      expect(getRowContent(9)).toEqual(['fetch_sra_to_bam.\nrun_date', '2022-06-22']);
-      expect(getRowContent(10)).toEqual(['fetch_sra_to_bam.\nsample_collected_by', 'Random lab']);
-      expect(getRowContent(11)).toEqual(['fetch_sra_to_bam.\nsample_strain', 'SARS-CoV-2/USA/44165/2020']);
-      expect(getRowContent(12)).toEqual(['fetch_sra_to_bam.\nsequencing_platform_model', 'NextSeq 550']);
+      expect(getRowContent(1)).toEqual(['sra_metadata', 'SRR13379731.json']);
+      expect(getRowContent(2)).toEqual(['reads_ubam', 'SRR13379731.bam']);
+      expect(getRowContent(3)).toEqual(['biosample_accession', 'kljkl2kj']);
+      expect(getRowContent(4)).toEqual(['sample_geo_loc', 'USA']);
+      expect(getRowContent(5)).toEqual(['sample_collection_date', '2020-11-30']);
+      expect(getRowContent(6)).toEqual(['sequencing_center', 'SEQ_CENTER']);
+      expect(getRowContent(7)).toEqual(['sequencing_platform', 'PLATFORM COMPANY']);
+      expect(getRowContent(8)).toEqual(['library_id', 'ST-VALUE-2012556126']);
+      expect(getRowContent(9)).toEqual(['run_date', '2022-06-22']);
+      expect(getRowContent(10)).toEqual(['sample_collected_by', 'Random lab']);
+      expect(getRowContent(11)).toEqual(['sample_strain', 'SARS-CoV-2/USA/44165/2020']);
+      expect(getRowContent(12)).toEqual(['sequencing_platform_model', 'NextSeq 550']);
     }
   });
 

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -61,10 +61,14 @@ type FilterableWorkflowTableProps = {
 };
 
 /**
- * When displaying task data, there is no need to include the workflow name as it is already present elsewhere on the page.
- * Here, we strip away the first part of the task key (expected to be the workflow name) to make it shorter and more readable.
- * @param keyValuePairs A map from fully qualified task name to value (can be either inputs or outputs)
- * @returns A map where the fully qualified task name has been stripped of the workflow name prefix.
+ * Workflow Inputs and Outputs are "fully qualified" and come in the form:
+ *    WorkflowName.TaskName.VariableName (for task input/outputs) or
+ *    WorkflowName.VariableName (for workflow inputs/outputs)
+ * Keep in mind that TaskName may be multiple segments in the case of nested workflows.
+ * When displaying these, there is no need to include the workflow name as it is already present elsewhere on the page.
+ * Here, we strip away the first part of the key (expected to be the workflow name) to make it shorter and more readable.
+ * @param keyValuePairs A map from fully qualified variable name to value.
+ * @returns A map where the fully qualified variable name has been stripped of the workflow name prefix.
  */
 const stripWorkflowPrefixFromKeys = <T extends Record<string, any>>(keyValuePairs: T): { [k: string]: any } => {
   const maybeRemovePrefix = (key: string): string => {


### PR DESCRIPTION
Fixed a bug where we were incorrectly displaying inputs/outputs (and including a newline for some reason) on the Submission Details page.

Before: `'WorkflowName.\nVariableName'`
After: `'CallName.VariableName'` (or just `'VariableName'` in the case of a workflow level input/output)