### PR TITLE
Move action bar to floating

### DIFF
--- a/src/components/ActionBar.ts
+++ b/src/components/ActionBar.ts
@@ -2,6 +2,8 @@ import { ReactElement } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { ButtonPrimary } from 'src/components/common';
 
+export const ACTION_BAR_HEIGHT = '5rem';
+
 type ActionBarProps = {
   /** The prompt to display next to the action bar button. */
   prompt: string | ReactElement;
@@ -22,8 +24,8 @@ export const ActionBar = (props: ActionBarProps) => {
         width: '100%',
         display: 'flex',
         justifyContent: 'flex-end',
-        height: '5rem',
-        position: 'absolute',
+        height: ACTION_BAR_HEIGHT,
+        position: 'fixed',
         bottom: 0,
         backgroundColor: 'white',
         boxShadow: '0 0 4px 0 rgba(0,0,0,0.5)',

--- a/src/dataset-builder/ConceptCart.tsx
+++ b/src/dataset-builder/ConceptCart.tsx
@@ -1,24 +1,25 @@
-import React, { Fragment } from 'react';
+import _ from 'lodash/fp';
+import React from 'react';
 import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
 import { SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
 
 interface ConceptCartProps {
   cart: Concept[];
-  onClick: () => void;
+  onCommit: (selected: Concept[]) => void;
   actionText: string;
 }
 
 export const ConceptCart = (props: ConceptCartProps) => {
-  const { cart, onClick, actionText } = props;
+  const { cart, onCommit, actionText } = props;
 
   return (
-    cart.length > 0 && (
+    cart.length !== 0 && (
       <>
         <div style={{ width: '100%', height: ACTION_BAR_HEIGHT }} />
         <ActionBar
           prompt={cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`}
           actionText={actionText}
-          onClick={onClick}
+          onClick={() => _.flow(onCommit)(cart)}
         />
       </>
     )

--- a/src/dataset-builder/ConceptCart.tsx
+++ b/src/dataset-builder/ConceptCart.tsx
@@ -1,0 +1,26 @@
+import React, { Fragment } from 'react';
+import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
+import { SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
+
+interface ConceptCartProps {
+  cart: Concept[];
+  onClick: () => void;
+  actionText: string;
+}
+
+export const ConceptCart = (props: ConceptCartProps) => {
+  const { cart, onClick, actionText } = props;
+
+  return (
+    cart.length > 0 && (
+      <>
+        <div style={{ width: '100%', height: ACTION_BAR_HEIGHT }} />
+        <ActionBar
+          prompt={cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`}
+          actionText={actionText}
+          onClick={onClick}
+        />
+      </>
+    )
+  );
+};

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -152,6 +152,6 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
           })
         : spinnerOverlay,
     ]),
-    h(ConceptCart, { cart, onClick: () => _.flow(onCommit)(cart), actionText }),
+    h(ConceptCart, { actionText, cart, onCommit }),
   ]);
 };

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -2,11 +2,11 @@ import { useLoadedData } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, strong } from 'react-hyperscript-helpers';
-import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
 import { LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput, withDebouncedChange } from 'src/components/input';
 import { SimpleTable } from 'src/components/table';
+import { ConceptCart } from 'src/dataset-builder/ConceptCart';
 import { tableHeaderStyle } from 'src/dataset-builder/ConceptSelector';
 import { BuilderPageHeader } from 'src/dataset-builder/DatasetBuilderHeader';
 import { formatCount, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
@@ -152,14 +152,6 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
           })
         : spinnerOverlay,
     ]),
-    cart.length !== 0 &&
-      h(Fragment, [
-        div({ style: { width: '100%', height: ACTION_BAR_HEIGHT } }, []),
-        h(ActionBar, {
-          prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
-          actionText,
-          onClick: () => _.flow(onCommit)(cart),
-        }),
-      ]),
+    h(ConceptCart, { cart, onClick: () => _.flow(onCommit)(cart), actionText }),
   ]);
 };

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -2,7 +2,7 @@ import { useLoadedData } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, strong } from 'react-hyperscript-helpers';
-import { ActionBar } from 'src/components/ActionBar';
+import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
 import { LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput, withDebouncedChange } from 'src/components/input';
