### PR TITLE
[UIE-189] Update workspace not found UX

### DIFF
--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -1,6 +1,6 @@
 import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
-import { PropsWithChildren, ReactNode, Ref, useEffect, useRef, useState } from 'react';
+import { Fragment, PropsWithChildren, ReactNode, Ref, useEffect, useRef, useState } from 'react';
 import { div, h, h2, h3, p, span } from 'react-hyperscript-helpers';
 import { AnalysesData } from 'src/analysis/Analyses';
 import AnalysisNotificationManager from 'src/analysis/AnalysisNotificationManager';
@@ -55,13 +55,11 @@ const GooglePermissionsSpinner = (): ReactNode => {
 interface WorkspaceContainerProps extends PropsWithChildren {
   namespace: string;
   name: string;
-  breadcrumbs: ReactNode[];
-  title: string;
   activeTab?: string;
   analysesData: AnalysesData;
   storageDetails: StorageDetails;
   refresh: () => Promise<void>;
-  workspace: InitializedWorkspaceWrapper | undefined;
+  workspace: InitializedWorkspaceWrapper;
   refreshWorkspace: () => void;
 }
 
@@ -69,8 +67,6 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const {
     namespace,
     name,
-    breadcrumbs,
-    title,
     activeTab,
     analysesData: {
       apps = [],
@@ -92,29 +88,20 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const [sharingWorkspace, setSharingWorkspace] = useState(false);
   const [showLockWorkspaceModal, setShowLockWorkspaceModal] = useState(false);
   const [leavingWorkspace, setLeavingWorkspace] = useState(false);
-  const workspaceLoaded = !!workspace;
-  const isGoogleWorkspaceSyncing =
-    workspaceLoaded && isGoogleWorkspace(workspace) && workspace?.workspaceInitialized === false;
+  const isGoogleWorkspaceSyncing = isGoogleWorkspace(workspace) && workspace.workspaceInitialized === false;
 
   useCloningWorkspaceNotifications();
-  useWorkspaceStatePolling(workspace ? [workspace] : [], workspaceLoaded ? 'Ready' : 'Loading');
+  useWorkspaceStatePolling([workspace], 'Ready');
 
   useEffect(() => {
-    if (workspace?.workspace?.state === 'Deleted') {
+    if (workspace.workspace.state === 'Deleted') {
       Nav.goToPath('workspaces');
       workspaceStore.reset();
     }
   }, [workspace]);
 
-  return h(FooterWrapper, [
-    h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
-      div({ style: Style.breadcrumb.breadcrumb }, [
-        div({ style: Style.noWrapEllipsis }, breadcrumbs),
-        h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [title || `${namespace}/${name}`]),
-      ]),
-      div({ style: { flexGrow: 1 } }),
-      h(AnalysisNotificationManager, { namespace, name, runtimes, apps }),
-    ]),
+  return h(Fragment, [
+    h(AnalysisNotificationManager, { namespace, name, runtimes, apps }),
     h(WorkspaceTabs, {
       namespace,
       name,
@@ -132,9 +119,8 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
     div({ role: 'main', style: Style.elements.pageContentContainer }, [
       div({ style: { flex: 1, display: 'flex' } }, [
         div({ style: { flex: 1, display: 'flex', flexDirection: 'column' } }, [children]),
-        workspace &&
-          workspace?.workspace.state !== 'Deleting' &&
-          workspace?.workspace.state !== 'DeleteFailed' &&
+        workspace.workspace.state !== 'Deleting' &&
+          workspace.workspace.state !== 'DeleteFailed' &&
           h(ContextBar, {
             workspace,
             apps,
@@ -148,21 +134,20 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
           }),
       ]),
     ]),
-    workspace &&
-      h(WorkspaceContainerModals, {
-        workspace,
-        refreshWorkspace,
-        deletingWorkspace,
-        setDeletingWorkspace,
-        cloningWorkspace,
-        setCloningWorkspace,
-        leavingWorkspace,
-        setLeavingWorkspace,
-        sharingWorkspace,
-        setSharingWorkspace,
-        showLockWorkspaceModal,
-        setShowLockWorkspaceModal,
-      }),
+    h(WorkspaceContainerModals, {
+      workspace,
+      refreshWorkspace,
+      deletingWorkspace,
+      setDeletingWorkspace,
+      cloningWorkspace,
+      setCloningWorkspace,
+      leavingWorkspace,
+      setLeavingWorkspace,
+      sharingWorkspace,
+      setSharingWorkspace,
+      showLockWorkspaceModal,
+      setShowLockWorkspaceModal,
+    }),
   ]);
 };
 
@@ -197,7 +182,7 @@ const WorkspaceAccessError = () => {
 export interface WrapWorkspaceOptions {
   breadcrumbs: (props: { name: string; namespace: string }) => ReactNode[];
   activeTab?: string;
-  title: string;
+  title: string | ((props: { name: string; namespace: string }) => string);
 }
 
 export interface WrappedComponentProps {
@@ -244,60 +229,75 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
         useCloudEnvironmentPolling(name, namespace, workspace);
       const { apps, refreshApps, lastRefresh } = useAppPolling(name, namespace, workspace);
 
-      if (accessError) {
-        return h(FooterWrapper, [h(TopBar), h(WorkspaceAccessError)]);
-      }
+      return h(FooterWrapper, [
+        h(TopBar, { title: 'Workspaces', href: Nav.getLink('workspaces') }, [
+          div({ style: Style.breadcrumb.breadcrumb }, [
+            div({ style: Style.noWrapEllipsis }, breadcrumbs(props)),
+            h2({ style: Style.breadcrumb.textUnderBreadcrumb }, [
+              (_.isFunction(title) ? title(props) : title) || `${namespace}/${name}`,
+            ]),
+          ]),
+        ]),
+        (() => {
+          if (loadingWorkspace) {
+            return spinnerOverlay;
+          }
 
-      return h(
-        WorkspaceContainer,
-        {
-          namespace,
-          name,
-          activeTab,
-          workspace,
-          refreshWorkspace,
-          title: _.isFunction(title) ? title(props) : title,
-          breadcrumbs: breadcrumbs(props),
-          analysesData: {
-            apps,
-            refreshApps,
-            lastRefresh,
-            runtimes,
-            refreshRuntimes,
-            appDataDisks,
-            persistentDisks,
-            isLoadingCloudEnvironments,
-          },
-          storageDetails,
-          refresh: async () => {
-            await refreshWorkspace();
-            if (_.isObject(child?.current) && 'refresh' in child.current && _.isFunction(child.current.refresh)) {
-              child.current.refresh();
-            }
-          },
-        },
-        [
-          workspace &&
-            h(WrappedComponent, {
-              ref: child,
-              workspace,
-              refreshWorkspace,
-              analysesData: {
-                apps,
-                refreshApps,
-                lastRefresh,
-                runtimes,
-                refreshRuntimes,
-                appDataDisks,
-                persistentDisks,
-                isLoadingCloudEnvironments,
+          if (accessError) {
+            return h(WorkspaceAccessError);
+          }
+
+          return (
+            workspace &&
+            h(
+              WorkspaceContainer,
+              {
+                namespace,
+                name,
+                activeTab,
+                workspace,
+                refreshWorkspace,
+                analysesData: {
+                  apps,
+                  refreshApps,
+                  lastRefresh,
+                  runtimes,
+                  refreshRuntimes,
+                  appDataDisks,
+                  persistentDisks,
+                  isLoadingCloudEnvironments,
+                },
+                storageDetails,
+                refresh: async () => {
+                  await refreshWorkspace();
+                  if (_.isObject(child?.current) && 'refresh' in child.current && _.isFunction(child.current.refresh)) {
+                    child.current.refresh();
+                  }
+                },
               },
-              storageDetails,
-              ...props,
-            }),
-          loadingWorkspace && spinnerOverlay,
-        ]
-      );
+              [
+                h(WrappedComponent, {
+                  ref: child,
+                  workspace,
+                  refreshWorkspace,
+                  analysesData: {
+                    apps,
+                    refreshApps,
+                    lastRefresh,
+                    runtimes,
+                    refreshRuntimes,
+                    appDataDisks,
+                    persistentDisks,
+                    isLoadingCloudEnvironments,
+                  },
+                  storageDetails,
+                  ...props,
+                }),
+              ]
+            )
+          );
+        })(),
+      ]);
     };
     return withDisplayName('wrapWorkspace', Wrapper);
   };

--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -238,23 +238,38 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
             ]),
           ]),
         ]),
