### PR TITLE
[DC-1120]Update Snapshot Builder Settings to include Dataset Table Name and Relationships

### DIFF
--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -132,7 +132,7 @@ describe('DatasetBuilder', () => {
   const renderConceptSetSelector = () =>
     render(
       h(ConceptSetSelector, {
-        conceptSets: [...(testSettings.datasetConceptSets ?? [])],
+        conceptSets: testSettings.datasetConceptSets,
         selectedConceptSets: [],
         updateConceptSets: jest.fn(),
         onChange: (conceptSets) => conceptSets,

--- a/src/dataset-builder/DatasetBuilder.test.ts
+++ b/src/dataset-builder/DatasetBuilder.test.ts
@@ -2,12 +2,11 @@ import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import { Cohort, convertDomainOptionToConceptSet } from 'src/dataset-builder/DatasetBuilderUtils';
+import { Cohort } from 'src/dataset-builder/DatasetBuilderUtils';
 import {
   DataRepo,
   DataRepoContract,
   SnapshotBuilderDatasetConceptSet,
-  SnapshotBuilderDomainOption,
   SnapshotBuilderSettings,
 } from 'src/libs/ajax/DataRepo';
 import * as Nav from 'src/libs/nav';
@@ -67,10 +66,10 @@ describe('DatasetBuilder', () => {
         snapshotBuilderSettings: testSettings,
         selectedCohorts: [],
         selectedConceptSets: [],
-        selectedValues: [],
+        selectedColumns: [],
         updateSelectedCohorts: jest.fn(),
         updateSelectedConceptSets: jest.fn(),
-        updateSelectedValues: jest.fn(),
+        updateSelectedColumns: jest.fn(),
         ...overrides,
       })
     );
@@ -133,10 +132,7 @@ describe('DatasetBuilder', () => {
   const renderConceptSetSelector = () =>
     render(
       h(ConceptSetSelector, {
-        conceptSets: [
-          ..._.map(convertDomainOptionToConceptSet, testSettings.domainOptions),
-          ...testSettings.datasetConceptSets,
-        ],
+        conceptSets: [...(testSettings.datasetConceptSets ?? [])],
         selectedConceptSets: [],
         updateConceptSets: jest.fn(),
         onChange: (conceptSets) => conceptSets,
@@ -195,10 +191,6 @@ describe('DatasetBuilder', () => {
 
   it('renders concept sets', () => {
     renderConceptSetSelector();
-    _.flow(
-      _.map((domainOption: SnapshotBuilderDomainOption) => domainOption.name),
-      _.forEach((domainConceptSetName: string) => expect(screen.getByText(domainConceptSetName)).toBeTruthy())
-    )(testSettings.domainOptions);
     _.flow(
       _.map((conceptSet: SnapshotBuilderDatasetConceptSet) => conceptSet.name),
       _.forEach((conceptSetName: string) => expect(screen.getByText(conceptSetName)).toBeTruthy())

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -12,7 +12,6 @@ import TopBar from 'src/components/TopBar';
 import { StringInput } from 'src/data-catalog/create-dataset/CreateDatasetInputs';
 import {
   Cohort,
-  convertDomainOptionToConceptSet,
   createSnapshotAccessRequest,
   createSnapshotBuilderCountRequest,
   DatasetBuilderValue,
@@ -25,7 +24,8 @@ import {
   SnapshotAccessRequestResponse,
   SnapshotBuilderCountResponse,
   SnapshotBuilderDatasetConceptSet as ConceptSet,
-  SnapshotBuilderFeatureValueGroup as FeatureValueGroup,
+  SnapshotBuilderDatasetConceptSet,
+  SnapshotBuilderOutputTableApi as OutputTable,
   SnapshotBuilderSettings,
 } from 'src/libs/ajax/DataRepo';
 import colors from 'src/libs/colors';
@@ -472,8 +472,8 @@ export type DatasetBuilderContentsProps = {
   updateSelectedCohorts: (cohorts: HeaderAndValues<Cohort>[]) => void;
   selectedConceptSets: HeaderAndValues<ConceptSet>[];
   updateSelectedConceptSets: (cohorts: HeaderAndValues<ConceptSet>[]) => void;
-  selectedValues: RequiredHeaderAndValues<DatasetBuilderValue>[];
-  updateSelectedValues: (values: RequiredHeaderAndValues<DatasetBuilderValue>[]) => void;
+  selectedColumns: RequiredHeaderAndValues<DatasetBuilderValue>[];
+  updateSelectedColumns: (values: RequiredHeaderAndValues<DatasetBuilderValue>[]) => void;
 };
 
 export const DatasetBuilderContents = ({
@@ -487,8 +487,8 @@ export const DatasetBuilderContents = ({
   updateSelectedCohorts,
   selectedConceptSets,
   updateSelectedConceptSets,
-  selectedValues,
-  updateSelectedValues,
+  selectedColumns,
+  updateSelectedColumns,
 }: DatasetBuilderContentsProps) => {
   const [requestingAccess, setRequestingAccess] = useState(false);
   const [snapshotRequestParticipantCount, setSnapshotRequestParticipantCount] =
@@ -507,33 +507,31 @@ export const DatasetBuilderContents = ({
           DataRepo().snapshot(snapshotId).getSnapshotBuilderCount(createSnapshotBuilderCountRequest(allCohorts))
         )
       );
-  }, [snapshotId, selectedValues, setSnapshotRequestParticipantCount, allCohorts, allConceptSets, requestValid]);
+  }, [snapshotId, selectedColumns, setSnapshotRequestParticipantCount, allCohorts, allConceptSets, requestValid]);
 
-  const getNewFeatureValueGroups = (includedFeatureValueGroups: string[]): string[] =>
+  const getNewColumns = (includedColumns: string[]): string[] =>
     _.without(
       [
         ..._.flatMap(
-          (selectedValueGroups: RequiredHeaderAndValues<DatasetBuilderValue>) => selectedValueGroups.header,
-          selectedValues
+          (selectedHeaderValues: RequiredHeaderAndValues<DatasetBuilderValue>) => selectedHeaderValues.header,
+          selectedColumns
         ),
         ..._.flow(
           _.flatMap((selectedConceptSetGroup: HeaderAndValues<ConceptSet>) => selectedConceptSetGroup.values),
-          _.map((selectedConceptSet) => selectedConceptSet.featureValueGroupName)
+          _.map((selectedConceptSet) => selectedConceptSet.name)
         )(selectedConceptSets),
       ],
-      includedFeatureValueGroups
+      includedColumns
     );
 
-  const createHeaderAndValuesFromFeatureValueGroups = (
-    featureValueGroups: string[]
-  ): RequiredHeaderAndValues<DatasetBuilderValue>[] =>
+  const createHeaderAndValuesFromColumns = (columns: string[]): RequiredHeaderAndValues<DatasetBuilderValue>[] =>
     _.flow(
-      _.filter((featureValueGroup: FeatureValueGroup) => _.includes(featureValueGroup.name, featureValueGroups)),
-      _.map((featureValueGroup: FeatureValueGroup) => ({
-        header: featureValueGroup.name,
-        values: _.map((value) => ({ name: value }), featureValueGroup.values),
+      _.filter((outputTable: OutputTable) => _.includes(outputTable.name, columns)),
+      _.map((datasetConceptSet: SnapshotBuilderDatasetConceptSet) => ({
+        header: datasetConceptSet.name,
+        values: _.map((value) => ({ name: value }), datasetConceptSet.table.columns),
       }))
-    )(snapshotBuilderSettings.featureValueGroups);
+    )(snapshotBuilderSettings.datasetConceptSets);
 
   return h(Fragment, [
     div({ style: { display: 'flex', flexDirection: 'column', justifyContent: 'space-between' } }, [
@@ -556,15 +554,12 @@ export const DatasetBuilderContents = ({
             conceptSets,
             selectedConceptSets,
             onChange: async (conceptSets) => {
-              const includedFeatureValueGroups = _.flow(
+              const includedColumns = _.flow(
                 _.flatMap((headerAndValues: HeaderAndValues<ConceptSet>) => headerAndValues.values),
-                _.map((conceptSet: ConceptSet) => conceptSet.featureValueGroupName)
+                _.map((conceptSet: ConceptSet) => conceptSet.name)
               )(conceptSets);
-              const newFeatureValueGroups = getNewFeatureValueGroups(includedFeatureValueGroups);
-              updateSelectedValues([
-                ...selectedValues,
-                ...createHeaderAndValuesFromFeatureValueGroups(newFeatureValueGroups),
-              ]);
+              const newColumns = getNewColumns(includedColumns);
+              updateSelectedColumns([...selectedColumns, ...createHeaderAndValuesFromColumns(newColumns)]);
               updateSelectedConceptSets(conceptSets);
             },
             onStateChange,
@@ -592,13 +587,12 @@ export const DatasetBuilderContents = ({
                         '',
                         snapshotId,
                         _.flatMap((cohortSet) => cohortSet.values, selectedCohorts),
-                        _.flatMap((conceptSetSet) => conceptSetSet.values, selectedConceptSets),
                         _.map(
-                          (valuesSet: RequiredHeaderAndValues<DatasetBuilderValue>) => ({
-                            domain: valuesSet.header,
-                            values: valuesSet.values,
+                          (outputTables: RequiredHeaderAndValues<DatasetBuilderValue>) => ({
+                            domain: outputTables.header,
+                            columns: outputTables.values,
                           }),
-                          selectedValues // convert from HeaderAndValues<DatasetBuilderType>[] to ValueSet[]
+                          selectedColumns // convert from HeaderAndValues<DatasetBuilderType>[] to ValueSet[]
                         )
                       )
                     )
@@ -641,14 +635,9 @@ export const DatasetBuilderView: React.FC<DatasetBuilderProps> = (props) => {
   const [cohorts, setCohorts] = useState<Cohort[]>([]);
   const [selectedCohorts, setSelectedCohorts] = useState([] as HeaderAndValues<Cohort>[]);
   const [selectedConceptSets, setSelectedConceptSets] = useState([] as HeaderAndValues<ConceptSet>[]);
-  const [selectedValues, setSelectedValues] = useState([] as RequiredHeaderAndValues<DatasetBuilderValue>[]);
+  const [selectedColumns, setSelectedColumns] = useState([] as RequiredHeaderAndValues<DatasetBuilderValue>[]);
   const conceptSets =
-    snapshotBuilderSettings.status === 'Ready'
-      ? [
-          ..._.map(convertDomainOptionToConceptSet, snapshotBuilderSettings.state.domainOptions),
-          ...(snapshotBuilderSettings.state.datasetConceptSets ?? []),
-        ]
-      : [];
+    snapshotBuilderSettings.status === 'Ready' ? [...(snapshotBuilderSettings.state.datasetConceptSets ?? [])] : [];
   const onStateChange = setDatasetBuilderState;
 
   const getNextCriteriaIndex = () => {
@@ -694,8 +683,8 @@ export const DatasetBuilderView: React.FC<DatasetBuilderProps> = (props) => {
                   updateSelectedCohorts: setSelectedCohorts,
                   selectedConceptSets,
                   updateSelectedConceptSets: setSelectedConceptSets,
-                  selectedValues,
-                  updateSelectedValues: setSelectedValues,
+                  selectedColumns,
+                  updateSelectedColumns: setSelectedColumns,
                 });
               case 'cohort-editor':
                 return h(CohortEditor, {

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -592,7 +592,7 @@ export const DatasetBuilderContents = ({
                             domain: outputTables.header,
                             columns: outputTables.values,
                           }),
-                          selectedColumns // convert from HeaderAndValues<DatasetBuilderType>[] to ValueSet[]
+                          selectedColumns // convert from HeaderAndValues<DatasetBuilderType>[] to OutputTable[]
                         )
                       )
                     )

--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -637,7 +637,7 @@ export const DatasetBuilderView: React.FC<DatasetBuilderProps> = (props) => {
   const [selectedConceptSets, setSelectedConceptSets] = useState([] as HeaderAndValues<ConceptSet>[]);
   const [selectedColumns, setSelectedColumns] = useState([] as RequiredHeaderAndValues<DatasetBuilderValue>[]);
   const conceptSets =
-    snapshotBuilderSettings.status === 'Ready' ? [...(snapshotBuilderSettings.state.datasetConceptSets ?? [])] : [];
+    snapshotBuilderSettings.status === 'Ready' ? snapshotBuilderSettings.state.datasetConceptSets : [];
   const onStateChange = setDatasetBuilderState;
 
   const getNextCriteriaIndex = () => {

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -4,18 +4,16 @@ import {
   Cohort,
   convertCohort,
   convertCriteria,
-  convertDomainOptionToConceptSet,
   convertValueSet,
   createSnapshotAccessRequest,
   CriteriaGroup,
-  DomainConceptSet,
   formatCount,
   HighlightConceptName,
+  OutputTable,
   ProgramDataListCriteria,
   ProgramDataRangeCriteria,
   ProgramDomainCriteria,
   SnapshotAccessRequest,
-  ValueSet,
 } from 'src/dataset-builder/DatasetBuilderUtils';
 import { testSnapshotId } from 'src/dataset-builder/TestConstants';
 import {
@@ -24,10 +22,9 @@ import {
   SnapshotBuilderCohort,
   SnapshotBuilderConcept,
   SnapshotBuilderCriteriaGroup,
-  SnapshotBuilderDatasetConceptSet,
   SnapshotBuilderDomainCriteria,
   SnapshotBuilderDomainOption,
-  SnapshotBuilderFeatureValueGroup,
+  SnapshotBuilderOutputTableApi,
   SnapshotBuilderProgramDataListCriteria,
   SnapshotBuilderProgramDataListItem,
   SnapshotBuilderProgramDataListOption,
@@ -54,11 +51,6 @@ const domainOption: SnapshotBuilderDomainOption = {
   conceptCount: 10,
   participantCount: 20,
   root: concept,
-};
-
-const domainConceptSet: SnapshotBuilderDatasetConceptSet = {
-  name: domainOptionName,
-  featureValueGroupName: domainOptionName,
 };
 
 const domainCriteria: ProgramDomainCriteria = {
@@ -155,34 +147,22 @@ const cohort: Cohort = { name: 'cohort', criteriaGroups: [criteriaGroup] };
 
 const cohortApi: SnapshotBuilderCohort = { name: 'cohort', criteriaGroups: [criteriaGroupApi] };
 
-const valueSet: ValueSet = { domain: 'valueDomain', values: [{ name: 'valueName' }] };
+const outputTable: OutputTable = { domain: 'valueDomain', columns: [{ name: 'valueName' }] };
 
-const valueSetApi: SnapshotBuilderFeatureValueGroup = { name: 'valueDomain', values: ['valueName'] };
-
-const conceptSet: DomainConceptSet = {
-  name: 'conceptSetName',
-  concept,
-  featureValueGroupName: 'featureValueGroupName',
-};
+const outputTableApi: SnapshotBuilderOutputTableApi = { name: 'valueDomain', columns: ['valueName'] };
 
 const datasetAccessRequest: SnapshotAccessRequest = {
   name: 'RequestName',
   researchPurposeStatement: 'purpose',
-  datasetRequest: { cohorts: [cohort], conceptSets: [conceptSet], valueSets: [valueSet] },
+  datasetRequest: { cohorts: [cohort], outputTables: [outputTable] },
 };
 
 const datasetAccessRequestApi: SnapshotAccessRequestApi = {
   sourceSnapshotId: testSnapshotId,
   name: 'RequestName',
   researchPurposeStatement: 'purpose',
-  snapshotBuilderRequest: { cohorts: [cohortApi], conceptSets: [conceptSet], valueSets: [valueSetApi] },
+  snapshotBuilderRequest: { cohorts: [cohortApi], outputTables: [outputTableApi] },
 };
-
-describe('test conversion of a domainOption to a domainConceptSet', () => {
-  test('domainOption converted to domainConceptSet', () => {
-    expect(convertDomainOptionToConceptSet(domainOption)).toStrictEqual(domainConceptSet);
-  });
-});
 
 describe('test conversion of criteria', () => {
   test('domainCriteria converted to domainCriteriaApi', () => {
@@ -203,8 +183,8 @@ describe('test conversion of a cohort', () => {
 });
 
 describe('test conversion of valueSets', () => {
-  test('valueSet converted to valueSetApi', () => {
-    expect(convertValueSet(valueSet)).toStrictEqual(valueSetApi);
+  test('outputTable converted to outputTableApi', () => {
+    expect(convertValueSet(outputTable)).toStrictEqual(outputTableApi);
   });
 });
 
@@ -216,8 +196,7 @@ describe('test conversion of DatasetAccessRequest', () => {
         datasetAccessRequest.researchPurposeStatement,
         testSnapshotId,
         datasetAccessRequest.datasetRequest.cohorts,
-        datasetAccessRequest.datasetRequest.conceptSets,
-        datasetAccessRequest.datasetRequest.valueSets
+        datasetAccessRequest.datasetRequest.outputTables
       )
     ).toStrictEqual(datasetAccessRequestApi);
   });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -4,7 +4,7 @@ import {
   Cohort,
   convertCohort,
   convertCriteria,
-  convertValueSet,
+  convertOutputTable,
   createSnapshotAccessRequest,
   CriteriaGroup,
   formatCount,
@@ -184,7 +184,7 @@ describe('test conversion of a cohort', () => {
 
 describe('test conversion of valueSets', () => {
   test('outputTable converted to outputTableApi', () => {
-    expect(convertValueSet(outputTable)).toStrictEqual(outputTableApi);
+    expect(convertOutputTable(outputTable)).toStrictEqual(outputTableApi);
   });
 });
 

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -81,10 +81,10 @@ export type SnapshotAccessRequest = {
   datasetRequest: SnapshotBuilderRequest;
 };
 
-export const convertValueSet = (valueSet: OutputTable): SnapshotBuilderOutputTableApi => {
+export const convertOutputTable = (outputTable: OutputTable): SnapshotBuilderOutputTableApi => {
   return {
-    name: valueSet.domain,
-    columns: _.map('name', valueSet.columns),
+    name: outputTable.domain,
+    columns: _.map('name', outputTable.columns),
   };
 };
 
@@ -137,7 +137,7 @@ export const createSnapshotAccessRequest = (
     researchPurposeStatement,
     snapshotBuilderRequest: {
       cohorts: _.map(convertCohort, cohorts),
-      outputTables: _.map(convertValueSet, valueSets),
+      outputTables: _.map(convertOutputTable, valueSets),
     },
   };
 };

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -6,14 +6,12 @@ import {
   DatasetBuilderType,
   SnapshotAccessRequest as SnapshotAccessRequestApi,
   SnapshotBuilderCohort,
-  SnapshotBuilderConcept,
   SnapshotBuilderCountRequest,
-  SnapshotBuilderDatasetConceptSet,
   SnapshotBuilderDomainCriteria,
   SnapshotBuilderDomainOption,
-  SnapshotBuilderFeatureValueGroup,
   SnapshotBuilderOption,
   SnapshotBuilderOptionTypeNames,
+  SnapshotBuilderOutputTableApi,
   SnapshotBuilderProgramDataListCriteria,
   SnapshotBuilderProgramDataListItem,
   SnapshotBuilderProgramDataListOption,
@@ -31,9 +29,6 @@ export interface Criteria {
 }
 
 /** Below are the UI types */
-export interface DomainConceptSet extends SnapshotBuilderDatasetConceptSet {
-  concept: SnapshotBuilderConcept;
-}
 
 export interface ProgramDomainCriteria extends Criteria {
   kind: 'domain';
@@ -56,8 +51,6 @@ export interface ProgramDataListCriteria extends Criteria {
 
 export type AnyCriteria = ProgramDomainCriteria | ProgramDataRangeCriteria | ProgramDataListCriteria;
 
-export type PrepackagedConceptSet = SnapshotBuilderDatasetConceptSet;
-
 /** A group of criteria. */
 export interface CriteriaGroup {
   name: string;
@@ -72,15 +65,14 @@ export interface Cohort extends DatasetBuilderType {
 
 export type DatasetBuilderValue = DatasetBuilderType;
 
-export type ValueSet = {
+export type OutputTable = {
   domain: string;
-  values: DatasetBuilderValue[];
+  columns: DatasetBuilderValue[];
 };
 
 export type SnapshotBuilderRequest = {
   cohorts: Cohort[];
-  conceptSets: SnapshotBuilderDatasetConceptSet[];
-  valueSets: ValueSet[];
+  outputTables: OutputTable[];
 };
 
 export type SnapshotAccessRequest = {
@@ -89,19 +81,10 @@ export type SnapshotAccessRequest = {
   datasetRequest: SnapshotBuilderRequest;
 };
 
-export const convertDomainOptionToConceptSet = (
-  domainOption: SnapshotBuilderDomainOption
-): SnapshotBuilderDatasetConceptSet => {
-  return {
-    name: domainOption.name,
-    featureValueGroupName: domainOption.name,
-  };
-};
-
-export const convertValueSet = (valueSet: ValueSet): SnapshotBuilderFeatureValueGroup => {
+export const convertValueSet = (valueSet: OutputTable): SnapshotBuilderOutputTableApi => {
   return {
     name: valueSet.domain,
-    values: _.map('name', valueSet.values),
+    columns: _.map('name', valueSet.columns),
   };
 };
 
@@ -146,8 +129,7 @@ export const createSnapshotAccessRequest = (
   researchPurposeStatement: string,
   snapshotId: string,
   cohorts: Cohort[],
-  conceptSets: SnapshotBuilderDatasetConceptSet[],
-  valueSets: ValueSet[]
+  valueSets: OutputTable[]
 ): SnapshotAccessRequestApi => {
   return {
     name,
@@ -155,8 +137,7 @@ export const createSnapshotAccessRequest = (
     researchPurposeStatement,
     snapshotBuilderRequest: {
       cohorts: _.map(convertCohort, cohorts),
-      conceptSets,
-      valueSets: _.map(convertValueSet, valueSets),
+      outputTables: _.map(convertValueSet, valueSets),
     },
   };
 };

--- a/src/dataset-builder/TestConstants.ts
+++ b/src/dataset-builder/TestConstants.ts
@@ -134,6 +134,15 @@ export const testSnapshotBuilderSettings = (): SnapshotBuilderSettings => ({
       },
     },
   ],
+  rootTable: {
+    datasetTableName: 'person',
+    rootColumn: 'person_id',
+    columns: [],
+  },
+  dictionaryTable: {
+    datasetTableName: 'concept',
+    columns: [],
+  },
 });
 
 const dummyConcepts = [

--- a/src/dataset-builder/TestConstants.ts
+++ b/src/dataset-builder/TestConstants.ts
@@ -80,36 +80,58 @@ export const testSnapshotBuilderSettings = (): SnapshotBuilderSettings => ({
       root: dummyGetConceptForId(300),
     },
   ],
-  featureValueGroups: [
-    {
-      values: ['condition column 1', 'condition column 2'],
-      name: 'Condition',
-    },
-    {
-      values: ['observation column 1', 'observation column 2'],
-      name: 'Observation',
-    },
-    {
-      values: ['procedure column 1', 'procedure column 2'],
-      name: 'Procedure',
-    },
-    {
-      values: ['surveys column 1', 'surveys column 2'],
-      name: 'Surveys',
-    },
-    {
-      values: ['demographics column 1', 'demographics column 2'],
-      name: 'Person',
-    },
-  ],
   datasetConceptSets: [
     {
-      name: 'Demographics',
-      featureValueGroupName: 'Person',
+      name: 'Procedure',
+      table: {
+        datasetTableName: 'procedure_occurrence',
+        columns: [],
+        primaryTableRelationship: 'fpk_person_procedure',
+        secondaryTableRelationships: [
+          'fpk_procedure_concept',
+          'fpk_procedure_concept_s',
+          'fpk_procedure_type_concept',
+          'fpk_procedure_modifier',
+        ],
+      },
     },
     {
-      name: 'All surveys',
-      featureValueGroupName: 'Surveys',
+      name: 'Observation',
+      table: {
+        datasetTableName: 'observation',
+        columns: [],
+        primaryTableRelationship: 'fpk_person_observation',
+        secondaryTableRelationships: [
+          'fpk_observation_period_person',
+          'fpk_observation_concept',
+          'fpk_observation_concept_s',
+          'fpk_observation_unit',
+          'fpk_observation_qualifier',
+          'fpk_observation_type_concept',
+          'fpk_observation_period_concept',
+          'fpk_observation_value',
+        ],
+      },
+    },
+    {
+      name: 'Demographics',
+      table: {
+        datasetTableName: 'person',
+        columns: [],
+        secondaryTableRelationships: [
+          'fpk_person_ethnicity_concept',
+          'fpk_person_ethnicity_concept_s',
+          'fpk_person_race_concept',
+        ],
+      },
+    },
+    {
+      name: 'Genomics',
+      table: {
+        datasetTableName: 'sample',
+        columns: [],
+        primaryTableRelationship: 'fpk_person_sample',
+      },
     },
   ],
 });

--- a/src/dataset-builder/TestConstants.ts
+++ b/src/dataset-builder/TestConstants.ts
@@ -114,18 +114,6 @@ export const testSnapshotBuilderSettings = (): SnapshotBuilderSettings => ({
       },
     },
     {
-      name: 'Demographics',
-      table: {
-        datasetTableName: 'person',
-        columns: [],
-        secondaryTableRelationships: [
-          'fpk_person_ethnicity_concept',
-          'fpk_person_ethnicity_concept_s',
-          'fpk_person_race_concept',
-        ],
-      },
-    },
-    {
       name: 'Genomics',
       table: {
         datasetTableName: 'sample',

--- a/src/dataset-builder/dataset-builder-types.ts
+++ b/src/dataset-builder/dataset-builder-types.ts
@@ -22,7 +22,7 @@ export const newCohort = (name: string): Cohort => ({
 
 export const newConceptSet = (name: string): SnapshotBuilderDatasetConceptSet => ({
   name,
-  featureValueGroupName: '',
+  table: { datasetTableName: 'datasetTableName', columns: [] },
 });
 
 type DatasetBuilderMode =

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -63,10 +63,16 @@ export type SnapshotBuilderTable = {
   secondaryTableRelationships?: string[];
 };
 
+interface SnapshotBuilderRootTable extends SnapshotBuilderTable {
+  rootColumn: string;
+}
+
 export type SnapshotBuilderSettings = {
   domainOptions: SnapshotBuilderDomainOption[];
   programDataOptions: (SnapshotBuilderProgramDataListOption | SnapshotBuilderProgramDataRangeOption)[];
   datasetConceptSets: SnapshotBuilderDatasetConceptSet[];
+  rootTable: SnapshotBuilderRootTable;
+  dictionaryTable?: SnapshotBuilderTable;
 };
 
 /** Criteria */

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -53,13 +53,19 @@ export interface DatasetBuilderType {
 }
 
 export interface SnapshotBuilderDatasetConceptSet extends DatasetBuilderType {
-  featureValueGroupName: string;
+  table: SnapshotBuilderTable;
 }
+
+export type SnapshotBuilderTable = {
+  datasetTableName: string;
+  columns: string[];
+  primaryTableRelationship?: string;
+  secondaryTableRelationships?: string[];
+};
 
 export type SnapshotBuilderSettings = {
   domainOptions: SnapshotBuilderDomainOption[];
   programDataOptions: (SnapshotBuilderProgramDataListOption | SnapshotBuilderProgramDataRangeOption)[];
-  featureValueGroups: SnapshotBuilderFeatureValueGroup[];
   datasetConceptSets: SnapshotBuilderDatasetConceptSet[];
 };
 
@@ -102,15 +108,14 @@ export interface SnapshotBuilderCohort extends DatasetBuilderType {
   criteriaGroups: SnapshotBuilderCriteriaGroup[];
 }
 
-export type SnapshotBuilderFeatureValueGroup = {
+export type SnapshotBuilderOutputTableApi = {
   name: string;
-  values: string[];
+  columns: string[];
 };
 
 export type SnapshotBuilderRequest = {
   cohorts: SnapshotBuilderCohort[];
-  conceptSets: SnapshotBuilderDatasetConceptSet[];
-  valueSets: SnapshotBuilderFeatureValueGroup[];
+  outputTables: SnapshotBuilderOutputTableApi[];
 };
 
 interface SnapshotDataset {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-1120

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Update the structure of the snapshot builder settings to match the changes on the backend
Update the structure of the snapshot access request to match the changes on the backend
Follow the changes through with some renaming and updating usages

### Testing strategy
I ran this branch connected to local TDR on branch DC-1120-update-settings. I followed these steps:
1. Use the set up resources script to get a full view snapshot locally, off which I can make snapshot access requests.
2. Update the settings on that full view snapshot to be the new settings shown in this PR.
3. On local terra-ui, go through the researcher flow to submit a snapshot access request. Below is a video of the flow and the json of the submitted snapshot access request. It includes the Drug and Condition tables.

Video of creating a snapshot access request: 
https://github.com/user-attachments/assets/7e8d7f5f-ecc5-437d-b5e8-4165163dd8d1

Resulting snapshot access request response: 
```
{
    "id": "6f8a1c2f-e1c9-4af2-a7ad-bb7fbc9bb016",
    "datasetId": null,
    "sourceSnapshotId": "f5555e71-f988-4119-ab22-20bbaf37a1cc",
    "snapshotName": "",
    "snapshotResearchPurpose": "",
    "snapshotSpecification": {
        "cohorts": [
            {
                "name": "cohort",
                "criteriaGroups": [
                    {
                        "name": "Group 4",
                        "criteria": [
                            {
                                "kind": "domain",
                                "id": 10,
                                "conceptId": 4187458
                            },
                            {
                                "kind": "domain",
                                "id": 10,
                                "conceptId": 4163872
                            },
                            {
                                "kind": "range",
                                "id": 0,
                                "low": 1911,
                                "high": 2005
                            },
                            {
                                "kind": "list",
                                "id": 1,
                                "values": [
                                    8532
                                ]
                            }
                        ],
                        "mustMeet": true,
                        "meetAll": false
                    }
                ]
            }
        ],
        "outputTables": [
            {
                "name": "Drug",
                "columns": []
            },
            {
                "name": "Condition",
                "columns": []
            }
        ]
    },
    "createdBy": "rjohanekdev@gmail.com",
    "status": "SUBMITTED",
    "createdDate": "2024-07-16T20:53:21.027691Z",
    "statusUpdatedDate": null,
    "flightid": null,
    "createdSnapshotId": null
}
```
4. On local tdr swagger, approve the request.
5. On local tdr swagger, create a snapshot using the byRequestId mode and the id of the snapshot access request id. Using this payload:
```
{
  "name": "unused_overwritten",
  "description": "testing settings changes with new backend changes",
  "contents": [
    {
      "datasetName": "unused_overwritten",
      "mode": "byRequestId",
      "requestIdSpec": {
        "snapshotRequestId": "6f8a1c2f-e1c9-4af2-a7ad-bb7fbc9bb016"
      }
    }
  ]
}
```
6. On local tdr swagger, use the querySnapshotDataById endpoint to check that the newly created snapshot has the selected tables (Drug and Condition) populated as well as the person and concept tables. Below is a video that shows what data was included in this snapshot and that other data, such as Procedure was not included.
Video showing snapshot data: 

https://github.com/user-attachments/assets/f4c2e595-d024-4f4c-97d1-16f315e88fcf

### Notes
Once this is merged, the settings on dev and prod will need to be updated for the product to work.




