### PR TITLE
[AJ-1067] Update layout of workspace data controls

### DIFF
--- a/src/workspace-data/WorkspaceAttributes.js
+++ b/src/workspace-data/WorkspaceAttributes.js
@@ -1,3 +1,4 @@
+import { ButtonSecondary, Icon } from '@terra-ui-packages/components';
 import FileSaver from 'file-saver';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useRef, useState } from 'react';
@@ -5,9 +6,10 @@ import { div, h } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { DeleteConfirmationModal, Link, Select, spinnerOverlay } from 'src/components/common';
 import Dropzone from 'src/components/Dropzone';
-import FloatingActionButton from 'src/components/FloatingActionButton';
 import { icon } from 'src/components/icons';
 import { DelayedSearchInput, TextInput } from 'src/components/input';
+import { MenuButton } from 'src/components/MenuButton';
+import { MenuTrigger } from 'src/components/PopupTrigger';
 import { FlexTable, HeaderCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
@@ -142,19 +144,64 @@ export const WorkspaceAttributes = ({
                 flex: 'none',
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: 'flex-end',
                 padding: '1rem',
                 background: colors.light(0.5),
                 borderBottom: `1px solid ${colors.grey(0.4)}`,
               },
             },
             [
-              h(Link, { onClick: download }, ['Download TSV']),
-              WorkspaceUtils.canEditWorkspace(workspace).value &&
-                h(Fragment, [div({ style: { whiteSpace: 'pre' } }, ['  |  Drag or click to ']), h(Link, { onClick: openUploader }, ['upload TSV'])]),
+              h(
+                MenuTrigger,
+                {
+                  side: 'bottom',
+                  closeOnClick: true,
+                  content: h(Fragment, [
+                    h(
+                      MenuButton,
+                      {
+                        disabled: editIndex !== undefined,
+                        onClick: () => {
+                          setEditIndex(amendedAttributes.length);
+                          setEditValue('');
+                          setEditKey('');
+                          setEditType('string');
+                          setEditDescription('');
+                        },
+                      },
+                      ['Add variable']
+                    ),
+                    h(
+                      MenuButton,
+                      {
+                        onClick: openUploader,
+                      },
+                      ['Upload TSV']
+                    ),
+                  ]),
+                },
+                [
+                  h(
+                    ButtonSecondary,
+                    {
+                      tooltip: 'Edit data',
+                      ...WorkspaceUtils.getWorkspaceEditControlProps(workspace),
+                      style: { marginRight: '1.5rem' },
+                    },
+                    [h(Icon, { icon: 'edit', style: { marginRight: '0.5rem' } }), 'Edit']
+                  ),
+                ]
+              ),
+              h(
+                ButtonSecondary,
+                {
+                  style: { marginRight: '1.5rem' },
+                  onClick: download,
+                },
+                [h(Icon, { icon: 'download', style: { marginRight: '0.5rem' } }), 'Download TSV']
+              ),
               h(DelayedSearchInput, {
                 'aria-label': 'Search',
-                style: { width: 300, marginLeft: '1rem' },
+                style: { width: 300, marginLeft: 'auto' },
                 placeholder: 'Search',
                 onChange: setTextFilter,
                 value: textFilter,
@@ -293,20 +340,6 @@ export const WorkspaceAttributes = ({
                 }),
             ]),
           ]),
