### PR TITLE
Show generic egress message if can't get bucket location (WOR-1741).

### DIFF
--- a/src/workspaces/NewWorkspaceModal/CloneEgressWarning.tsx
+++ b/src/workspaces/NewWorkspaceModal/CloneEgressWarning.tsx
@@ -1,4 +1,4 @@
-import { icon, Link } from '@terra-ui-packages/components';
+import { Icon, Link } from '@terra-ui-packages/components';
 import { CSSProperties, ReactNode } from 'react';
 import * as React from 'react';
 import { getLocationType, getRegionInfo } from 'src/components/region-common';
@@ -25,15 +25,15 @@ export interface CloneEgressWarningProps {
   sourceAzureWorkspaceRegion: string; // default value is ''
   selectedBillingProject: BillingProject;
   sourceGCPWorkspaceRegion: string; // default is a defaultLocation ('US-CENTRAL1')
+  sourceGCPWorkspaceRegionError: boolean; // did we encounter an error getting the actual GCP workspace bucket location?
   selectedGcpBucketLocation: string | undefined;
-  requesterPaysWorkspace: boolean;
 }
 
 export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode => {
   const sourceWorkspace = props.sourceWorkspace;
   const sourceAzureWorkspaceRegion = props.sourceAzureWorkspaceRegion;
   const selectedBillingProject = props.selectedBillingProject;
-  const requesterPaysWorkspace = props.requesterPaysWorkspace;
+  const sourceGCPWorkspaceRegionError = props.sourceGCPWorkspaceRegionError;
   const selectedGcpBucketLocation = props.selectedGcpBucketLocation;
   const sourceGCPWorkspaceRegion = props.sourceGCPWorkspaceRegion;
 
@@ -53,13 +53,9 @@ export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode =>
 
   const shouldShowGcpRegionWarning =
     !isAzureWorkspace(sourceWorkspace) &&
-    // If requester pays workspace, don't know the source region
-    (requesterPaysWorkspace || (!!selectedGcpBucketLocation && selectedGcpBucketLocation !== sourceGCPWorkspaceRegion));
-
-  const warningIcon = icon('warning-standard', {
-    size: 24,
-    style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' },
-  });
+    // If we could not get the source workspace bucket location, we default to showing a generic warning.
+    (sourceGCPWorkspaceRegionError ||
+      (!!selectedGcpBucketLocation && selectedGcpBucketLocation !== sourceGCPWorkspaceRegion));
 
   const genericEgressMessage = <span>Copying data may incur network egress charges.</span>;
   const renderRegionSpecificMessage = (sourceRegion: string, destinationRegion: string): ReactNode => {
@@ -74,7 +70,11 @@ export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode =>
   if (shouldShowAzureRegionWarning) {
     return (
       <div style={warningStyle}>
-        {warningIcon}
+        <Icon
+          icon='warning-standard'
+          size={24}
+          style={{ color: colors.warning(), flex: 'none', marginRight: '0.5rem' }}
+        />
         <div style={{ flex: 1 }}>
           {!haveAzureRegionNames
             ? genericEgressMessage
@@ -91,9 +91,13 @@ export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode =>
   if (shouldShowGcpRegionWarning) {
     return (
       <div style={warningStyle}>
-        {warningIcon}
+        <Icon
+          icon='warning-standard'
+          size={24}
+          style={{ color: colors.warning(), flex: 'none', marginRight: '0.5rem' }}
+        />
         <div style={{ flex: 1 }}>
-          {requesterPaysWorkspace
+          {sourceGCPWorkspaceRegionError
             ? genericEgressMessage
             : renderRegionSpecificMessage(
                 getRegionInfo(sourceGCPWorkspaceRegion, getLocationType(sourceGCPWorkspaceRegion)).regionDescription,
@@ -104,7 +108,7 @@ export const CloneEgressWarning = (props: CloneEgressWarningProps): ReactNode =>
           <span> </span>
           <Link href='https://support.terra.bio/hc/en-us/articles/360058964552' {...Utils.newTabLinkProps}>
             For more information please read the documentation.
-            {icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })}
+            <Icon icon='pop-out' size={12} style={{ marginLeft: '0.25rem' }} />
           </Link>
         </div>
       </div>

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1355,6 +1355,8 @@ describe('NewWorkspaceModal', () => {
         const user = userEvent.setup();
         const { checkBucketLocation } = setup({ billingProjects: [gcpBillingProject] });
         checkBucketLocation.mockRejectedValue(mockRejectedValue);
+        // Don't show expected message about bucket location not being available
+        jest.spyOn(console, 'log').mockImplementation(() => {});
 
         // Act
         await act(async () => {

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1344,31 +1344,38 @@ describe('NewWorkspaceModal', () => {
       );
     });
 
-    it('shows a generic message if the source workspace is requester pays', async () => {
-      // Arrange
-      const user = userEvent.setup();
-      const { checkBucketLocation } = setup({ billingProjects: [gcpBillingProject] });
-      checkBucketLocation.mockRejectedValue(mockBucketRequesterPaysError);
+    it.each([
+      { mockRejectedValue: mockBucketRequesterPaysError },
+      { mockRejectedValue: new Response('', { status: 403 }) },
+      { mockRejectedValue: new Response('', { status: 500 }) },
+    ] as { mockRejectedValue: any }[])(
+      'shows a generic message if the source bucket location cannot be obtained ($mockRejectedValue)',
+      async ({ mockRejectedValue }) => {
+        // Arrange
+        const user = userEvent.setup();
+        const { checkBucketLocation } = setup({ billingProjects: [gcpBillingProject] });
+        checkBucketLocation.mockRejectedValue(mockRejectedValue);
 
-      // Act
-      await act(async () => {
-        render(
-          h(NewWorkspaceModal, {
-            cloneWorkspace: defaultGoogleWorkspace,
-            onDismiss: () => {},
-            onSuccess: () => {},
-          })
-        );
-      });
+        // Act
+        await act(async () => {
+          render(
+            h(NewWorkspaceModal, {
+              cloneWorkspace: defaultGoogleWorkspace,
+              onDismiss: () => {},
+              onSuccess: () => {},
+            })
+          );
+        });
 
-      // Verify warning doesn't show up until a destination billing project is selected.
-      expect(screen.queryByText(egressWarning)).toBeNull();
+        // Verify warning doesn't show up until a destination billing project is selected.
+        expect(screen.queryByText(egressWarning)).toBeNull();
 
-      await selectBillingProject(user, 'Google Billing Project');
+        await selectBillingProject(user, 'Google Billing Project');
 
-      // Assert
-      screen.getByText(nonRegionSpecificEgressWarning);
-    });
+        // Assert
+        screen.getByText(nonRegionSpecificEgressWarning);
+      }
+    );
   });
 
   describe('shows egress warnings for cloning Azure workspaces', () => {

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -282,14 +282,14 @@ export const NewWorkspaceModal = withDisplayName(
               setBucketLocation(isSupportedBucketLocation(location) ? location : defaultLocation);
               setSourceGcpWorkspaceRegion(location);
             })
-            .catch((error) => {
+            .catch((_) => {
               // We cannot get the bucket location in a couple of scenarios:
               // 1. The bucket is requester pays.
               // 2. The user permissions are still syncing.
               // In either case, we will just show a generic egress warning message to prevent the
               // user from being blocked from cloning the workspace.
-              console.log(`Error getting the source workspace bucket location: ${error}`); // eslint-disable-line no-console
               setSourceGCPWorkspaceRegionError(true);
+              console.log('Error getting the source workspace bucket location'); // eslint-disable-line no-console
             }),
         !!cloneWorkspace &&
           isAzureWorkspace(cloneWorkspace) &&

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -5,7 +5,6 @@ import React, { ReactNode, useState } from 'react';
 import { defaultLocation } from 'src/analysis/utils/runtime-utils';
 import { AzureBillingProject, BillingProject, CloudPlatform, GCPBillingProject } from 'src/billing-core/models';
 import { supportsPhiTracking } from 'src/billing-core/utils';
-import { isBucketErrorRequesterPays } from 'src/components/bucket-utils';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import {
   ButtonPrimary,
@@ -121,7 +120,7 @@ export const NewWorkspaceModal = withDisplayName(
     const [bucketLocation, setBucketLocation] = useState(defaultLocation);
     const [sourceAzureWorkspaceRegion, setSourceAzureWorkspaceRegion] = useState<string>('');
     const [sourceGCPWorkspaceRegion, setSourceGcpWorkspaceRegion] = useState<string>(defaultLocation);
-    const [requesterPaysError, setRequesterPaysError] = useState(false);
+    const [sourceGCPWorkspaceRegionError, setSourceGCPWorkspaceRegionError] = useState(false);
     const [isAlphaRegionalityUser, setIsAlphaRegionalityUser] = useState(false);
     const [phiTracking, setPhiTracking] = useState<boolean | undefined>(undefined);
     const signal = useCancellation();
@@ -284,11 +283,13 @@ export const NewWorkspaceModal = withDisplayName(
               setSourceGcpWorkspaceRegion(location);
             })
             .catch((error) => {
-              if (isBucketErrorRequesterPays(error)) {
-                setRequesterPaysError(true);
-              } else {
-                throw error;
-              }
+              // We cannot get the bucket location in a couple of scenarios:
+              // 1. The bucket is requester pays.
+              // 2. The user permissions are still syncing.
+              // In either case, we will just show a generic egress warning message to prevent the
+              // user from being blocked from cloning the workspace.
+              console.log(`Error getting the source workspace bucket location: ${error}`); // eslint-disable-line no-console
+              setSourceGCPWorkspaceRegionError(true);
             }),
         !!cloneWorkspace &&
           isAzureWorkspace(cloneWorkspace) &&
@@ -584,9 +585,9 @@ export const NewWorkspaceModal = withDisplayName(
                     sourceWorkspace={cloneWorkspace}
                     sourceAzureWorkspaceRegion={sourceAzureWorkspaceRegion}
                     selectedBillingProject={selectedBillingProject}
-                    requesterPaysWorkspace={requesterPaysError}
                     selectedGcpBucketLocation={bucketLocation}
                     sourceGCPWorkspaceRegion={sourceGCPWorkspaceRegion}
+                    sourceGCPWorkspaceRegionError={sourceGCPWorkspaceRegionError}
                   />
                 )}
                 <IdContainer>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1741

Before:
<img width="1316" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/5ac7373c-eda9-40a8-9d41-beaf9254d549">

After:
<img width="655" alt="image" src="https://github.com/DataBiosphere/terra-ui/assets/484484/da57bda5-d53f-4dce-aea4-c373051ec8f4">

To reproduce/test:
1. Find a GCP workspace that needs to sync permissions. This will often be true for workspaces created be someone else. If you can't find one, see if you have access to https://pr-1-dot-bvdp-saturn-dev.appspot.com/#workspaces/galaxy-anvil-dev/Galaxy-Workshop-ASHG_2020_GWAS_Demo, which at least for me always has permissions sync'ing.
2. Bring up the Clone workspace dialog. Note the general egress warning message.
3. Test cloning the workspace.