### PR TITLE
[AJ-1766] Apply resource limits to Azure cloud environment configuration form

### DIFF
--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.test.ts
@@ -127,4 +127,20 @@ describe('AutopauseConfiguration', () => {
     // Assert
     expect(onChangeAutopauseThreshold).toHaveBeenCalledWith(defaultAutopauseThreshold);
   });
+
+  it('shows a message describing minimum threshold', () => {
+    // Arrange/Act
+    setup();
+
+    // Assert
+    screen.getByText('Choose a duration of 10 minutes or more.');
+  });
+
+  it('shows a message describing minimum/maximum threshold', () => {
+    // Arrange/Act
+    setup({ minThreshold: 10, maxThreshold: 30 });
+
+    // Assert
+    screen.getByText('Choose a duration between 10 and 30 minutes.');
+  });
 });

--- a/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
+++ b/src/analysis/modals/ComputeModal/AutopauseConfiguration.ts
@@ -1,11 +1,11 @@
-import { icon, Link, useUniqueId } from '@terra-ui-packages/components';
+import { ExternalLink, useUniqueId } from '@terra-ui-packages/components';
+import { cond } from '@terra-ui-packages/core-utils';
 import { CSSProperties, ReactNode } from 'react';
-import { div, h, label, span } from 'react-hyperscript-helpers';
+import { div, h, label, p, span } from 'react-hyperscript-helpers';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getAutopauseThreshold, isAutopauseEnabled } from 'src/analysis/utils/runtime-utils';
 import { LabeledCheckbox } from 'src/components/common';
 import { NumberInput } from 'src/components/input';
-import * as Utils from 'src/libs/utils';
 
 export interface AutopauseConfigurationProps {
   autopauseRequired?: boolean;
@@ -22,7 +22,7 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
     autopauseRequired = false,
     autopauseThreshold,
     disabled = false,
-    maxThreshold = 999,
+    maxThreshold = undefined,
     minThreshold = 10,
     style,
     onChangeAutopauseThreshold,
@@ -42,13 +42,12 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
       [span({ style: { ...computeStyles.label } }, ['Enable autopause'])]
     ),
     h(
-      Link,
+      ExternalLink,
       {
         style: { marginLeft: '1rem', verticalAlign: 'bottom' },
         href: 'https://support.terra.bio/hc/en-us/articles/360029761352-Preventing-runaway-costs-with-Cloud-Environment-autopause-#h_27c11f46-a6a7-4860-b5e7-fac17df2b2b5',
-        ...Utils.newTabLinkProps,
       },
-      ['Learn more about autopause.', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+      ['Learn more about autopause.']
     ),
     div(
       {
@@ -64,7 +63,7 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
         h(NumberInput, {
           id: `${id}-threshold`,
           min: minThreshold,
-          max: maxThreshold,
+          max: maxThreshold || 999,
           isClearable: false,
           onlyInteger: true,
           disabled,
@@ -74,6 +73,7 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
             ? 'Autopause must be enabled to configure pause time.'
             : undefined,
           onChange: (v) => onChangeAutopauseThreshold(Number(v)),
+          'aria-describedby': `${id}-threshold-description`,
           'aria-label': 'Minutes of inactivity before autopausing',
         }),
         label(
@@ -85,5 +85,20 @@ export const AutopauseConfiguration = (props: AutopauseConfigurationProps): Reac
         ),
       ]
     ),
+    isAutopauseEnabled(autopauseThreshold) &&
+      (minThreshold !== undefined || maxThreshold !== undefined) &&
+      p(
+        {
+          id: `${id}-threshold-description`,
+        },
+        [
+          'Choose a duration ',
+          cond(
+            [minThreshold !== undefined && maxThreshold === undefined, () => `of ${minThreshold} minutes or more.`],
+            [minThreshold === undefined && maxThreshold !== undefined, () => `of ${maxThreshold} minutes or less.`],
+            () => `between ${minThreshold} and ${maxThreshold} minutes.`
+          ),
+        ]
+      ),
   ]);
 };

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.js
@@ -6,18 +6,22 @@ import { AutopauseConfiguration } from 'src/analysis/modals/ComputeModal/Autopau
 import { AzureApplicationConfigurationSection } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzureApplicationConfigurationSection';
 import { AzureComputeProfileSelect } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeProfileSelect';
 import { AzurePersistentDiskSection } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection';
