### PR TITLE
[DC-941] Preserve selection of objects across cohort builder

### DIFF
--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -60,6 +60,12 @@ describe('DatasetBuilder', () => {
         onStateChange: (state) => state,
         snapshotId: testSnapshotId,
         snapshotBuilderSettings: testSettings,
+        selectedCohorts: [],
+        selectedConceptSets: [],
+        selectedValues: [],
+        updateSelectedCohorts: jest.fn(),
+        updateSelectedConceptSets: jest.fn(),
+        updateSelectedValues: jest.fn(),
         ...overrides,
       })
     );

--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -103,7 +103,7 @@ describe('DatasetBuilder', () => {
       }),
   });
 
-  const initializeValidDatasetRequest = async () => {
+  const initializeValidDatasetRequest = () => {
     const cohortOne = newCohort('cohort 1');
     const conditionConceptSet = newConceptSet('Condition');
     showDatasetBuilderContents({
@@ -226,11 +226,11 @@ describe('DatasetBuilder', () => {
     });
 
     // Assert
-    expect(screen.getByLabelText('cohort 1')).toBeChecked();
-    expect(screen.getByLabelText('cohort 2')).not.toBeChecked();
-    expect(screen.getByLabelText('Condition')).toBeChecked();
-    expect(screen.getByLabelText('Procedure')).not.toBeChecked();
-    expect(screen.getByLabelText('Observation')).not.toBeChecked();
+    expect(await screen.findByLabelText('cohort 1')).toBeChecked();
+    expect(await screen.findByLabelText('cohort 2')).not.toBeChecked();
+    expect(await screen.findByLabelText('Condition')).toBeChecked();
+    expect(await screen.findByLabelText('Procedure')).not.toBeChecked();
+    expect(await screen.findByLabelText('Observation')).not.toBeChecked();
   });
 
   it('calls update on selecting cohorts, and concept sets', async () => {
@@ -288,7 +288,7 @@ describe('DatasetBuilder', () => {
     } as Partial<DataRepoContract> as DataRepoContract;
     asMockedFn(DataRepo).mockImplementation(() => mockDataRepoContract as DataRepoContract);
     // Arrange
-    await initializeValidDatasetRequest();
+    initializeValidDatasetRequest();
     // Assert
     expect(await screen.findByText('100 participants in this dataset')).toBeTruthy();
     expect(await screen.findByText('Request this data snapshot')).toBeTruthy();

--- a/src/dataset-builder/dataset-builder-types.ts
+++ b/src/dataset-builder/dataset-builder-types.ts
@@ -1,5 +1,9 @@
 import { Cohort, CriteriaGroup } from 'src/dataset-builder/DatasetBuilderUtils';
-import { SnapshotBuilderConcept as Concept, SnapshotBuilderDomainOption } from 'src/libs/ajax/DataRepo';
+import {
+  SnapshotBuilderConcept as Concept,
+  SnapshotBuilderDatasetConceptSet,
+  SnapshotBuilderDomainOption,
+} from 'src/libs/ajax/DataRepo';
 
 let groupCount = 1;
 export const newCriteriaGroup = (): CriteriaGroup => {
@@ -11,12 +15,15 @@ export const newCriteriaGroup = (): CriteriaGroup => {
   };
 };
 
-export const newCohort = (name: string): Cohort => {
-  return {
-    name,
-    criteriaGroups: [],
-  };
-};
+export const newCohort = (name: string): Cohort => ({
+  name,
+  criteriaGroups: [],
+});
+
+export const newConceptSet = (name: string): SnapshotBuilderDatasetConceptSet => ({
+  name,
+  featureValueGroupName: '',
+});
 
 type DatasetBuilderMode =
   | 'homepage'


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-941

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
I lifted up state for all selected objects from the selector view so that the selection would persist across all pages. I left the typing as it was, since that minimized scope and reduced the impact of the change. Tested manually.

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