@@ -153,10 +153,13 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
         : spinnerOverlay,
     ]),
     cart.length !== 0 &&
-      h(ActionBar, {
-        prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
-        actionText,
-        onClick: () => _.flow(onCommit)(cart),
-      }),
+      h(Fragment, [
+        div({ style: { width: '100%', height: ACTION_BAR_HEIGHT } }, []),
+        h(ActionBar, {
+          prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
+          actionText,
+          onClick: () => _.flow(onCommit)(cart),
+        }),
+      ]),
   ]);
 };

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -41,7 +41,7 @@ export const findRoot = <T extends RowContents>(parents: Parent<T>[]) => {
 };
 
 export const ConceptSelector = (props: ConceptSelectorProps) => {
-  const { title, onCancel, onCommit, snapshotId, initialCart, parents, openedConcept } = props;
+  const { title, onCancel, onCommit, actionText, snapshotId, initialCart, parents, openedConcept } = props;
 
   const [cart, setCart] = useState<Concept[]>(initialCart);
   const getChildren = async (concept: Concept): Promise<Concept[]> =>
@@ -102,6 +102,6 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
         headerStyle: tableHeaderStyle,
       }),
     ]),
-    h(ConceptCart, { onClick: () => _.flow(onCommit)(cart), cart, actionText }),
+    h(ConceptCart, { actionText, cart, onCommit }),
   ]);
 };

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
-import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
 import { LabeledCheckbox, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { Parent, RowContents, TreeGrid } from 'src/components/TreeGrid';
+import { ConceptCart } from 'src/dataset-builder/ConceptCart';
 import { BuilderPageHeader } from 'src/dataset-builder/DatasetBuilderHeader';
 import { formatCount } from 'src/dataset-builder/DatasetBuilderUtils';
 import { DataRepo, SnapshotBuilderConcept as Concept } from 'src/libs/ajax/DataRepo';
@@ -41,7 +41,7 @@ export const findRoot = <T extends RowContents>(parents: Parent<T>[]) => {
 };
 
 export const ConceptSelector = (props: ConceptSelectorProps) => {
-  const { title, onCancel, onCommit, actionText, snapshotId, initialCart, parents, openedConcept } = props;
+  const { title, onCancel, onCommit, snapshotId, initialCart, parents, openedConcept } = props;
 
   const [cart, setCart] = useState<Concept[]>(initialCart);
   const getChildren = async (concept: Concept): Promise<Concept[]> =>
@@ -102,14 +102,6 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
         headerStyle: tableHeaderStyle,
       }),
     ]),
-    cart.length !== 0 &&
-      h(Fragment, [
-        div({ style: { width: '100%', height: ACTION_BAR_HEIGHT } }, []),
-        h(ActionBar, {
-          prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
-          actionText,
-          onClick: () => _.flow(onCommit)(cart),
-        }),
-      ]),
+    h(ConceptCart, { onClick: () => _.flow(onCommit)(cart), cart, actionText }),
   ]);
 };

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { CSSProperties, Fragment, useState } from 'react';
 import { div, h, h2 } from 'react-hyperscript-helpers';
-import { ActionBar } from 'src/components/ActionBar';
+import { ACTION_BAR_HEIGHT, ActionBar } from 'src/components/ActionBar';
 import { LabeledCheckbox, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { Parent, RowContents, TreeGrid } from 'src/components/TreeGrid';
@@ -103,10 +103,13 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
       }),
     ]),
     cart.length !== 0 &&
-      h(ActionBar, {
-        prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
-        actionText,
-        onClick: () => _.flow(onCommit)(cart),
-      }),
+      h(Fragment, [
+        div({ style: { width: '100%', height: ACTION_BAR_HEIGHT } }, []),
+        h(ActionBar, {
+          prompt: cart.length === 1 ? '1 concept selected' : `${cart.length} concepts selected`,
+          actionText,
+          onClick: () => _.flow(onCommit)(cart),
+        }),
+      ]),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-965

## Summary of changes:
Makes the action bar float

### What
- This converts the action bar to being floating.
- For the case of the ConceptSearch and ConceptSelector use cases, this adds a div to the bottom of the page to add spacing for when you are scrolled all the way down

### Why
- Users were getting confused when the action bar wasn't immediately visible

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
