### PR TITLE
[AJ-1859] Show notice about region when creating a billing project on AnVIL branded site

### DIFF
--- a/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
+++ b/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
@@ -34,10 +34,6 @@ jest.mock('src/libs/react-utils', (): ReactUtilsExports => {
 });
 
 describe('transforming user info to the request object', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
   it('splits lists of emails and maps them to roles', () => {
     const emailList = 'a@b.com, b@c.com';
     const result = userInfoListToProjectAccessObjects(emailList, 'User');
@@ -72,8 +68,7 @@ describe('AzureBillingProjectWizard', () => {
     screen.getByLabelText('Yes, set up my environment with additional security monitoring');
   const getNoProtectedDataRadio = () => screen.getByLabelText('No');
 
-  beforeEach(() => {
-    jest.resetAllMocks();
+  const setup = () => {
     asMockedFn(Ajax).mockImplementation(
       () =>
         ({
@@ -86,14 +81,18 @@ describe('AzureBillingProjectWizard', () => {
         onSuccess,
       })
     );
-  });
+  };
 
   it('should not fail any accessibility tests in initial state', async () => {
+    setup();
+
     expect(await axe(renderResult.container)).toHaveNoViolations();
   });
 
   it('should support happy path of submitting with no users/owners and without protected data', async () => {
     // Integration test of steps (act/arrange/assert not really possible)
+    setup();
+
     const createAzureProject = jest.fn().mockResolvedValue({});
     const billingProjectName = 'LotsOfCash';
 
@@ -131,6 +130,8 @@ describe('AzureBillingProjectWizard', () => {
 
   it('should support happy path of submitting with owners and users and protected data', async () => {
     // Integration test of steps (act/arrange/assert not really possible)
+    setup();
+
     const createAzureProject = jest.fn().mockResolvedValue({ ok: true });
     const billingProjectName = 'LotsOfCashForAll';
 
@@ -174,6 +175,8 @@ describe('AzureBillingProjectWizard', () => {
 
   it('shows error if billing project already exists with the name', async () => {
     // Integration test of steps (act/arrange/assert not really possible)
+    setup();
+
     const createAzureProject = jest.fn().mockRejectedValue({ status: 409 });
     const billingProjectName = 'ProjectNameInUse';
 
@@ -199,6 +202,8 @@ describe('AzureBillingProjectWizard', () => {
   });
 
   it('shows error if there is no billing project name or name is badly formatted', async () => {
+    setup();
+
     const nameRequiredText = 'A name is required to create a billing project.';
     const tooShortText = 'Billing project name is too short (minimum is 6 characters)';
 

--- a/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
+++ b/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.test.ts
@@ -17,12 +17,21 @@ import {
   verifyCreateBillingProjectDisabled,
 } from 'src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep.test';
 import { Ajax } from 'src/libs/ajax';
+import { isAnvil } from 'src/libs/brand-utils';
 import Events from 'src/libs/events';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
 // Note that mocking is done by selectManagedApp (as well as default mocking in setUp).
 type AjaxContract = ReturnType<typeof Ajax>;
 jest.mock('src/libs/ajax');
+
+type BrandUtilsExports = typeof import('src/libs/brand-utils');
+jest.mock('src/libs/brand-utils', (): BrandUtilsExports => {
+  return {
+    ...jest.requireActual<BrandUtilsExports>('src/libs/brand-utils'),
+    isAnvil: jest.fn().mockReturnValue(false),
+  };
+});
 
 type ReactUtilsExports = typeof import('src/libs/react-utils');
 jest.mock('src/libs/react-utils', (): ReactUtilsExports => {
@@ -218,5 +227,17 @@ describe('AzureBillingProjectWizard', () => {
     await nameBillingProject('');
     await screen.findByText(nameRequiredText);
     expect(screen.queryByText(tooShortText)).toBeNull();
+  });
+
+  it.each([true, false])('shows a notice about region on AnVIL branded site', (isAnvilBrandedSite) => {
+    // Arrange/Act
+    asMockedFn(isAnvil).mockReturnValue(isAnvilBrandedSite);
+    setup();
+
+    // Assert
+    const isNoticeShown = !!screen.queryByText(
+      'Working with NHGRI data on Azure? Set up your Terra Managed Application in the South Central US region to reduce egress costs.'
+    );
+    expect(isNoticeShown).toBe(isAnvilBrandedSite);
   });
 });

--- a/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.ts
+++ b/src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureBillingProjectWizard.ts
@@ -1,7 +1,7 @@
-import { SpinnerOverlay } from '@terra-ui-packages/components';
+import { Icon, SpinnerOverlay } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
-import { h } from 'react-hyperscript-helpers';
+import { h, p } from 'react-hyperscript-helpers';
 import { AddUsersStep } from 'src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AddUsersStep';
 import { AzureSubscriptionStep } from 'src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/AzureSubscriptionStep';
 import { CreateNamedProjectStep } from 'src/billing/NewBillingProjectWizard/AzureBillingProjectWizard/CreateNamedProjectStep';
@@ -10,6 +10,7 @@ import { StepWizard } from 'src/billing/NewBillingProjectWizard/StepWizard/StepW
 import { billingProjectNameValidator } from 'src/billing/utils';
 import { AzureManagedAppCoordinates, BillingRole } from 'src/billing-core/models';
 import { Ajax } from 'src/libs/ajax';
+import { isAnvil } from 'src/libs/brand-utils';
 import { reportErrorAndRethrow } from 'src/libs/error';
 import Events from 'src/libs/events';
 import { useOnMount } from 'src/libs/react-utils';
@@ -139,8 +140,17 @@ export const AzureBillingProjectWizard = ({ onSuccess }: AzureBillingProjectWiza
       StepWizard,
       {
         title: 'Link an Azure Subscription to Terra',
-        intro: `The linked subscription is required to cover all Azure data storage, compute and egress costs incurred in a Terra workspace.
-        Cloud costs are billed directly from Azure and passed through Terra billing projects with no markup.`,
+        intro: h(Fragment, [
+          p([
+            'The linked subscription is required to cover all Azure data storage, compute and egress costs incurred in a Terra workspace. ',
+            'Cloud costs are billed directly from Azure and passed through Terra billing projects with no markup.',
+          ]),
+          isAnvil() &&
+            p({ style: { fontWeight: 'bold' } }, [
+              h(Icon, { icon: 'info-circle', size: 14, style: { marginRight: '0.5rem' } }),
+              'Working with NHGRI data on Azure? Set up your Terra Managed Application in the South Central US region to reduce egress costs.',
+            ]),
+        ]),
       },
       [
         h(AzureSubscriptionStep, {

--- a/src/billing/NewBillingProjectWizard/StepWizard/StepWizard.ts
+++ b/src/billing/NewBillingProjectWizard/StepWizard/StepWizard.ts
@@ -1,12 +1,12 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import { div, h2, section, ul } from 'react-hyperscript-helpers';
 
 export type StepWizardProps = PropsWithChildren<{
   title: string;
-  intro: string;
+  intro: ReactNode;
 }>;
 
-export const StepWizard = ({ children, title, intro }: StepWizardProps) => {
+export const StepWizard = ({ children, title, intro }: StepWizardProps): ReactNode => {
   return section({ style: { padding: '1.5rem 3rem', width: '100%' } }, [
     h2({ style: { fontWeight: 'bold', fontSize: 18 } }, [title]),
     div({ style: { marginTop: '0.5rem', fontSize: 14, padding: 0, listStyleType: 'none', width: '100%' } }, [intro]),


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1859

AnVIL data is hosted in the South Central US region. We'd like users who are importing that data into workspaces to create their workspaces in the same region to reduce egress costs.

This adds a notice to the new Azure billing project screen in the AnVIL branded site (https://anvil.terra.bio/) suggesting users set up their managed app / billing project in the South Central US region.

To simulate the AnVIL branded site, use configuration overrides. In the JS console, run the following command and reload the page.
```js
window.configOverridesStore.set({ brand: 'anvil' });
```

## AnVIL

![Screenshot 2024-06-24 at 2 48 06 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/26b7c0d6-fc34-4f02-9bb9-b04048f6bc55)

## Terra

![Screenshot 2024-06-24 at 2 48 38 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/5135def9-2f0e-4565-811e-6dc909527697)

  