### PR TITLE
[WM-2683] Use CBAS /capabilities API to fetch records from WDS

### DIFF
--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -175,8 +175,8 @@ export const WorkspaceData = (signal) => ({
     );
     return await res.json();
   },
-  queryRecords: async (root: string, instanceId: string, wdsType: string): Promise<any> => {
-    const searchPayload = { limit: 100 };
+  queryRecords: async (root: string, instanceId: string, wdsType: string, searchLimit: number): Promise<any> => {
+    const searchPayload = { limit: searchLimit };
     const res = await fetchWDS(root)(
       `${instanceId}/search/v0.2/${wdsType}`,
       _.mergeAll([authOpts(), { signal, method: 'POST' }, jsonBody(searchPayload)])

--- a/src/libs/ajax/workflows-app/Cbas.js
+++ b/src/libs/ajax/workflows-app/Cbas.js
@@ -11,6 +11,10 @@ export const Cbas = (signal) => ({
     const res = await fetchFromProxy(cbasUrlRoot)('actuator/info', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
     return res.json();
   },
+  capabilities: async (cbasUrlRoot) => {
+    const res = await fetchFromProxy(cbasUrlRoot)('capabilities/v1', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+    return res.json();
+  },
   runs: {
     get: async (cbasUrlRoot, submissionId) => {
       const keyParams = qs.stringify({ run_set_id: submissionId });

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -43,6 +43,7 @@ export const BaseSubmissionConfig = (
   const [availableMethodVersions, setAvailableMethodVersions] = useState();
   const [selectedMethodVersion, setSelectedMethodVersion] = useState();
   const [records, setRecords] = useState([]);
+  const [totalRecordsInActualDataTable, setTotalRecordsInActualDataTable] = useState();
   const [loading, setLoading] = useState(false);
   const [workflowScript, setWorkflowScript] = useState();
   const [cbasSubmissionLimits, setCbasSubmissionLimits] = useState({
@@ -71,6 +72,7 @@ export const BaseSubmissionConfig = (
       try {
         const searchResult = await Ajax(signal).WorkspaceData.queryRecords(wdsUrlRoot, workspaceId, recordType, searchLimit);
         setRecords(searchResult.records);
+        setTotalRecordsInActualDataTable(searchResult.totalRecords);
       } catch (error) {
         if (recordType === undefined) {
           setNoRecordTypeData('Select a data table');
@@ -528,6 +530,7 @@ export const BaseSubmissionConfig = (
           selectedRecords,
           setSelectedRecords,
           selectedDataTable: _.keyBy('name', recordTypes)[selectedRecordType || records[0].type],
+          totalRecordsInActualDataTable,
         })
       : 'No data table rows selected...';
   };

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -251,18 +251,16 @@ export const BaseSubmissionConfig = (
       const { wdsProxyUrlState, cbasProxyUrlState } = await loadAppUrls(workspaceId, 'cbasProxyUrlState');
 
       if (cbasProxyUrlState.status === AppProxyUrlStatus.Ready) {
-        loadRunSet(cbasProxyUrlState.state).then((runSet) => {
-          if (runSet !== undefined) {
-            loadMethodsData(cbasProxyUrlState.state, runSet.method_id, runSet.method_version_id);
-            loadCbasSubmissionLimits(cbasProxyUrlState.state).then((submissionLimits) => {
-              loadWdsData({
-                wdsProxyUrlDetails: wdsProxyUrlState,
-                recordType: runSet.record_type,
-                searchLimit: submissionLimits.maxWorkflows,
-              });
-            });
-          }
-        });
+        const runSet = await loadRunSet(cbasProxyUrlState.state);
+        if (runSet !== undefined) {
+          await loadMethodsData(cbasProxyUrlState.state, runSet.method_id, runSet.method_version_id);
+          const submissionLimits = await loadCbasSubmissionLimits(cbasProxyUrlState.state);
+          await loadWdsData({
+            wdsProxyUrlDetails: wdsProxyUrlState,
+            recordType: runSet.record_type,
+            searchLimit: submissionLimits.maxWorkflows,
+          });
+        }
       }
     };
     loadWorkflowsApp();

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -2186,7 +2186,7 @@ describe('CBAS Capabilities API', () => {
       expect(mockSearchResponse).toHaveBeenCalledTimes(1);
       expect(mockCapabilitiesResponse).toHaveBeenCalledTimes(1);
 
-      // verify that search limit was set to default because /capabilities API threw error
+      // verify that search limit was set to expected value
       expect(mockSearchResponse).toHaveBeenCalledWith('https://lz-abc/wds-abc-c07807929cd1/', 'abc-c07807929cd1', 'FOO', test.expectedSearchLimit);
     });
   });

--- a/src/workflows-app/SubmissionConfig.test.js
+++ b/src/workflows-app/SubmissionConfig.test.js
@@ -610,6 +610,8 @@ describe('Initial state', () => {
 
     const cells = within(rows[1]).getAllByRole('cell');
     expect(cells.length).toBe(4);
+
+    screen.getByText("Note: You are viewing 4 out of 4 records from the 'FOO' data table");
   });
 
   it('should initially populate the inputs definition table with attributes determined by the previously executed run set', async () => {
@@ -979,6 +981,8 @@ describe('Records Table updates', () => {
     expect(mockMethodsResponse).toHaveBeenCalledTimes(1);
     expect(mockSearchResponse).toHaveBeenCalledTimes(1);
     expect(mockWdlResponse).toHaveBeenCalledTimes(1);
+    screen.getByText("Note: You are viewing 4 out of 4 records from the 'FOO' data table");
+
     const table = screen.getByRole('table');
 
     // ** ACT **
@@ -995,6 +999,7 @@ describe('Records Table updates', () => {
     expect(headers.length).toBe(4);
     const cells = within(rowsBAR[1]).getAllByRole('cell');
     expect(cells.length).toBe(4);
+    screen.getByText("Note: You are viewing 2 out of 2 records from the 'BAR' data table");
 
     // ** ACT **
     await dropdownSelect.selectOption('FOO');

--- a/src/workflows-app/components/RecordsTable.test.ts
+++ b/src/workflows-app/components/RecordsTable.test.ts
@@ -87,8 +87,11 @@ describe('RecordsTable', () => {
         selectedRecords,
         setSelectedRecords,
         selectedDataTable,
+        totalRecordsInActualDataTable: mockRecordsData.length,
       })
     );
+
+    screen.getByText("Note: You are viewing 1 out of 1 records from the 'foo-data' data table");
 
     const table = screen.getByRole('table');
     const rows = within(table).getAllByRole('row');
@@ -165,8 +168,11 @@ describe('RecordsTable', () => {
         selectedRecords,
         setSelectedRecords,
         selectedDataTable,
+        totalRecordsInActualDataTable: records.length,
       })
     );
+
+    screen.getByText("Note: You are viewing 4 out of 4 records from the 'FOO' data table");
 
     const table = screen.getByRole('table');
     const rows = within(table).getAllByRole('row');

--- a/src/workflows-app/utils/submission-utils.ts
+++ b/src/workflows-app/utils/submission-utils.ts
@@ -24,6 +24,12 @@ export const AutoRefreshInterval = 1000 * 60; // 1 minute
 export const WdsPollInterval = 1000 * 30; // 30 seconds
 export const CbasPollInterval = 1000 * 30; // 30 seconds
 
+export const CbasDefaultSubmissionLimits = {
+  maxWorkflows: 100,
+  maxInputs: 200,
+  maxOutputs: 300,
+};
+
 export type InputTableData = {
   configurationIndex: number;
   inputTypeStr: string;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2683

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds a call to CBAS' /capabilities API to determine the max workflows per submission supported by that CBAS instance

### Why
- to support incremental rollout for submission scaling limits

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] tested locally
- [ ] added unit tests

### Visual Aids
In Workflows app that doesn't yet have /capabilities API UI will by default display 100 records and user will only be able to submit 100 workflows (which is the current experience):
![Screenshot 2024-07-12 at 6 50 09 PM](https://github.com/user-attachments/assets/2a2f88e2-6717-4997-9647-448ec9ba48ba)

![Screenshot 2024-07-12 at 6 50 27 PM](https://github.com/user-attachments/assets/162d5001-0431-4b92-99d9-db5fb89a5e35)

---

In a manually updated Workflows app using changes from [CBAS PR-298](https://github.com/DataBiosphere/cbas/pull/298) UI will display 300 records and user can submit 300 workflows in a submission:
![Screenshot 2024-07-12 at 6 46 40 PM](https://github.com/user-attachments/assets/29a5ffa4-f445-4d75-9379-0472d376ba62)

![Screenshot 2024-07-12 at 6 47 08 PM](https://github.com/user-attachments/assets/6fa3f9ec-394c-4d82-ace3-a5c296e7db1d)
