### PR TITLE
UIE-190 Auth Fetch Breakout part-1

### DIFF
--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -7,8 +7,10 @@ import { h } from 'react-hyperscript-helpers';
 import RModal from 'react-modal';
 import { startPollingServiceAlerts } from 'src/alerts/service-alerts-polling';
 import { startPollingVersion } from 'src/alerts/version-polling';
-import { initializeAuth } from 'src/auth/auth';
-import { initializeClientId } from 'src/auth/oidc-broker';
+import { initializeAuthListeners, initializeAuthUser } from 'src/auth/app-load/init-auth';
+import { initAuthTesting } from 'src/auth/app-load/init-auth-test';
+import { initializeAuthMetrics } from 'src/auth/app-load/init-metrics';
+import { initializeClientId } from 'src/auth/app-load/initializeClientId';
 import { initializeSystemProperties } from 'src/auth/system-loader';
 import { isAxeEnabled } from 'src/libs/config';
 import Main from 'src/pages/Main';
@@ -19,6 +21,10 @@ RModal.defaultStyles = { overlay: {}, content: {} };
 
 window._ = _;
 
+initializeAuthListeners();
+initializeAuthMetrics();
+initAuthTesting();
+
 initializeClientId().then(() => {
   const root = createRoot(rootElement);
   root.render(h(Main));
@@ -28,7 +34,7 @@ initializeClientId().then(() => {
   // doing anything that may show a notification.
   setTimeout(() => {
     initializeSystemProperties();
-    initializeAuth();
+    initializeAuthUser();
     startPollingServiceAlerts();
     startPollingVersion();
   }, 0);

--- a/src/auth/app-load/init-auth-test.ts
+++ b/src/auth/app-load/init-auth-test.ts
@@ -1,0 +1,53 @@
+import { initializeAuthUser } from 'src/auth/app-load/init-auth';
+import { OidcUser } from 'src/auth/oidc-broker';
+import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';
+import { withErrorReporting } from 'src/libs/error';
+import { authStore, oidcStore, userStore } from 'src/libs/state';
+
+interface GoogleUserInfo {
+  sub: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  picture: string;
+  email: string;
+  email_verified: boolean;
+  locale: string;
+  hd: string;
+}
+
+export const initAuthTesting = () => {
+  // This is intended for integration tests to short circuit the login flow
+  window.forceSignIn = withErrorReporting('Error forcing sign in')(async (token) => {
+    await initializeAuthUser(); // don't want this clobbered when real auth initializes
+    const res = await fetchOk('https://www.googleapis.com/oauth2/v3/userinfo', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data: GoogleUserInfo = await res.json();
+    oidcStore.update((state) => ({
+      ...state,
+      user: {
+        ...data,
+        access_token: token,
+      } as unknown as OidcUser,
+    }));
+    authStore.update((state) => ({
+      ...state,
+      signInStatus: 'authenticated',
+      isTimeoutEnabled: undefined,
+      cookiesAccepted: true,
+    }));
+    userStore.update((state) => ({
+      ...state,
+      terraUser: {
+        token,
+        id: data.sub,
+        email: data.email,
+        name: data.name,
+        givenName: data.given_name,
+        familyName: data.family_name,
+        imageUrl: data.picture,
+      },
+    }));
+  });
+};

--- a/src/auth/app-load/init-auth.ts
+++ b/src/auth/app-load/init-auth.ts
@@ -1,0 +1,143 @@
+import _ from 'lodash/fp';
+import { cookiesAcceptedKey } from 'src/auth/accept-cookies';
+import { loadOidcUser } from 'src/auth/auth';
+import { getCurrentOidcUser, initializeOidcUserManager, OidcUser } from 'src/auth/oidc-broker';
+import { loadTerraUser } from 'src/auth/user-profile/user';
+import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
+import { Groups } from 'src/libs/ajax/Groups';
+import { User } from 'src/libs/ajax/User';
+import { withErrorReporting } from 'src/libs/error';
+import * as Nav from 'src/libs/nav';
+import { getLocalPref, setLocalPref } from 'src/libs/prefs';
+import {
+  asyncImportJobStore,
+  AuthState,
+  authStore,
+  requesterPaysProjectStore,
+  workspacesStore,
+  workspaceStore,
+} from 'src/libs/state';
+import { allOAuth2Providers } from 'src/profile/external-identities/OAuth2Providers';
+
+export const userCanNowUseTerra = (oldState: AuthState, state: AuthState) => {
+  return (
+    // The user was not loaded, and became loaded and is allowed to use the system.
+    (oldState.signInStatus !== 'userLoaded' &&
+      state.signInStatus === 'userLoaded' &&
+      state.terraUserAllowances.allowed) ||
+    // The user was loaded and not allowed, but became allowed to use the system
+    (oldState.signInStatus === 'userLoaded' &&
+      !oldState.terraUserAllowances.allowed &&
+      state.signInStatus === 'userLoaded' &&
+      state.terraUserAllowances.allowed)
+  );
+};
+
+const isNowSignedIn = (oldState: AuthState, state: AuthState) => {
+  return oldState.signInStatus !== 'authenticated' && state.signInStatus === 'authenticated';
+};
+
+export const initializeAuthListeners = () => {
+  authStore.subscribe((state: AuthState) => {
+    // We can't guarantee that someone reopening the window is the same user,
+    // so we should not persist cookie acceptance across sessions for people signed out
+    // Per compliance recommendation, we could probably persist through a session, but
+    // that would require a second store in session storage instead of local storage
+    if (state.signInStatus === 'userLoaded' && state.cookiesAccepted !== getLocalPref(cookiesAcceptedKey)) {
+      setLocalPref(cookiesAcceptedKey, state.cookiesAccepted);
+    }
+  });
+
+  authStore.subscribe(
+    withErrorReporting('Error checking groups for timeout status')(async (state: AuthState, oldState: AuthState) => {
+      if (userCanNowUseTerra(oldState, state)) {
+        const isTimeoutEnabled = _.some({ groupName: 'session_timeout' }, await Groups().list());
+        authStore.update((state) => ({ ...state, isTimeoutEnabled }));
+      }
+    })
+  );
+
+  const doSignInEvents = (state: AuthState) => {
+    if (state.termsOfService.isCurrentVersion === false) {
+      // The user could theoretically navigate away from the Terms of Service page during the Rolling Acceptance Window.
+      // This is not a concern, since the user will be denied access to the system once the Rolling Acceptance Window ends.
+      // This is really just a convenience to make sure the user is not disrupted once the Rolling Acceptance Window ends.
+      Nav.goToPath('terms-of-service');
+    }
+  };
+
+  authStore.subscribe(
+    withErrorReporting('Error loading user')(async (state: AuthState, oldState: AuthState) => {
+      if (isNowSignedIn(oldState, state)) {
+        await loadTerraUser();
+        if (state.userJustSignedIn) {
+          const loadedState = authStore.get();
+          doSignInEvents(loadedState);
+          authStore.update((state: AuthState) => ({ ...state, userJustSignedIn: false }));
+        }
+      }
+    })
+  );
+
+  authStore.subscribe(
+    withErrorReporting('Error loading NIH account link status')(async (state: AuthState, oldState: AuthState) => {
+      if (userCanNowUseTerra(oldState, state)) {
+        const nihStatus = await User().getNihStatus();
+        authStore.update((state: AuthState) => ({ ...state, nihStatus, nihStatusLoaded: true }));
+      }
+    })
+  );
+
+  authStore.subscribe(
+    withErrorReporting('Error loading OAuth2 account status')(async (state: AuthState, oldState: AuthState) => {
+      if (userCanNowUseTerra(oldState, state)) {
+        await Promise.all(
+          _.map(async (provider) => {
+            const status = await ExternalCredentials()(provider).getAccountLinkStatus();
+            authStore.update(_.set(['oAuth2AccountStatus', provider.key], status));
+          }, allOAuth2Providers)
+        );
+      }
+    })
+  );
+
+  authStore.subscribe((state: AuthState, oldState: AuthState) => {
+    const isSignedOut = state.signInStatus === 'signedOut';
+    const wasSignedIn = oldState.signInStatus !== 'signedOut';
+    if (wasSignedIn && isSignedOut) {
+      workspaceStore.reset();
+      workspacesStore.reset();
+      asyncImportJobStore.reset();
+      window.Appcues?.reset();
+    }
+  });
+
+  workspaceStore.subscribe((newState, oldState) => {
+    const getWorkspaceId = (ws) => ws?.workspace.workspaceId;
+    if (getWorkspaceId(newState) !== getWorkspaceId(oldState)) {
+      requesterPaysProjectStore.reset();
+    }
+  });
+};
+
+// this function is only called when the browser refreshes
+export const initializeAuthUser = _.memoize(async (): Promise<void> => {
+  initializeOidcUserManager();
+  const setSignedOut = () =>
+    authStore.update((state) => ({
+      ...state,
+      signInStatus: 'signedOut',
+    }));
+  try {
+    const initialOidcUser: OidcUser | null = await getCurrentOidcUser();
+    if (initialOidcUser !== null) {
+      loadOidcUser(initialOidcUser);
+    } else {
+      setSignedOut();
+    }
+  } catch (e) {
+    console.error('Error in contacting oidc-client');
+    setSignedOut();
+    throw new Error('Failed to initialize auth.');
+  }
+});

--- a/src/auth/app-load/init-metrics.ts
+++ b/src/auth/app-load/init-metrics.ts
@@ -1,0 +1,45 @@
+import { userCanNowUseTerra } from 'src/auth/app-load/init-auth';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { withErrorIgnoring } from 'src/libs/error';
+import { captureAppcuesEvent } from 'src/libs/events';
+import { AuthState, authStore, metricStore, userStore } from 'src/libs/state';
+
+export const initializeAuthMetrics = () => {
+  authStore.subscribe(
+    withErrorIgnoring(async (state: AuthState, oldState: AuthState) => {
+      if (!oldState.termsOfService.permitsSystemUsage && state.termsOfService.permitsSystemUsage) {
+        if (window.Appcues) {
+          const { terraUser, samUser } = userStore.get();
+          // for Sam users who have been invited but not yet registered
+          // and for a set of users who didn't have registration dates to migrate into Sam
+          // registeredAt may be null in the Sam db. In that case, default to epoch (1970) instead
+          // so the survey won't be immediately displayed
+          const dateJoined = samUser.registeredAt ? samUser.registeredAt.getTime() : new Date('1970-01-01').getTime();
+          window.Appcues.identify(terraUser.id!, {
+            dateJoined,
+          });
+          window.Appcues.on('all', captureAppcuesEvent);
+        }
+      }
+    })
+  );
+
+  authStore.subscribe(
+    withErrorIgnoring(async (state: AuthState, oldState: AuthState) => {
+      if (userCanNowUseTerra(oldState, state)) {
+        await Metrics().syncProfile();
+      }
+    })
+  );
+
+  authStore.subscribe(
+    withErrorIgnoring(async (state: AuthState, oldState: AuthState) => {
+      if (userCanNowUseTerra(oldState, state)) {
+        const { anonymousId } = metricStore.get();
+        if (anonymousId) {
+          return await Metrics().identify(anonymousId);
+        }
+      }
+    })
+  );
+};

--- a/src/auth/app-load/initializeClientId.ts
+++ b/src/auth/app-load/initializeClientId.ts
@@ -1,0 +1,9 @@
+import _ from 'lodash/fp';
+import { OAuth2, OidcConfig } from 'src/libs/ajax/OAuth2';
+import { oidcStore } from 'src/libs/state';
+
+// This is the first thing that happens on app load.
+export const initializeClientId = _.memoize(async (): Promise<void> => {
+  const oidcConfig: OidcConfig = await OAuth2().getConfiguration();
+  oidcStore.update((state) => ({ ...state, config: oidcConfig }));
+});

--- a/src/auth/login.test.ts
+++ b/src/auth/login.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
 import { act } from '@testing-library/react';
-import { loadTerraUser } from 'src/auth/auth';
+import { loadTerraUser } from 'src/auth/user-profile/user';
 import { Groups, GroupsContract } from 'src/libs/ajax/Groups';
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import { SamUserTermsOfServiceDetails, TermsOfService, TermsOfServiceContract } from 'src/libs/ajax/TermsOfService';

--- a/src/auth/oidc-broker.ts
+++ b/src/auth/oidc-broker.ts
@@ -1,7 +1,5 @@
-import _ from 'lodash/fp';
 import { ExtraSigninRequestArgs, IdTokenClaims, User, UserManager, WebStorageStateStore } from 'oidc-client-ts';
 import { AuthContextProps } from 'react-oidc-context';
-import { OAuth2, OidcConfig } from 'src/libs/ajax/OAuth2';
 import { getLocalStorage } from 'src/libs/browser-storage';
 import { getConfig } from 'src/libs/config';
 import { oidcStore } from 'src/libs/state';
@@ -46,12 +44,6 @@ export const getOidcConfig = () => {
     redirect_uri: '', // this field is not being used currently, but is expected from UserManager
   };
 };
-
-// This is the first thing that happens on app load.
-export const initializeClientId = _.memoize(async (): Promise<void> => {
-  const oidcConfig: OidcConfig = await OAuth2().getConfiguration();
-  oidcStore.update((state) => ({ ...state, config: oidcConfig }));
-});
 
 export const initializeOidcUserManager = () => {
   const userManager: UserManager = new UserManager(getOidcConfig());

--- a/src/auth/user-profile/user.ts
+++ b/src/auth/user-profile/user.ts
@@ -1,0 +1,46 @@
+import { SamUserAttributes, User } from 'src/libs/ajax/User';
+import { clearNotification, sessionExpirationProps } from 'src/libs/notifications';
+import { AuthState, authStore, TerraUserProfile, TerraUserState, userStore } from 'src/libs/state';
+
+export const refreshTerraProfile = async () => {
+  const profile: TerraUserProfile = await User().profile.get();
+  userStore.update((state: TerraUserState) => ({ ...state, profile }));
+};
+
+export const refreshSamUserAttributes = async (): Promise<void> => {
+  const terraUserAttributes: SamUserAttributes = await User().getUserAttributes();
+  userStore.update((state: TerraUserState) => ({ ...state, terraUserAttributes }));
+};
+
+export const loadTerraUser = async (): Promise<void> => {
+  try {
+    const signInStatus = 'userLoaded';
+    const getProfile = User().profile.get();
+    const getCombinedState = User().getSamUserCombinedState();
+    const [profile, terraUserCombinedState] = await Promise.all([getProfile, getCombinedState]);
+    const { terraUserAttributes, enterpriseFeatures, samUser, terraUserAllowances, termsOfService } =
+      terraUserCombinedState;
+    clearNotification(sessionExpirationProps.id);
+    userStore.update((state: TerraUserState) => ({
+      ...state,
+      profile,
+      terraUserAttributes,
+      enterpriseFeatures,
+      samUser,
+    }));
+    authStore.update((state: AuthState) => ({
+      ...state,
+      signInStatus,
+      terraUserAllowances,
+      termsOfService,
+    }));
+  } catch (error: unknown) {
+    if ((error as Response).status !== 403) {
+      throw error;
+    }
+    // If the call to User endpoints fail with a 403, it means the user is not registered.
+    // Update the AuthStore state to forward them to the registration page.
+    const signInStatus = 'unregistered';
+    authStore.update((state: AuthState) => ({ ...state, signInStatus }));
+  }
+};

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -1,4 +1,4 @@
-import { abandonedPromise, delay } from '@terra-ui-packages/core-utils';
+import { delay } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import {
   AuthTokenState,
@@ -10,8 +10,8 @@ import {
 import { sessionExpirationErrorMessage } from 'src/auth/auth-errors';
 import { signOut, SignOutCause } from 'src/auth/signout/sign-out';
 import { FetchFn } from 'src/libs/ajax/data-client-common';
+import { withCancellation, withErrorRejection, withInstrumentation } from 'src/libs/ajax/fetch/fetch-core';
 import { getConfig } from 'src/libs/config';
-import { ajaxOverridesStore } from 'src/libs/state';
 
 export const authOpts = (token = getAuthToken()) => ({ headers: { Authorization: `Bearer ${token}` } });
 export const jsonBody = (body) => ({
@@ -160,48 +160,6 @@ export const checkRequesterPaysError = async (response): Promise<RequesterPaysEr
 export const responseContainsRequesterPaysError = (responseText) => {
   return _.includes('requester pays', responseText);
 };
-
-// Allows use of ajaxOverrideStore to stub responses for testing
-const withInstrumentation =
-  (wrappedFetch) =>
-  (...args) => {
-    return _.flow(
-      ..._.map(
-        'fn',
-        _.filter(({ filter }) => {
-          const [url, { method = 'GET' } = {}] = args;
-          return _.isFunction(filter)
-            ? filter(...args)
-            : url.match(filter.url) && (!filter.method || filter.method === method);
-        }, ajaxOverridesStore.get())
-      )
-    )(wrappedFetch)(...args);
-  };
-
-// Ignores cancellation error when request is cancelled
-const withCancellation =
-  (wrappedFetch) =>
-  async (...args) => {
-    try {
-      return await wrappedFetch(...args);
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') {
-        return abandonedPromise();
-      }
-      throw error;
-    }
-  };
-
-// Converts non-200 responses to exceptions
-const withErrorRejection =
-  (wrappedFetch) =>
-  async (...args) => {
-    const res = await wrappedFetch(...args);
-    if (res.ok) {
-      return res;
-    }
-    throw res;
-  };
 
 export const fetchOk = _.flow(withInstrumentation, withCancellation, withErrorRejection)(fetch);
 

--- a/src/libs/ajax/fetch/fetch-core.ts
+++ b/src/libs/ajax/fetch/fetch-core.ts
@@ -1,0 +1,55 @@
+import { abandonedPromise } from '@terra-ui-packages/core-utils';
+import _ from 'lodash/fp';
+import { ajaxOverridesStore } from 'src/libs/state';
+
+export const jsonBody = (body) => ({
+  body: JSON.stringify(body),
+  headers: { 'Content-Type': 'application/json' },
+});
+// Allows use of ajaxOverrideStore to stub responses for testing
+export const withInstrumentation =
+  (wrappedFetch) =>
+  (...args) => {
+    return _.flow(
+      ..._.map(
+        'fn',
+        _.filter(({ filter }) => {
+          const [url, { method = 'GET' } = {}] = args;
+          return _.isFunction(filter)
+            ? filter(...args)
+            : url.match(filter.url) && (!filter.method || filter.method === method);
+        }, ajaxOverridesStore.get())
+      )
+    )(wrappedFetch)(...args);
+  };
+
+// Ignores cancellation error when request is cancelled
+export const withCancellation =
+  (wrappedFetch) =>
+  async (...args) => {
+    try {
+      return await wrappedFetch(...args);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return abandonedPromise();
+      }
+      throw error;
+    }
+  };
+
+// Converts non-200 responses to exceptions
+export const withErrorRejection =
+  (wrappedFetch) =>
+  async (...args) => {
+    const res = await wrappedFetch(...args);
+    if (res.ok) {
+      return res;
+    }
+    throw res;
+  };
+
+export const fetchOk = _.flow(withInstrumentation, withCancellation, withErrorRejection)(fetch);
+
+export const withUrlPrefix = _.curry((prefix, wrappedFetch) => (path, ...args) => {
+  return wrappedFetch(prefix + path, ...args);
+});

--- a/src/profile/notification-settings/utils.test.ts
+++ b/src/profile/notification-settings/utils.test.ts
@@ -1,5 +1,5 @@
 import { asMockedFn } from '@terra-ui-packages/test-utils';
-import { refreshSamUserAttributes, refreshTerraProfile } from 'src/auth/auth';
+import { refreshSamUserAttributes, refreshTerraProfile } from 'src/auth/user-profile/user';
 import { Ajax } from 'src/libs/ajax';
 import Events, { EventWorkspaceAttributes, extractWorkspaceDetails } from 'src/libs/events';
 
@@ -8,6 +8,7 @@ import { notificationEnabled, updateNotificationPreferences, updateUserAttribute
 type AjaxContract = ReturnType<typeof Ajax>;
 
 jest.mock('src/auth/auth');
+jest.mock('src/auth/user-profile/user');
 jest.mock('src/libs/ajax');
 
 describe('utils', () => {

--- a/src/profile/notification-settings/utils.ts
+++ b/src/profile/notification-settings/utils.ts
@@ -1,4 +1,4 @@
-import { refreshSamUserAttributes, refreshTerraProfile } from 'src/auth/auth';
+import { refreshSamUserAttributes, refreshTerraProfile } from 'src/auth/user-profile/user';
 import { Ajax } from 'src/libs/ajax';
 import Events, { EventWorkspaceAttributes, extractWorkspaceDetails } from 'src/libs/events';
 

--- a/src/profile/useUserProfile.test.ts
+++ b/src/profile/useUserProfile.test.ts
@@ -1,7 +1,7 @@
 import { abandonedPromise } from '@terra-ui-packages/core-utils';
 import { act } from '@testing-library/react';
 import _ from 'lodash/fp';
-import { refreshTerraProfile } from 'src/auth/auth';
+import { refreshTerraProfile } from 'src/auth/user-profile/user';
 import { User } from 'src/libs/ajax/User';
 import { reportError } from 'src/libs/error';
 import { TerraUserProfile, userStore } from 'src/libs/state';
@@ -17,8 +17,7 @@ jest.mock('src/libs/ajax/User', (): UserExports => {
   };
 });
 
-// Mock the entire auth module to work around the auth/ajax-common import cycle.
-jest.mock('src/auth/auth');
+jest.mock('src/auth/user-profile/user');
 
 type SignOutExports = typeof import('src/auth/signout/sign-out');
 jest.mock(

--- a/src/profile/useUserProfile.ts
+++ b/src/profile/useUserProfile.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { refreshTerraProfile } from 'src/auth/auth';
+import { refreshTerraProfile } from 'src/auth/user-profile/user';
 import { UpdateTerraUserProfileRequest, User } from 'src/libs/ajax/User';
 import { reportError } from 'src/libs/error';
 import { useStore } from 'src/libs/react-utils';

--- a/src/registration/Register.test.ts
+++ b/src/registration/Register.test.ts
@@ -2,8 +2,8 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, fireEvent, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
-import { loadTerraUser } from 'src/auth/auth';
 import { signOut } from 'src/auth/signout/sign-out';
+import { loadTerraUser } from 'src/auth/user-profile/user';
 import { Ajax } from 'src/libs/ajax';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
@@ -17,8 +17,8 @@ jest.mock('src/auth/signout/sign-out', () => ({
   userSignedOut: jest.fn(),
 }));
 
-jest.mock('src/auth/auth', () => ({
-  ...jest.requireActual('src/auth/auth'),
+jest.mock('src/auth/user-profile/user', () => ({
+  ...jest.requireActual('src/auth/user-profile/user'),
   loadTerraUser: jest.fn(),
 }));
 

--- a/src/registration/Register.tsx
+++ b/src/registration/Register.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@terra-ui-packages/components';
 import React, { ReactNode, useState } from 'react';
-import { loadTerraUser } from 'src/auth/auth';
 import { signOut } from 'src/auth/signout/sign-out';
+import { loadTerraUser } from 'src/auth/user-profile/user';
 import { ButtonPrimary, ButtonSecondary, LabeledCheckbox } from 'src/components/common';
 import { centeredSpinner } from 'src/components/icons';
 import planet from 'src/images/register-planet.svg';

--- a/src/registration/terms-of-service/TermsOfServicePage.tsx
+++ b/src/registration/terms-of-service/TermsOfServicePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { loadTerraUser } from 'src/auth/auth';
 import { signOut } from 'src/auth/signout/sign-out';
+import { loadTerraUser } from 'src/auth/user-profile/user';
 import { ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/common';
 import scienceBackground from 'src/images/science-background.jpg';
 import { Ajax } from 'src/libs/ajax';


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/UIE-190

## Summary of changes:
 - first wave of larger cleanup.  [draft PR](https://github.com/DataBiosphere/terra-ui/pull/4931)
 - remove bulk of circular dependencies in auth.ts and ajax-common.ts death-loop by breaking out specialized app-load bits in auth.ts

### What
- auth.ts shows up in the dependency graph of many unit test imports since it is interwoven with ajax-common.ts.  This easily causes circular dependencies when seemingly unrelated code/module structure changes are made.  There are two main reasons for this:

1) auth.ts has ALOT of things in it, which pull in additional imports
2) auth.ts functions/utils themselves make reference to ajax-common.ts or things that find their way to ajax-common.ts

This PR implements the first wave of improving this by breaking apart auth.ts so that much of it is only hit from app startup flow, or user-profile related flows.

### Why
- unravel the circular dependencies: good for general code health, and AoU/broader code sharing efforts.
- improve unit-testability: many things in auth.ts self-execute at the module global scope, greatly complicating unit-testing.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] Smoke Test auth flows

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