-        (() => {
-          if (loadingWorkspace) {
-            return spinnerOverlay;
-          }
-
-          if (accessError) {
-            return h(WorkspaceAccessError);
-          }
-
-          return (
-            workspace &&
-            h(
-              WorkspaceContainer,
-              {
-                namespace,
-                name,
-                activeTab,
+        loadingWorkspace && spinnerOverlay,
+        accessError && h(WorkspaceAccessError),
+        workspace &&
+          h(
+            WorkspaceContainer,
+            {
+              namespace,
+              name,
+              activeTab,
+              workspace,
+              refreshWorkspace,
+              analysesData: {
+                apps,
+                refreshApps,
+                lastRefresh,
+                runtimes,
+                refreshRuntimes,
+                appDataDisks,
+                persistentDisks,
+                isLoadingCloudEnvironments,
+              },
+              storageDetails,
+              refresh: async () => {
+                await refreshWorkspace();
+                if (_.isObject(child?.current) && 'refresh' in child.current && _.isFunction(child.current.refresh)) {
+                  child.current.refresh();
+                }
+              },
+            },
+            [
+              h(WrappedComponent, {
+                ref: child,
                 workspace,
                 refreshWorkspace,
                 analysesData: {
@@ -268,35 +283,10 @@ export const wrapWorkspace = (opts: WrapWorkspaceOptions): WrapWorkspaceFn => {
                   isLoadingCloudEnvironments,
                 },
                 storageDetails,
-                refresh: async () => {
-                  await refreshWorkspace();
-                  if (_.isObject(child?.current) && 'refresh' in child.current && _.isFunction(child.current.refresh)) {
-                    child.current.refresh();
-                  }
-                },
-              },
-              [
-                h(WrappedComponent, {
-                  ref: child,
-                  workspace,
-                  refreshWorkspace,
-                  analysesData: {
-                    apps,
-                    refreshApps,
-                    lastRefresh,
-                    runtimes,
-                    refreshRuntimes,
-                    appDataDisks,
-                    persistentDisks,
-                    isLoadingCloudEnvironments,
-                  },
-                  storageDetails,
-                  ...props,
-                }),
-              ]
-            )
-          );
-        })(),
+                ...props,
+              }),
+            ]
+          ),
       ]);
     };
     return withDisplayName('wrapWorkspace', Wrapper);


