### PR TITLE
[WM-2335] catch errors when requesting build info

### DIFF
--- a/src/workflows-app/WorkflowsInWorkspace.ts
+++ b/src/workflows-app/WorkflowsInWorkspace.ts
@@ -68,8 +68,14 @@ export const WorkflowsInWorkspace = ({
 
   const loadCbasInfo = useCallback(
     async (cbasProxyUrlDetails) => {
-      const { build } = await Cbas(signal).info(cbasProxyUrlDetails.state);
-      setCbasBuildInfo(build);
+      try {
+        const { build } = await Cbas(signal).info(cbasProxyUrlDetails.state);
+        setCbasBuildInfo(build);
+      } catch (error) {
+        notify('error', 'Error loading CBAS build information', {
+          detail: error instanceof Response ? await error.text() : error,
+        });
+      }
     },
     [signal]
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2335

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Catches any error when requesting CBAS build info
- Quick followup PR to https://github.com/DataBiosphere/terra-ui/pull/4863

### Why
- We're using CBAS's /actuator/info endpoint to gate the workflow deletion feature based on CBAS version. we wanted to cover the interaction with a contract test, but doing that will be more difficult because of how CBAS verifies its contracts. We decided to forgo the contract test until this endpoint is more widely used, and instead make sure failure is more graceful when the endpoint fails (which I probably should have just done in the first place)

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] Manual BEE test

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
