### PR TITLE
[AJ-1870] Show app error message in data table status modal

### DIFF
--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
@@ -429,4 +429,53 @@ describe('WdsTroubleshooter', () => {
       ].join('\n')
     );
   });
+
+  it('shows app error message', async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    const mockStatus: WdsStatus = {
+      numApps: '1',
+      wdsResponsive: 'unknown',
+      version: 'unknown',
+      chartVersion: 'unknown',
+      image: 'unknown',
+      wdsStatus: 'unresponsinve',
+      wdsDbStatus: 'unknown',
+      wdsPingStatus: 'unknown',
+      wdsIamStatus: 'unknown',
+      appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
+      appStatus: 'ERROR',
+      appErrorMessage: 'Something went wrong',
+      proxyUrl: null,
+      defaultInstanceExists: null,
+      cloneSourceWorkspaceId: null,
+      cloneStatus: null,
+      cloneErrorMessage: null,
+    };
+
+    asMockedFn(useWdsStatus).mockReturnValue({
+      status: mockStatus,
+      refreshStatus: jest.fn(),
+    });
+
+    // Act
+    render(
+      h(WdsTroubleshooter, {
+        workspaceId: 'test-workspace',
+        mrgId: 'test-mrg',
+        onDismiss: jest.fn(),
+      })
+    );
+
+    // Assert
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+
+    // Act
+    const showAppErrorMessageButton = screen.getByRole('button', { name: 'Show details' });
+    await user.click(showAppErrorMessageButton);
+
+    // Assert
+    screen.getByText('Something went wrong');
+  });
 });

