### PR TITLE
[WOR-1760] Add keyword search by googleProject and state to workspaces list

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -34,7 +34,7 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await waitForNoSpinners(page);
-  await fillIn(page, input({ placeholder: 'Search by keyword' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name, project, or state' }), workspaceName);
   await click(page, clickable({ textContains: workspaceName }), { timeout: Millis.ofMinute });
 
   await noSpinnersAfter(page, {

--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -34,7 +34,7 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await waitForNoSpinners(page);
-  await fillIn(page, input({ placeholder: 'Search by name, project, or state' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name or project' }), workspaceName);
   await click(page, clickable({ textContains: workspaceName }), { timeout: Millis.ofMinute });
 
   await noSpinnersAfter(page, {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -501,7 +501,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
   await signIntoTerra(page, { token });
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await dismissInfoNotifications(page);
-  await fillIn(page, input({ placeholder: 'Search by name, project, or state' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name or project' }), workspaceName);
   // Wait for workspace table to rerender filtered items
   await delay(Millis.ofSecond);
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) });

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -501,7 +501,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
   await signIntoTerra(page, { token });
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await dismissInfoNotifications(page);
-  await fillIn(page, input({ placeholder: 'Search by keyword' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name, project, or state' }), workspaceName);
   // Wait for workspace table to rerender filtered items
   await delay(Millis.ofSecond);
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) });

--- a/src/workspaces/list/WorkspaceFilters.test.ts
+++ b/src/workspaces/list/WorkspaceFilters.test.ts
@@ -109,7 +109,7 @@ describe('WorkspaceFilters', () => {
       render(h(WorkspaceFilters, { workspaces: [defaultGoogleWorkspace] }));
     });
 
-    const filterSelector = screen.getByLabelText('Search workspaces by keyword');
+    const filterSelector = screen.getByLabelText('Search workspaces by name, project, or state');
     await filterSelector.click();
     await user.type(filterSelector, 'x');
     await act(() => delay(300)); // debounced search

--- a/src/workspaces/list/WorkspaceFilters.test.ts
+++ b/src/workspaces/list/WorkspaceFilters.test.ts
@@ -109,7 +109,7 @@ describe('WorkspaceFilters', () => {
       render(h(WorkspaceFilters, { workspaces: [defaultGoogleWorkspace] }));
     });
 
-    const filterSelector = screen.getByLabelText('Search workspaces by name, project, or state');
+    const filterSelector = screen.getByLabelText('Search workspaces by name or project');
     await filterSelector.click();
     await user.type(filterSelector, 'x');
     await act(() => delay(300)); // debounced search

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -32,14 +32,14 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
   const { query } = Nav.useRoute();
   const filters = getWorkspaceFiltersFromQuery(query);
 
-  let keywordLastEvented = useInstance(() => filters.nameFilter);
+  let keywordLastEvented = useInstance(() => filters.keywordFilter);
   const [lastKeywordSearched, setLastKeywordSearched] = useState(keywordLastEvented);
 
   return div({ style: { display: 'flex', margin: '1rem 0' } }, [
     div({ style: { ...styles.filter, flexGrow: 1.5 } }, [
       h(DelayedSearchInput, {
-        placeholder: 'Search by keyword',
-        'aria-label': 'Search workspaces by keyword',
+        placeholder: 'Search by name, project, or state',
+        'aria-label': 'Search workspaces by name, project, or state',
         onChange: (newFilter) => {
           // Store in a state variable to make unit testing possible (as opposed to onBlur comparing the current
           // value to what exists in filters.nameFilter).
@@ -52,7 +52,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
             Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'keyword', option: keywordLastEvented });
           }
         },
-        value: filters.nameFilter,
+        value: filters.keywordFilter,
       }),
     ]),
     div({ style: styles.filter }, [
@@ -124,7 +124,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
 };
 
 export interface WorkspaceFilterValues {
-  nameFilter: string;
+  keywordFilter: string;
   accessLevels: string[];
   projects?: string;
   cloudPlatform?: CloudPlatform;
@@ -133,7 +133,7 @@ export interface WorkspaceFilterValues {
 }
 
 export const getWorkspaceFiltersFromQuery = (query: any): WorkspaceFilterValues => ({
-  nameFilter: query.filter || '',
+  keywordFilter: query.filter || '',
   accessLevels: query.accessLevelsFilter || EMPTY_LIST,
   projects: query.projectsFilter || undefined,
   cloudPlatform: query.cloudPlatform || undefined,

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -38,8 +38,8 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
   return div({ style: { display: 'flex', margin: '1rem 0' } }, [
     div({ style: { ...styles.filter, flexGrow: 1.5 } }, [
       h(DelayedSearchInput, {
-        placeholder: 'Search by name, project, or state',
-        'aria-label': 'Search workspaces by name, project, or state',
+        placeholder: 'Search by name or project',
+        'aria-label': 'Search workspaces by name or project',
         onChange: (newFilter) => {
           // Store in a state variable to make unit testing possible (as opposed to onBlur comparing the current
           // value to what exists in filters.nameFilter).

--- a/src/workspaces/list/WorkspacesListTabs.ts
+++ b/src/workspaces/list/WorkspacesListTabs.ts
@@ -64,14 +64,25 @@ export const WorkspacesListTabs = (props: WorkspacesListTabsProps): ReactNode =>
   );
 };
 
-const filterWorkspaces = (workspaces: CategorizedWorkspaces, filters: WorkspaceFilterValues): CategorizedWorkspaces => {
+// exported for unit testing
+export const filterWorkspaces = (
+  workspaces: CategorizedWorkspaces,
+  filters: WorkspaceFilterValues
+): CategorizedWorkspaces => {
   const filterWorkspacesCategory = (workspaces: Workspace[], filters: WorkspaceFilterValues): Workspace[] => {
     const matches = (ws: Workspace): boolean => {
       const {
-        workspace: { namespace, name, attributes },
+        workspace: { namespace, name, attributes, state, googleProject },
       } = ws;
+
+      const containsKeywordFilter = (textToMatchWithin: string | undefined): boolean => {
+        return textToMatchWithin === undefined ? false : textMatch(filters.keywordFilter, textToMatchWithin!);
+      };
+
       return !!(
-        textMatch(filters.nameFilter, `${namespace}/${name}`) &&
+        (containsKeywordFilter(`${namespace}/${name}`) ||
+          containsKeywordFilter(googleProject) ||
+          containsKeywordFilter(state)) &&
         (_.isEmpty(filters.accessLevels) || filters.accessLevels.includes(ws.accessLevel)) &&
         (_.isEmpty(filters.projects) || filters.projects === namespace) &&
         (_.isEmpty(filters.cloudPlatform) || getCloudProviderFromWorkspace(ws) === filters.cloudPlatform) &&


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1760

The "Search by keyword" filter on the workspaces list actually did a case-insensitive, partial match on either the name or namespace (billing project) of a workspace.

As requested by support, it now also will match on the Google project of GCP workspaces. And while I was making this change, I added search by workspace state, which make it easy for example to find workspaces that failed to delete or create, or to check on the status of workspaces that are in the process of cloning or deleting.

I updated the placeholder and aria text for the field to make it clearer what one can search for, using "project" as a generic term since both billing project and Google project will be searched (note that there is a separate filter for billing project, but that does an exact match and provides you a list of all the billing projects you have access to). Adam asked that I not mention state as it won't make sense to users, and instead it's an undocumented feature (mostly for our use).

<img width="941" alt="image" src="https://github.com/user-attachments/assets/57229740-e837-41ca-a9ef-250c0231e80d">

<img width="518" alt="image" src="https://github.com/user-attachments/assets/4467bbf3-b1ac-4947-b691-446d425adfd6">