-          !creatingNewVariable &&
-            editIndex === undefined &&
-            WorkspaceUtils.canEditWorkspace(workspace).value &&
-            h(FloatingActionButton, {
-              label: 'ADD VARIABLE',
-              iconShape: 'plus',
-              onClick: () => {
-                setEditIndex(amendedAttributes.length);
-                setEditValue('');
-                setEditKey('');
-                setEditType('string');
-                setEditDescription('');
-              },
-            }),
           deleteIndex !== undefined &&
             h(DeleteConfirmationModal, {
               objectType: 'variable',

--- a/src/workspace-data/WorkspaceAttributes.test.tsx
+++ b/src/workspace-data/WorkspaceAttributes.test.tsx
@@ -1,0 +1,124 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { fireEvent, screen, within } from '@testing-library/react';
+import React from 'react';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+import { WorkspaceWrapper } from 'src/workspaces/utils';
+
+import { useWorkspaceDataAttributes } from './useWorkspaceDataAttributes';
+import { WorkspaceAttributes } from './WorkspaceAttributes';
+
+type UseWorkspaceDataAttributesExports = typeof import('./useWorkspaceDataAttributes');
+jest.mock(
+  './useWorkspaceDataAttributes',
+  (): UseWorkspaceDataAttributesExports => ({
+    ...jest.requireActual<UseWorkspaceDataAttributesExports>('./useWorkspaceDataAttributes'),
+    useWorkspaceDataAttributes: jest.fn(),
+  })
+);
+
+type ReactVirtualizedExports = typeof import('react-virtualized');
+jest.mock('react-virtualized', (): ReactVirtualizedExports => {
+  const actual = jest.requireActual<ReactVirtualizedExports>('react-virtualized');
+
+  const { AutoSizer } = actual;
+  class MockAutoSizer extends AutoSizer {
+    state = {
+      height: 1000,
+      width: 1000,
+    };
+
+    setState = () => {};
+  }
+
+  return {
+    ...actual,
+    AutoSizer: MockAutoSizer,
+  };
+});
+
+describe('WorkspaceAttributes', () => {
+  interface SetupArgs {
+    attributes?: [string, unknown, string][];
+    workspace?: WorkspaceWrapper;
+  }
+
+  const setup = (args: SetupArgs = {}): void => {
+    const { attributes = [], workspace = defaultGoogleWorkspace } = args;
+
+    const refresh = jest.fn().mockResolvedValue(Promise.resolve());
+
+    asMockedFn(useWorkspaceDataAttributes).mockReturnValue([
+      {
+        state: attributes,
+        status: 'Ready',
+      },
+      refresh,
+    ]);
+
+    render(<WorkspaceAttributes refreshKey={0} workspace={workspace} />);
+  };
+
+  it('loads and displays workspace data attributes', () => {
+    // Arrange/Act
+    setup({
+      attributes: [
+        ['attribute1', 'value1', 'description1'],
+        ['attribute2', 'value2', 'description2'],
+      ],
+    });
+
+    // Assert
+    expect(useWorkspaceDataAttributes).toHaveBeenCalledWith(
+      defaultGoogleWorkspace.workspace.namespace,
+      defaultGoogleWorkspace.workspace.name
+    );
+
+    const rows = screen.getAllByRole('row');
+
+    const firstRowCells = within(rows[1]).getAllByRole('cell');
+    expect(firstRowCells.map((el) => el.textContent)).toEqual([
+      'attribute1',
+      'value1',
+      'description1Edit variableDelete variable',
+    ]);
+
+    const secondRowCells = within(rows[2]).getAllByRole('cell');
+    expect(secondRowCells.map((el) => el.textContent)).toEqual([
+      'attribute2',
+      'value2',
+      'description2Edit variableDelete variable',
+    ]);
+  });
+
+  it('has option to add a new variable', () => {
+    // Arrange
+    setup();
+
+    // Act
+    const editMenuButton = screen.getByRole('button', { name: 'Edit' });
+    fireEvent.click(editMenuButton);
+
+    const addVariableButton = screen.getByText('Add variable');
+    fireEvent.click(addVariableButton);
+
+    // Assert
+    const rows = screen.getAllByRole('row');
+    const inputs = within(rows[1]).getAllByRole('textbox');
+    expect(inputs).toHaveLength(3);
+  });
+
+  it('disables edit menu for read-only workspaces', () => {
+    // Arrange/Act
+    setup({
+      workspace: {
+        ...defaultGoogleWorkspace,
+        accessLevel: 'READER',
+      },
+    });
+
+    // Assert
+    const editMenuButton = screen.getByRole('button', { name: 'Edit' });
+    expect(editMenuButton).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/src/workspace-data/useWorkspaceDataAttributes.ts
+++ b/src/workspace-data/useWorkspaceDataAttributes.ts
@@ -24,7 +24,9 @@ const isWorkspaceDataAttribute = (name: string): boolean => {
  * @param workspaceAttributes - Workspace attributes.
  * @returns List of [attribute name, attribute value, attribute description] tuples.
  */
-export const getWorkspaceDataAttributes = (workspaceAttributes: { [key: string]: unknown }) => {
+export const getWorkspaceDataAttributes = (workspaceAttributes: {
+  [key: string]: unknown;
+}): [string, unknown, string | undefined][] => {
   return Object.entries(workspaceAttributes)
     .filter(([name]) => isWorkspaceDataAttribute(name))
     .map(([name, value]): [string, unknown, string | undefined] => {
@@ -44,7 +46,7 @@ export const getWorkspaceDataAttributes = (workspaceAttributes: { [key: string]:
 export const useWorkspaceDataAttributes = (
   namespace: string,
   name: string
-): [AutoLoadedState<[string, unknown, unknown]>, () => Promise<void>] => {
+): [AutoLoadedState<[string, unknown, string | undefined][]>, () => Promise<void>] => {
   const { reportError } = useNotificationsFromContext();
 
   const signal = useCancellation();
@@ -55,7 +57,7 @@ export const useWorkspaceDataAttributes = (
     return getWorkspaceDataAttributes(attributes) as any;
   }, [namespace, name, signal]);
 
-  const [state, load] = useAutoLoadedData<[string, unknown, unknown]>(loadAttributes, [namespace, name], {
+  const [state, load] = useAutoLoadedData<[string, unknown, string | undefined][]>(loadAttributes, [namespace, name], {
     onError: ({ error }) => reportError('Error loading workspace data', error),
   });
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1067

The floating "Add variable" button on the Workspace Data screen can get in the way of the edit/delete buttons for some rows of the table.

This removes the floating "Add variable" button and updates the menu to be more like the menu for data tables, with "Add variable" and "Upload TSV" nested under an "Edit" menu.

## Before
![Screenshot 2024-07-01 at 10 34 27 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/a4462f5e-b99d-480c-ad99-4cf099417148)

## After
![Screenshot 2024-07-01 at 10 34 31 AM](https://github.com/DataBiosphere/terra-ui/assets/1156625/34bbcdc0-28db-4cd9-bf17-63027544ee10)