--- a/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
+++ b/src/workspace-data/data-table/wds/WdsTroubleshooter.test.ts
@@ -57,6 +57,7 @@ describe('WdsTroubleshooter', () => {
       wdsIamStatus: 'UP',
       appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
       appStatus: 'RUNNING',
+      appErrorMessage: null,
       proxyUrl:
         'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
       defaultInstanceExists: 'true',
@@ -122,6 +123,7 @@ describe('WdsTroubleshooter', () => {
       wdsIamStatus: 'UP',
       appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
       appStatus: 'RUNNING',
+      appErrorMessage: null,
       proxyUrl:
         'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
       defaultInstanceExists: 'true',
@@ -188,6 +190,7 @@ describe('WdsTroubleshooter', () => {
       wdsIamStatus: 'UP',
       appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
       appStatus: 'RUNNING',
+      appErrorMessage: null,
       proxyUrl:
         'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
       defaultInstanceExists: 'true',
@@ -282,6 +285,7 @@ describe('WdsTroubleshooter', () => {
       wdsIamStatus: 'UP',
       appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
       appStatus: 'RUNNING',
+      appErrorMessage: null,
       proxyUrl:
         'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
       defaultInstanceExists: 'true',
@@ -378,6 +382,7 @@ describe('WdsTroubleshooter', () => {
       wdsIamStatus: 'UP',
       appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
       appStatus: 'RUNNING',
+      appErrorMessage: null,
       proxyUrl:
         'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
       defaultInstanceExists: 'true',

--- a/src/workspace-data/data-table/wds/wds-status.test.ts
+++ b/src/workspace-data/data-table/wds/wds-status.test.ts
@@ -51,6 +51,7 @@ describe('useWdsStatus', () => {
         numApps: 'unknown',
         appName: 'unknown',
         appStatus: 'unknown',
+        appErrorMessage: null,
         proxyUrl: 'unknown',
         wdsResponsive: 'unknown',
         version: 'unknown',
@@ -87,6 +88,7 @@ describe('useWdsStatus', () => {
           numApps: '0',
           appName: 'unknown',
           appStatus: 'unknown',
+          appErrorMessage: null,
           proxyUrl: 'unknown',
           wdsResponsive: 'unknown',
           version: 'unknown',
@@ -160,6 +162,7 @@ describe('useWdsStatus', () => {
         numApps: '1',
         appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
         appStatus: 'RUNNING',
+        appErrorMessage: null,
         proxyUrl:
           'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
         wdsResponsive: null,
@@ -239,6 +242,73 @@ describe('useWdsStatus', () => {
       expect(hookReturnRef.current.status).toEqual({
         appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
         appStatus: 'ERROR',
+        appErrorMessage: null,
+        chartVersion: 'unknown',
+        defaultInstanceExists: 'unknown',
+        image: 'unknown',
+        numApps: '1',
+        proxyUrl:
+          'https://lz34dd00bf3fdaa72f755eeea8f928bab7cd135043043d59d5.servicebus.windows.net/wds-6601fdbb-4b53-41da-87b2-81385f4a760e-6601fdbb-4b53-41da-87b2-81385f4a760e/',
+        version: 'unknown',
+        wdsDbStatus: 'unknown',
+        wdsIamStatus: 'unknown',
+        wdsPingStatus: 'unknown',
+        wdsResponsive: 'unknown',
+        wdsStatus: 'unresponsive',
+        cloneSourceWorkspaceId: null,
+        cloneStatus: null,
+        cloneErrorMessage: null,
+      });
+    });
+
+    it('returns error message if app is in error state', async () => {
+      // Arrange
+      const getVersion = jest.fn().mockReturnValue(abandonedPromise());
+      const getStatus = jest.fn().mockReturnValue(abandonedPromise());
+      const listInstances = jest.fn().mockReturnValue(abandonedPromise());
+      const getCloneStatus = jest.fn().mockReturnValue(abandonedPromise());
+
+      const mockAjax: DeepPartial<AjaxContract> = {
+        Apps: {
+          listAppsV2: jest.fn().mockResolvedValue([
+            {
+              ...wdsApp,
+              status: 'ERROR',
+              errors: [
+                {
+                  errorMessage: 'Something went wrong!',
+                  timestamp: '2023-07-20T18:49:17.264656',
+                  action: 'action',
+                  source: 'source',
+                  googleErrorCode: null,
+                  traceId: null,
+                },
+              ],
+            } satisfies ListAppItem,
+          ]),
+        },
+        WorkspaceData: {
+          getVersion,
+          getStatus,
+          listInstances,
+          getCloneStatus,
+        },
+      };
+      asMockedFn(Ajax).mockReturnValue(mockAjax as AjaxContract);
+
+      // Act
+      const { result: hookReturnRef } = await renderHookInAct(() => useWdsStatus({ workspaceId }));
+
+      // Assert
+      expect(getVersion).not.toHaveBeenCalled();
+      expect(getStatus).not.toHaveBeenCalled();
+      expect(listInstances).not.toHaveBeenCalled();
+      expect(getCloneStatus).not.toHaveBeenCalled();
+
+      expect(hookReturnRef.current.status).toEqual({
+        appName: 'wds-6601fdbb-4b53-41da-87b2-81385f4a760e',
+        appStatus: 'ERROR',
+        appErrorMessage: 'Something went wrong!',
         chartVersion: 'unknown',
         defaultInstanceExists: 'unknown',
         image: 'unknown',
@@ -666,6 +736,7 @@ describe('useWdsStatus', () => {
     expect(renderHookRef.current.status).toEqual({
       numApps: '0',
       appName: 'unknown',
+      appErrorMessage: null,
       appStatus: 'unknown',
       proxyUrl: 'unknown',
       wdsResponsive: 'unknown',
@@ -693,6 +764,7 @@ describe('useWdsStatus', () => {
       numApps: null,
       appName: null,
       appStatus: null,
+      appErrorMessage: null,
       proxyUrl: null,
       wdsResponsive: null,
       version: null,

--- a/src/workspace-data/data-table/wds/wds-status.ts
+++ b/src/workspace-data/data-table/wds/wds-status.ts
@@ -13,6 +13,7 @@ export type WdsStatus = {
 
   appName: string | null;
   appStatus: string | null;
+  appErrorMessage: string | null;
   proxyUrl: string | null;
 
   wdsResponsive: string | null;
@@ -49,6 +50,7 @@ const initialStatus: WdsStatus = {
   wdsIamStatus: null,
   appName: null,
   appStatus: null,
+  appErrorMessage: null,
   proxyUrl: null,
   defaultInstanceExists: null,
   cloneSourceWorkspaceId: null,
@@ -75,6 +77,7 @@ export const useWdsStatus = ({ workspaceId }: UseWdsStatusArgs) => {
         numApps: 'unknown',
         appName: 'unknown',
         appStatus: 'unknown',
+        appErrorMessage: null,
         proxyUrl: 'unknown',
         wdsResponsive: 'unknown',
         version: 'unknown',
@@ -121,6 +124,7 @@ export const useWdsStatus = ({ workspaceId }: UseWdsStatusArgs) => {
       ...previousStatus,
       appName: wdsApp.appName,
       appStatus: wdsApp.status,
+      appErrorMessage: wdsApp.errors[0]?.errorMessage || null,
       proxyUrl,
     }));
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1870

Show app error message (if any) in WDS status modal.

Since error message may be lengthy (for example, if they include a stack trace), this hides them by default and shows a button to show the message. The copy status to clipboard button will include the error message even if it's hidden.

![Screenshot 2024-06-27 at 10 55 08 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/36198df3-916c-49ce-b133-c46566b900a5)

![Screenshot 2024-06-27 at 10 55 13 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/0df5e792-25a9-4c84-be50-52c60e2a50a5)

To test this, run the following in the JavaScript console before clicking the "Data Table Status" button:
```js
ajaxOverridesStore.set([
  {
    filter: { url: /\/apps\/v2\// },
    fn: ajaxOverrideUtils.makeSuccess([
        {
            "workspaceId": "eeff20de-0070-4c1c-809c-6f0c2e01eb24",
            "cloudContext": {
                "cloudProvider": "AZURE",
                "cloudResource": "0cb7a640-45a2-4ed6-be9f-63519f86e04b/0fa61a72-3a6b-4d51-a7e9-75fbeb7c7ed9/mrg-terra-dev-previ-20230626173007"
            },
            "kubernetesRuntimeConfig": {
                "numNodes": 1,
                "machineType": "Standard_A2_v2",
                "autoscalingEnabled": false
            },
            "errors": [
                {
                    errorMessage: 'Something went wrong!',
                    timestamp: '2023-07-20T18:49:17.264656',
                    action: 'action',
                    source: 'source',
                    googleErrorCode: null,
                    traceId: null,
                  },
            ],
            "status": "ERROR",
            "proxyUrls": {
                "wds": "https://lz81067ca761368f63128f883248bc7c26e250eaa41f49a163.servicebus.windows.net/wds-eeff20de-0070-4c1c-809c-6f0c2e01eb24-eeff20de-0070-4c1c-809c-6f0c2e01eb24/"
            },
            "appName": "wds-eeff20de-0070-4c1c-809c-6f0c2e01eb24",
            "appType": "WDS",
            "diskName": null,
            "auditInfo": {
                "creator": "user@example.com",
                "createdDate": "2023-07-20T18:42:28.798500Z",
                "destroyedDate": null,
                "dateAccessed": "2023-07-20T18:42:28.798500Z"
            },
            "accessScope": "WORKSPACE_SHARED",
            "labels": {}
        }
    ])
  }
])
```