### PR TITLE
[AJ-1900] Add option to refresh files in file browser

### DIFF
--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -127,6 +127,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
                   setSelectedFiles({});
                   reload();
                 },
+                onRefresh: reload,
               }),
 
               h(NoticeForPath, {

--- a/src/components/file-browser/FilesMenu.test.ts
+++ b/src/components/file-browser/FilesMenu.test.ts
@@ -54,6 +54,7 @@ describe('FilesMenu', () => {
           onClickUpload: () => {},
           onCreateDirectory: () => {},
           onDeleteFiles,
+          onRefresh: () => Promise.resolve(),
         })
       );
 
@@ -106,6 +107,7 @@ describe('FilesMenu', () => {
         onClickUpload: () => {},
         onCreateDirectory,
         onDeleteFiles: () => {},
+        onRefresh: () => Promise.resolve(),
       })
     );
 

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -1,6 +1,7 @@
+import { useBusyState } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { useState } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
+import { div, h, span } from 'react-hyperscript-helpers';
 import { ButtonPrimary, Link, topSpinnerOverlay } from 'src/components/common';
 import { DeleteFilesConfirmationModal } from 'src/components/file-browser/DeleteFilesConfirmationModal';
 import { icon } from 'src/components/icons';
@@ -22,6 +23,7 @@ interface FilesMenuProps {
   onClickUpload: () => void;
   onCreateDirectory: (directory: FileBrowserDirectory) => void;
   onDeleteFiles: () => void;
+  onRefresh: () => Promise<void>;
 }
 
 export const FilesMenu = (props: FilesMenuProps) => {
@@ -34,8 +36,10 @@ export const FilesMenu = (props: FilesMenuProps) => {
     onClickUpload,
     onCreateDirectory,
     onDeleteFiles,
+    onRefresh,
   } = props;
 
+  const [refreshing, withRefreshing] = useBusyState();
   const [busy, setBusy] = useState(false);
   const [creatingNewDirectory, setCreatingNewDirectory] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -97,6 +101,18 @@ export const FilesMenu = (props: FilesMenuProps) => {
           onClick: () => setConfirmingDelete(true),
         },
         [icon('trash'), ' Delete']
+      ),
+
+      span({ style: { flex: 1 } }),
+
+      h(
+        Link,
+        {
+          disabled: refreshing,
+          style: { padding: '0.5rem' },
+          onClick: withRefreshing(onRefresh),
+        },
+        [icon(refreshing ? 'loadingSpinner' : 'sync'), ' Refresh']
       ),
 
       creatingNewDirectory &&


### PR DESCRIPTION
Based on a request in Slack: https://broadinstitute.slack.com/archives/C0544AAC70D/p1709850566488749?thread_ts=1709826117.494939&cid=C0544AAC70D

This adds a Refresh button the file browser to see files added through other channels, such as gsutil/azcopy or a running workflow.

![Screenshot 2024-06-12 at 10 11 17 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/397e1701-584c-4b79-a4ff-5b5821d11137)