+import { azureDiskSizes } from 'src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSizeSelectInput';
 import { DeleteEnvironment } from 'src/analysis/modals/DeleteEnvironment';
 import { computeStyles } from 'src/analysis/modals/modalStyles';
 import { getAzureComputeCostEstimate, getAzureDiskCostEstimate } from 'src/analysis/utils/cost-utils';
 import { generatePersistentDiskName } from 'src/analysis/utils/disk-utils';
 import { autopauseDisabledValue, defaultAutopauseThreshold, generateRuntimeName, getIsRuntimeBusy } from 'src/analysis/utils/runtime-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
+import { useWorkspaceBillingProfile } from 'src/billing/useWorkspaceBillingProfile';
+import { getResourceLimits } from 'src/billing-core/resource-limits';
 import { ButtonOutline, ButtonPrimary, spinnerOverlay } from 'src/components/common';
 import { withModalDrawer } from 'src/components/ModalDrawer';
 import TitleBar from 'src/components/TitleBar';
 import { Ajax } from 'src/libs/ajax';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import {
+  azureMachineTypes,
   defaultAzureComputeConfig,
   defaultAzureDiskSize,
   defaultAzureMachineType,
@@ -33,6 +37,8 @@ import { cloudProviderTypes } from 'src/workspaces/utils';
 
 const titleId = 'azure-compute-modal-title';
 
+const minAutopause = 10;
+
 export const AzureComputeModalBase = ({
   onDismiss,
   onSuccess,
@@ -46,7 +52,6 @@ export const AzureComputeModalBase = ({
   hideCloseButton = false,
 }) => {
   const [_loading, setLoading] = useState(false);
-  const loading = _loading || isLoadingCloudEnvironments;
   const [viewMode, setViewMode] = useState(undefined);
   const [currentRuntimeDetails, setCurrentRuntimeDetails] = useState(currentRuntime);
   const [currentPersistentDiskDetails] = useState(currentDisk);
@@ -55,6 +60,11 @@ export const AzureComputeModalBase = ({
   const { namespace, name: workspaceName, workspaceId } = workspace.workspace;
   const persistentDiskExists = !!currentPersistentDiskDetails;
   const [deleteDiskSelected, setDeleteDiskSelected] = useState(false);
+  const billingProfile = useWorkspaceBillingProfile(workspaceId);
+  const resourceLimits = billingProfile.status === 'Ready' ? getResourceLimits(billingProfile.state) : undefined;
+  const availableMachineTypes = resourceLimits?.availableMachineTypes || Object.keys(azureMachineTypes);
+
+  const loading = _loading || isLoadingCloudEnvironments || billingProfile.status === 'Loading';
 
   // Lifecycle
   useEffect(() => {
@@ -82,6 +92,34 @@ export const AzureComputeModalBase = ({
     });
     refreshRuntime();
   }, [currentRuntime, location, onError, workspaceId]);
+
+  // Once all data is loaded, check if default computeConfig need to be adjusted based on billing project limits.
+  useEffect(() => {
+    // If there's an existing runtime, computeConfig will be based on its configuration and should be not be changed.
+    if (!loading && !currentRuntimeDetails && resourceLimits) {
+      if (resourceLimits.availableMachineTypes) {
+        const selectedMachineType = computeConfig.machineType;
+        if (!resourceLimits.availableMachineTypes.includes(selectedMachineType)) {
+          updateComputeConfig('machinetypes', resourceLimits.availableMachineTypes[0]);
+        }
+      }
+
+      if (resourceLimits.maxAutopause) {
+        const autopauseConfig = computeConfig.autopauseThreshold;
+        updateComputeConfig('autopauseThreshold', _.clamp(minAutopause, resourceLimits.maxAutopause, autopauseConfig));
+      }
+
+      if (resourceLimits.maxPersistentDiskSize) {
+        const diskSize = computeConfig.persistentDiskSize;
+        if (diskSize > resourceLimits.maxPersistentDiskSize) {
+          updateComputeConfig(
+            'persistentDiskSize',
+            azureDiskSizes.findLast((size) => size <= resourceLimits.maxPersistentDiskSize)
+          );
+        }
+      }
+    }
+  }, [loading]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const renderTitleAndTagline = () => {
     return h(Fragment, [
@@ -241,17 +279,22 @@ export const AzureComputeModalBase = ({
           h(AzureComputeProfileSelect, {
             disabled: doesRuntimeExist(),
             machineType: computeConfig.machineType,
+            machineTypeOptions: availableMachineTypes,
             style: { marginBottom: '1.5rem' },
             onChangeMachineType: (v) => updateComputeConfig('machineType', v),
           }),
           h(AutopauseConfiguration, {
+            autopauseRequired: resourceLimits?.maxAutopause !== undefined,
             autopauseThreshold: computeConfig.autopauseThreshold,
             disabled: doesRuntimeExist(),
+            minThreshold: minAutopause,
+            maxThreshold: resourceLimits?.maxAutopause,
             style: { gridColumnEnd: 'span 6' },
             onChangeAutopauseThreshold: (v) => updateComputeConfig('autopauseThreshold', v),
           }),
         ]),
         h(AzurePersistentDiskSection, {
+          maxPersistentDiskSize: resourceLimits?.maxPersistentDiskSize,
           persistentDiskExists,
           onClickAbout: () => {
             setViewMode('aboutPersistentDisk');

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzureComputeModal.test.ts
@@ -22,6 +22,7 @@ import { RuntimeAjaxContractV2 } from 'src/libs/ajax/leonardo/Runtimes';
 import { WorkspaceManagerResources, WorkspaceManagerResourcesContract } from 'src/libs/ajax/WorkspaceManagerResources';
 import { azureMachineTypes, defaultAzureMachineType, getMachineTypeLabel } from 'src/libs/azure-utils';
 import { formatUSD } from 'src/libs/utils';
+import { azureBillingProfile } from 'src/testing/billing-profile-fixtures';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 
@@ -81,38 +82,12 @@ describe('AzureComputeModal', () => {
     // Arrange
     asMockedFn(Ajax).mockReturnValue(defaultAjaxImpl);
 
-    const billingProfile = {
-      id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
-      biller: 'direct',
-      displayName: 'TestBillingProfile',
-      description: 'This is only a test.',
-      cloudPlatform: 'AZURE',
-      tenantId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-      subscriptionId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-      managedResourceGroupId: 'TestMRG',
-      createdDate: '2024-05-28T18:29:26.333295Z',
-      lastModified: '2024-05-28T18:29:26.333295Z',
-      createdBy: 'user@example.com',
-      policies: {
-        inputs: [
-          {
-            namespace: 'terra',
-            name: 'protected-data',
-            additionalData: [],
-          },
-        ],
-      },
-      organization: {
-        enterprise: false,
-      },
-    };
-
-    const getWorkspace = jest.fn(() => Promise.resolve({ spendProfile: billingProfile.id }));
+    const getWorkspace = jest.fn(() => Promise.resolve({ spendProfile: azureBillingProfile.id }));
     asMockedFn(WorkspaceManagerResources).mockImplementation(
       () => ({ getWorkspace } as Partial<WorkspaceManagerResourcesContract> as WorkspaceManagerResourcesContract)
     );
 
-    const getBillingProfile = jest.fn(() => Promise.resolve(billingProfile));
+    const getBillingProfile = jest.fn(() => Promise.resolve(azureBillingProfile));
     asMockedFn(Billing).mockImplementation(
       () => ({ getBillingProfile } as Partial<BillingContract> as BillingContract)
     );
@@ -502,28 +477,9 @@ describe('AzureComputeModal', () => {
       asMockedFn(Billing).mockReturnValue(
         partial<BillingContract>({
           getBillingProfile: jest.fn().mockResolvedValue({
-            id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
-            biller: 'direct',
-            displayName: 'TestBillingProfile',
-            description: 'This is only a test.',
-            cloudPlatform: 'AZURE',
-            tenantId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-            subscriptionId: 'aaaabbbb-cccc-dddd-0000-111122223333',
-            managedResourceGroupId: 'TestMRG',
-            createdDate: '2024-05-28T18:29:26.333295Z',
-            lastModified: '2024-05-28T18:29:26.333295Z',
-            createdBy: 'user@example.com',
-            policies: {
-              inputs: [
-                {
-                  namespace: 'terra',
-                  name: 'protected-data',
-                  additionalData: [],
-                },
-              ],
-            },
+            ...azureBillingProfile,
             organization: {
-              enterprise: false,
+              ...azureBillingProfile.organization,
               limits: {
                 machinetypes: 'Standard_DS2_v2,Standard_DS3_v2',
                 autopause: '30',

--- a/src/billing-core/models.ts
+++ b/src/billing-core/models.ts
@@ -1,9 +1,10 @@
 export type {
+  AzureBillingProject,
   AzureManagedAppCoordinates,
+  BillingProfile,
   BillingProject,
   BillingRole,
   CloudPlatform,
-  AzureBillingProject,
   GCPBillingProject,
   GoogleBillingAccount,
 } from 'src/libs/ajax/Billing';

--- a/src/billing-core/resource-limits.test.ts
+++ b/src/billing-core/resource-limits.test.ts
@@ -1,50 +1,26 @@
+import { azureBillingProfile } from 'src/testing/billing-profile-fixtures';
+
 import { BillingProfile } from './models';
 import { getResourceLimits } from './resource-limits';
 
 describe('getResourceLimits', () => {
-  const billingProfile: BillingProfile = {
-    id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
-    biller: 'direct',
-    displayName: 'TestBillingProfile',
-    description: 'This is only a test.',
-    cloudPlatform: 'AZURE',
-    tenantId: 'dcdfd729-0a05-45e0-bfc9-a2458f8ee29b',
-    subscriptionId: 'aff128c1-8e0c-442a-b5d7-ff435e621fc9',
-    managedResourceGroupId: 'TestMRG',
-    createdDate: '2024-05-28T18:29:26.333295Z',
-    lastModified: '2024-05-28T18:29:26.333295Z',
-    createdBy: 'user@example.com',
-    policies: {
-      inputs: [
-        {
-          namespace: 'terra',
-          name: 'protected-data',
-          additionalData: [],
-        },
-      ],
-    },
-    organization: {
-      enterprise: false,
-    },
-  };
-
   it.each([
     {
-      billingProfile,
+      billingProfile: azureBillingProfile,
       expectedResourceLimits: undefined,
     },
     {
       billingProfile: {
-        ...billingProfile,
-        organization: { ...billingProfile.organization, limits: {} },
+        ...azureBillingProfile,
+        organization: { ...azureBillingProfile.organization, limits: {} },
       },
       expectedResourceLimits: undefined,
     },
     {
       billingProfile: {
-        ...billingProfile,
+        ...azureBillingProfile,
         organization: {
-          ...billingProfile.organization,
+          ...azureBillingProfile.organization,
           limits: { machinetypes: 'Standard_DS2_v2,Standard_DS3_v2', autopause: '30', persistentdisk: '32' },
         },
       },
@@ -56,9 +32,9 @@ describe('getResourceLimits', () => {
     },
     {
       billingProfile: {
-        ...billingProfile,
+        ...azureBillingProfile,
         organization: {
-          ...billingProfile.organization,
+          ...azureBillingProfile.organization,
           limits: {
             machinetypes: '',
             autopause: 30,

--- a/src/billing-core/resource-limits.test.ts
+++ b/src/billing-core/resource-limits.test.ts
@@ -1,0 +1,85 @@
+import { BillingProfile } from './models';
+import { getResourceLimits } from './resource-limits';
+
+describe('getResourceLimits', () => {
+  const billingProfile: BillingProfile = {
+    id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
+    biller: 'direct',
+    displayName: 'TestBillingProfile',
+    description: 'This is only a test.',
+    cloudPlatform: 'AZURE',
+    tenantId: 'dcdfd729-0a05-45e0-bfc9-a2458f8ee29b',
+    subscriptionId: 'aff128c1-8e0c-442a-b5d7-ff435e621fc9',
+    managedResourceGroupId: 'TestMRG',
+    createdDate: '2024-05-28T18:29:26.333295Z',
+    lastModified: '2024-05-28T18:29:26.333295Z',
+    createdBy: 'user@example.com',
+    policies: {
+      inputs: [
+        {
+          namespace: 'terra',
+          name: 'protected-data',
+          additionalData: [],
+        },
+      ],
+    },
+    organization: {
+      enterprise: false,
+    },
+  };
+
+  it.each([
+    {
+      billingProfile,
+      expectedResourceLimits: undefined,
+    },
+    {
+      billingProfile: {
+        ...billingProfile,
+        organization: { ...billingProfile.organization, limits: {} },
+      },
+      expectedResourceLimits: undefined,
+    },
+    {
+      billingProfile: {
+        ...billingProfile,
+        organization: {
+          ...billingProfile.organization,
+          limits: { machinetypes: 'Standard_DS2_v2,Standard_DS3_v2', autopause: '30', persistentdisk: '32' },
+        },
+      },
+      expectedResourceLimits: {
+        availableMachineTypes: ['Standard_DS2_v2', 'Standard_DS3_v2'],
+        maxAutopause: 30,
+        maxPersistentDiskSize: 32,
+      },
+    },
+    {
+      billingProfile: {
+        ...billingProfile,
+        organization: {
+          ...billingProfile.organization,
+          limits: {
+            machinetypes: '',
+            autopause: 30,
+            persistentdisk: '',
+          },
+        },
+      },
+      expectedResourceLimits: {
+        availableMachineTypes: undefined,
+        maxAutopause: 30,
+        maxPersistentDiskSize: undefined,
+      },
+    },
+  ] as { billingProfile: BillingProfile; expectedResourceLimits: BillingProfile | undefined }[])(
+    'should return the expected resource limits',
+    ({ billingProfile, expectedResourceLimits }) => {
+      // Act
+      const resourceLimits = getResourceLimits(billingProfile);
+
+      // Assert
+      expect(resourceLimits).toEqual(expectedResourceLimits);
+    }
+  );
+});

--- a/src/billing-core/resource-limits.ts
+++ b/src/billing-core/resource-limits.ts
@@ -1,0 +1,58 @@
+import { BillingProfile } from 'src/billing-core/models';
+
+export interface BillingProfileResourceLimits {
+  availableMachineTypes?: string[];
+  maxAutopause?: number;
+  maxPersistentDiskSize?: number;
+}
+
+/**
+ * Parses a comma-separated string into an array of strings.
+ * If the input is not a string or an empty string, returns undefined.
+ */
+const getCommaSeparatedValues = (value: unknown): string[] | undefined => {
+  if (typeof value === 'string' && value.length !== 0) {
+    return value.split(',');
+  }
+  return undefined;
+};
+
+/**
+ * Parses a value into a number.
+ */
+const getNumberValue = (value: unknown): number | undefined => {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const n = parseInt(value, 10);
+    return Number.isNaN(n) ? undefined : n;
+  }
+  return undefined;
+};
+
+/**
+ * Parse a billing profile's resource limits (if any).
+ *
+ * @param billingProfile - The billing profile.
+ * @returns The billing profile's resource limits, or undefined if the profile does not have any resource limits.
+ */
+export const getResourceLimits = (billingProfile: BillingProfile): BillingProfileResourceLimits | undefined => {
+  if (billingProfile.cloudPlatform !== 'AZURE' || !billingProfile.organization?.limits) {
+    return undefined;
+  }
+
+  const limits = billingProfile.organization.limits;
+  if (Object.keys(limits).length === 0) {
+    return undefined;
+  }
+
+  // The BPM API returns all resource limits as strings. This parses them into more structured types.
+  const resourceLimits: BillingProfileResourceLimits = {
+    availableMachineTypes: getCommaSeparatedValues(limits.machinetypes),
+    maxAutopause: getNumberValue(limits.autopause),
+    maxPersistentDiskSize: getNumberValue(limits.persistentdisk),
+  };
+
+  return resourceLimits;
+};

--- a/src/billing-core/resource-limits.ts
+++ b/src/billing-core/resource-limits.ts
@@ -38,7 +38,7 @@ const getNumberValue = (value: unknown): number | undefined => {
  * @returns The billing profile's resource limits, or undefined if the profile does not have any resource limits.
  */
 export const getResourceLimits = (billingProfile: BillingProfile): BillingProfileResourceLimits | undefined => {
-  if (billingProfile.cloudPlatform !== 'AZURE' || !billingProfile.organization?.limits) {
+  if (!billingProfile.organization?.limits) {
     return undefined;
   }
 

--- a/src/billing/useWorkspaceBillingProfile.test.ts
+++ b/src/billing/useWorkspaceBillingProfile.test.ts
@@ -1,0 +1,86 @@
+import { Billing, BillingContract } from 'src/libs/ajax/Billing';
+import { WorkspaceManagerResources, WorkspaceManagerResourcesContract } from 'src/libs/ajax/WorkspaceManagerResources';
+import { asMockedFn, mockNotifications, renderHookInActWithAppContexts } from 'src/testing/test-utils';
+
+import { useWorkspaceBillingProfile } from './useWorkspaceBillingProfile';
+
+jest.mock('src/libs/ajax/Billing', () => ({ Billing: jest.fn() }));
+jest.mock('src/libs/ajax/WorkspaceManagerResources', () => ({ WorkspaceManagerResources: jest.fn() }));
+
+describe('useWorkspaceBillingProfile', () => {
+  it('returns billing profile', async () => {
+    // Arrange
+    const billingProfile = {
+      id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
+      biller: 'direct',
+      displayName: 'TestBillingProfile',
+      description: 'This is only a test.',
+      cloudPlatform: 'AZURE',
+      tenantId: 'dcdfd729-0a05-45e0-bfc9-a2458f8ee29b',
+      subscriptionId: 'aff128c1-8e0c-442a-b5d7-ff435e621fc9',
+      managedResourceGroupId: 'TestMRG',
+      createdDate: '2024-05-28T18:29:26.333295Z',
+      lastModified: '2024-05-28T18:29:26.333295Z',
+      createdBy: 'user@example.com',
+      policies: {
+        inputs: [
+          {
+            namespace: 'terra',
+            name: 'protected-data',
+            additionalData: [],
+          },
+        ],
+      },
+      organization: {
+        enterprise: false,
+        limits: {
+          autopause: '30',
+          persistentdisk: '32',
+          machinetypes: 'Standard_DS2_v2,Standard_DS3_v2',
+        },
+      },
+    };
+
+    const getWorkspace = jest.fn(() => Promise.resolve({ spendProfile: billingProfile.id }));
+    asMockedFn(WorkspaceManagerResources).mockImplementation(
+      () => ({ getWorkspace } as Partial<WorkspaceManagerResourcesContract> as WorkspaceManagerResourcesContract)
+    );
+
+    const getBillingProfile = jest.fn(() => Promise.resolve(billingProfile));
+    asMockedFn(Billing).mockImplementation(
+      () => ({ getBillingProfile } as Partial<BillingContract> as BillingContract)
+    );
+
+    const workspaceId = 'cb8e5e9b-c432-4872-bec4-e774b0ed24f3';
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInActWithAppContexts(() =>
+      useWorkspaceBillingProfile(workspaceId)
+    );
+    const result = hookReturnRef.current;
+
+    // Assert
+    expect(getWorkspace).toHaveBeenCalledWith(workspaceId);
+    expect(getBillingProfile).toHaveBeenCalledWith(billingProfile.id);
+    expect(result).toEqual({ status: 'Ready', state: billingProfile });
+  });
+
+  it('handles errors', async () => {
+    // Arrange
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    asMockedFn(Billing).mockReturnValue({
+      getBillingProfile: (_name) => Promise.reject(new Error('Something went wrong')),
+    } as BillingContract);
+
+    // Act
+    const { result: hookReturnRef } = await renderHookInActWithAppContexts(() =>
+      useWorkspaceBillingProfile('cb8e5e9b-c432-4872-bec4-e774b0ed24f3')
+    );
+    const result = hookReturnRef.current;
+
+    // Assert
+    expect(mockNotifications.notify).toHaveBeenCalled();
+    expect(result).toEqual({ status: 'Error', state: null, error: new Error('Something went wrong') });
+  });
+});

--- a/src/billing/useWorkspaceBillingProfile.test.ts
+++ b/src/billing/useWorkspaceBillingProfile.test.ts
@@ -1,5 +1,6 @@
-import { Billing, BillingContract } from 'src/libs/ajax/Billing';
+import { Billing, BillingContract, BillingProfile } from 'src/libs/ajax/Billing';
 import { WorkspaceManagerResources, WorkspaceManagerResourcesContract } from 'src/libs/ajax/WorkspaceManagerResources';
+import { azureBillingProfile } from 'src/testing/billing-profile-fixtures';
 import { asMockedFn, mockNotifications, renderHookInActWithAppContexts } from 'src/testing/test-utils';
 
 import { useWorkspaceBillingProfile } from './useWorkspaceBillingProfile';
@@ -10,29 +11,10 @@ jest.mock('src/libs/ajax/WorkspaceManagerResources', () => ({ WorkspaceManagerRe
 describe('useWorkspaceBillingProfile', () => {
   it('returns billing profile', async () => {
     // Arrange
-    const billingProfile = {
-      id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
-      biller: 'direct',
-      displayName: 'TestBillingProfile',
-      description: 'This is only a test.',
-      cloudPlatform: 'AZURE',
-      tenantId: 'dcdfd729-0a05-45e0-bfc9-a2458f8ee29b',
-      subscriptionId: 'aff128c1-8e0c-442a-b5d7-ff435e621fc9',
-      managedResourceGroupId: 'TestMRG',
-      createdDate: '2024-05-28T18:29:26.333295Z',
-      lastModified: '2024-05-28T18:29:26.333295Z',
-      createdBy: 'user@example.com',
-      policies: {
-        inputs: [
-          {
-            namespace: 'terra',
-            name: 'protected-data',
-            additionalData: [],
-          },
-        ],
-      },
+    const billingProfile: BillingProfile = {
+      ...azureBillingProfile,
       organization: {
-        enterprise: false,
+        ...azureBillingProfile.organization,
         limits: {
           autopause: '30',
           persistentdisk: '32',

--- a/src/billing/useWorkspaceBillingProfile.ts
+++ b/src/billing/useWorkspaceBillingProfile.ts
@@ -1,0 +1,35 @@
+import { useLoadedData, UseLoadedDataArgs } from '@terra-ui-packages/components';
+import { LoadedState } from '@terra-ui-packages/core-utils';
+import { useNotificationsFromContext } from '@terra-ui-packages/notifications';
+import { useEffect } from 'react';
+import { BillingProfile } from 'src/billing-core/models';
+import { Billing } from 'src/libs/ajax/Billing';
+import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
+
+export const useWorkspaceBillingProfile = (
+  workspaceId: string,
+  options: UseLoadedDataArgs<BillingProfile, unknown> = {}
+): LoadedState<BillingProfile, unknown> => {
+  const { reportError } = useNotificationsFromContext();
+  const [state, load] = useLoadedData<BillingProfile>({
+    ...options,
+    onError: (error) => {
+      reportError('Error loading billing project.', error);
+      options.onError?.(error);
+    },
+  });
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    load(async () => {
+      const workspace = await WorkspaceManagerResources(abortController.signal).getWorkspace(workspaceId);
+      const billingProfile = await Billing(abortController.signal).getBillingProfile(workspace.spendProfile);
+      return billingProfile;
+    });
+    return () => {
+      abortController.abort();
+    };
+  }, [load, workspaceId]);
+
+  return state;
+};

--- a/src/libs/ajax/WorkspaceManagerResources.ts
+++ b/src/libs/ajax/WorkspaceManagerResources.ts
@@ -2,6 +2,10 @@ import _ from 'lodash/fp';
 import { authOpts, fetchWorkspaceManager } from 'src/libs/ajax/ajax-common';
 
 export const WorkspaceManagerResources = (signal) => ({
+  getWorkspace: (workspaceId: string): Promise<any> => {
+    return fetchWorkspaceManager(`workspaces/v1/${workspaceId}`, _.merge(authOpts(), { signal })).then((r) => r.json());
+  },
+
   controlledResources: async (workspaceId) => {
     const res = await fetchWorkspaceManager(
       `workspaces/v1/${workspaceId}/resources?stewardship=CONTROLLED&limit=1000`,
@@ -10,3 +14,5 @@ export const WorkspaceManagerResources = (signal) => ({
     return await res.json();
   },
 });
+
+export type WorkspaceManagerResourcesContract = ReturnType<typeof WorkspaceManagerResources>;

--- a/src/testing/billing-profile-fixtures.ts
+++ b/src/testing/billing-profile-fixtures.ts
@@ -1,0 +1,19 @@
+import { BillingProfile } from 'src/billing-core/models';
+
+export const azureBillingProfile: BillingProfile = {
+  id: '04cb122b-89a7-4b92-ad69-35f9877406ef',
+  biller: 'direct',
+  displayName: 'TestBillingProfile',
+  description: 'This is only a test.',
+  cloudPlatform: 'AZURE',
+  tenantId: 'dcdfd729-0a05-45e0-bfc9-a2458f8ee29b',
+  subscriptionId: 'aff128c1-8e0c-442a-b5d7-ff435e621fc9',
+  managedResourceGroupId: 'TestMRG',
+  createdDate: '2024-05-28T18:29:26.333295Z',
+  lastModified: '2024-05-28T18:29:26.333295Z',
+  createdBy: 'user@example.com',
+  policies: { inputs: [] },
+  organization: {
+    enterprise: false,
+  },
+};


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1766

This applies resource limits from the workspace's billing profile to the cloud environment configuration form.

Currently, these resource limits can be used to limit available machine types, require auto pause, and limit the size of persistent disks.

Note for IA / Workspaces reviewers: AJ has a billing project with these limits set up. We can add you to the billing project / a workspace within it.

Auto pause cannot be disabled. Min/max values are shown.
![Screenshot 2024-06-24 at 5 13 14 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/bdc36bab-b08e-477e-87cd-3100d5350b81)

Available machine types are limited.
![Screenshot 2024-06-24 at 11 18 38 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/f9cebfbc-3c2b-4574-93a5-824e7042d378)
