### PR TITLE
[UIE-188] Fix ClipboardButton styles

### DIFF
--- a/src/components/ClipboardButton.tsx
+++ b/src/components/ClipboardButton.tsx
@@ -12,7 +12,6 @@ const styles = {
   clickableLink: {
     display: 'inline',
     color: colors.accent(),
-    cursor: 'pointer',
     fontWeight: 500,
   },
 };
@@ -23,14 +22,13 @@ interface ClipboardButtonProps extends PropsWithChildren<ClickableProps> {
 }
 
 export const ClipboardButton = (props: ClipboardButtonProps): ReactNode => {
-  const { text, children, iconSize, onClick, ...rest } = props;
+  const { text, children, iconSize, style, onClick, ...rest } = props;
   const [copied, setCopied] = useState(false);
 
   return (
     <Clickable
       tooltip={copied ? 'Copied to clipboard' : 'Copy to clipboard'}
-      style={styles.clickableLink}
-      /* eslint-disable-next-line react/jsx-props-no-spreading */
+      style={{ ...styles.clickableLink, ...style }}
       {...rest}
       onClick={_.flow(
         withErrorReporting('Error copying to clipboard'),


### PR DESCRIPTION
I noticed that the copy to clipboard button in the WDS status modal was on a new line and hovering over it showed the tooltip in the middle of the modal. It turns out, this is because it's styled with `display: block`.

![Screenshot 2024-06-12 at 11 57 19 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/17076fe6-cfa6-48bd-8121-8e3011ba6ca8)

It _should_ be inline though. It turns out that https://github.com/DataBiosphere/terra-ui/pull/4651, which converted ClipboardButton to TSX, broke the styling and now applying _any_ custom style overrides _all_ default styles. Previously, the custom styles were merged with the default styles.

This restores the previous behavior, making ClipboardButton inline, even when some custom style (like margin) is applied.

![Screenshot 2024-06-12 at 11 57 10 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/9fe94c09-9d5e-4b5b-99c8-30cba1b0b289)

This explains the regressions fixed by https://github.com/DataBiosphere/terra-ui/pull/4816 and https://github.com/DataBiosphere/terra-ui/pull/4869.