### PR DESCRIPTION
Based off feedback at Connect Day demos...
https://broadinstitute.slack.com/archives/C03GMG4DUSE/p1717611642718629

Currently, while a workspace is loading, you see the workspace name in the top bar and the workspace tabs. If the workspace is not found or you don't have access to it, those then disappear when the no access message is displayed.

Feedback from the demo was that the flash of content is confusing... it looked like the workspace loaded and then access was denied client-side afterwards when, in fact, the workspace was never successfully loaded.

Also, the no access screen isn't great... the navigation affordance of which workspace you're trying to look at is taken away.

This changes the UX so that the workspace name is always shown in the top bar while loading _and_ if access is denied/the workspace isn't found. To avoid the possible flash of content, the workspace tabs aren't shown until the workspace is actually loaded.

It also moves the page layout pieces (FooterWrapper and TopBar) from WorkspaceContainer to Wrapper. Since WorkspaceContainer now is only rendered once the workspace is loaded, it can be simplified because its `workspace` prop is now typed `Workspace` instead of `Workspace | undefined`.

Note for reviewers: the diff is smaller with whitespace changes ignored (https://github.com/DataBiosphere/terra-ui/pull/4887/files?w=1).

## Before

(Screen recordings have an artificial delay added to loading the workspace to highlight the UX)

https://github.com/DataBiosphere/terra-ui/assets/1156625/6ccb09e0-0343-4677-be62-2be8cc590ed9

## After

https://github.com/DataBiosphere/terra-ui/assets/1156625/05070bf6-2b96-475e-b1c9-89a0b68220e7




