### PR TITLE
[AJ-1917] Handle undefined descriptions in workspace data search

### DIFF
--- a/src/workspace-data/WorkspaceAttributes.js
+++ b/src/workspace-data/WorkspaceAttributes.js
@@ -65,10 +65,9 @@ export const WorkspaceAttributes = ({
 
   const initialAttributes = attributes.state || [];
   const creatingNewVariable = editIndex === initialAttributes.length;
-  const filteredAttributes = _.filter(
-    ([key, value, description]) => Utils.textMatch(textFilter, `${key} ${value} ${description}`),
-    initialAttributes
-  );
+  const filteredAttributes = initialAttributes.filter(([key, value, description]) => {
+    return [key, value, description].some((v) => `${v ?? ''}`.toLowerCase().includes(textFilter.toLowerCase()));
+  });
   const amendedAttributes = _.flow(creatingNewVariable ? Utils.append(['', '', '']) : _.identity)(filteredAttributes);
 
   const allVisibleAttributesSelected = filteredAttributes.every(([id]) => selection[id]);

--- a/src/workspace-data/WorkspaceAttributes.test.tsx
+++ b/src/workspace-data/WorkspaceAttributes.test.tsx
@@ -1,4 +1,4 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { DeepPartial, delay } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act, fireEvent, screen, within } from '@testing-library/react';
 import React from 'react';
@@ -52,7 +52,7 @@ type AjaxContract = ReturnType<typeof Ajax>;
 
 describe('WorkspaceAttributes', () => {
   interface SetupArgs {
-    attributes?: [string, unknown, string][];
+    attributes?: [string, unknown, string | undefined][];
     workspace?: WorkspaceWrapper;
   }
 
@@ -102,6 +102,33 @@ describe('WorkspaceAttributes', () => {
       'value2',
       'description2Edit variable',
     ]);
+  });
+
+  it.each([
+    { filter: 'f', expectedMatches: ['foo', 'baz'] },
+    { filter: '2', expectedMatches: ['bar'] },
+    { filter: 'def', expectedMatches: ['baz'] },
+  ])('filters workspace data attributes by name, value, or description', async ({ filter, expectedMatches }) => {
+    // Arrange
+    setup({
+      attributes: [
+        ['foo', '1', undefined],
+        ['bar', '2', 'abc'],
+        ['baz', '3', 'def'],
+      ],
+    });
+
+    // Act
+    const filterInput = screen.getByLabelText('Search');
+    fireEvent.change(filterInput, { target: { value: filter } });
+
+    await act(() => delay(250)); // debounced input
+
+    // Assert
+    const rows = screen.getAllByRole('row').slice(1);
+    const filteredAttributes = rows.map((row) => within(row).getAllByRole('cell')[1].textContent);
+
+    expect(filteredAttributes).toEqual(expectedMatches);
   });
 
   it('has option to add a new variable', () => {


### PR DESCRIPTION
Currently, search/filter for workspace data is implemented as:
```ts
const filteredAttributes = _.filter(
  ([key, value, description]) => Utils.textMatch(textFilter, `${key} ${value} ${description}`),
  initialAttributes
);
```

However, `description` may be undefined. In those cases, the string conversion means that search query gets matched against a string containing "undefined". If the search query matches "undefined", this results in attributes without descriptions incorrectly showing up in search results.

## Before
`foo` has no description, and incorrectly matches a search for "undefined".

![Screenshot 2024-07-03 at 1 43 51 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/69d69a3b-84c9-4dbc-ba65-ed13b274c16a)

## After
![Screenshot 2024-07-03 at 1 43 54 PM](https://github.com/DataBiosphere/terra-ui/assets/1156625/a1bbbd3e-d571-48a1-8784-382b4f3b04ad)