### PR TITLE
AJ-1902 Require unique keys for workspace data

### DIFF
--- a/src/workspace-data/WorkspaceAttributes.js
+++ b/src/workspace-data/WorkspaceAttributes.js
@@ -74,7 +74,12 @@ export const WorkspaceAttributes = ({
 
   const DESCRIPTION_MAX_LENGTH = 200;
   const inputErrors = editIndex !== undefined && [
-    ...(_.keys(_.unset(amendedAttributes[editIndex][0], attributes.state)).includes(editKey) ? ['Key must be unique'] : []),
+    ...(_.map(
+      (innerArray) => _.first(innerArray),
+      attributes.state.filter((_, index) => index !== editIndex)
+    ).includes(editKey)
+      ? ['Key must be unique']
+      : []),
     ...(!/^[\w-]*$/.test(editKey) ? ['Key can only contain letters, numbers, underscores, and dashes'] : []),
     ...(editKey === 'description' ? ["Key cannot be 'description'"] : []),
     ...(isDescriptionKey(editKey) ? [`Key cannot start with '${DESCRIPTION_PREFIX}'`] : []),

--- a/src/workspace-data/WorkspaceAttributes.test.tsx
+++ b/src/workspace-data/WorkspaceAttributes.test.tsx
@@ -1,6 +1,7 @@
 import { DeepPartial, delay } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act, fireEvent, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -198,5 +199,28 @@ describe('WorkspaceAttributes', () => {
       'attribute3',
       '__DESCRIPTION__attribute3',
     ]);
+  });
+
+  it('requires unique keys when editing', async () => {
+    // Arrange
+    setup({
+      attributes: [
+        ['attribute1', 'value1', 'description1'],
+        ['attribute2', 'value2', 'description2'],
+      ],
+    });
+
+    // Act
+    const rows = screen.getAllByRole('row');
+    const editMenuButton = within(rows[1]).getByRole('button', { name: 'Edit variable' });
+    fireEvent.click(editMenuButton);
+
+    const input = within(rows[1]).getAllByRole('textbox')[0];
+    await userEvent.clear(input);
+    await userEvent.type(input, 'attribute2');
+
+    // Assert
+    within(rows[1]).getByRole('button', { name: 'Key must be unique' });
+    // expect(saveChanges).toHaveLength(1);
   });
 });

--- a/src/workspace-data/WorkspaceAttributes.test.tsx
+++ b/src/workspace-data/WorkspaceAttributes.test.tsx
@@ -221,6 +221,5 @@ describe('WorkspaceAttributes', () => {
 
     // Assert
     within(rows[1]).getByRole('button', { name: 'Key must be unique' });
-    // expect(saveChanges).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1902
I discovered that recent changes to the Workspace Data attributes page failed to protect against non-unique keys - you could edit a variable to have the same key as another attribute.  This is because the check for unique keys was against the keys of an array - that is, the indices (0,1,2...) instead of the attribute key.  This PR fixes that and adds a test.