### PR TITLE
AJ-1911: fix page-breaking JS error in data table url links

### DIFF
--- a/src/workspace-data/data-table/shared/UriViewerLink.ts
+++ b/src/workspace-data/data-table/shared/UriViewerLink.ts
@@ -26,7 +26,7 @@ export const UriViewerLink = (props: UriViewerLinkProps): ReactNode => {
           setModalOpen(true);
         },
       },
-      [isGsUri(uri) || isAzureUri(uri) ? _.last(uri.split(/\/\b/)) : uri]
+      [typeof uri === 'string' && (isGsUri(uri) || isAzureUri(uri)) ? _.last(uri.split(/\/\b/)) : uri]
     ),
     modalOpen &&
       h(UriViewer, {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1911

## Summary of changes:
Fixes a page-breaking JS error

### What
Fixes a page-breaking JS error in cases where a data table contains a nested array of urls, something like:
```
[
  [
    "https://foo.blob.core.windows.net/1",
    "https://foo.blob.core.windows.net/2"
  ],
  [
    "https://foo.blob.core.windows.net/3",
    "https://foo.blob.core.windows.net/4"
  ]
]
```

This is NOT the final fix. This is a temporary fix to eliminate the error because the error completely breaks the page and makes the data table unusable. I want to resolve that page-breaking error quickly.

This temporary fix still has problems in that the preview modal for these URLs doesn't work; it shows that the file does not exist. But I'd rather be in that state than a page-breaking error.

### Before
![Screenshot 15-07-2024 at 09 21 (1)](https://github.com/user-attachments/assets/934e5531-44f9-43ca-a2fa-a80c26f3baec)


### After
![Screenshot 15-07-2024 at 09 21](https://github.com/user-attachments/assets/066060f5-36a3-48c1-ad5e-9a8353a5c730)

