### PR TITLE
AJ-1911 render nested url arrays

### DIFF
--- a/src/workspace-data/data-table/entity-service/renderDataCell.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.js
@@ -85,7 +85,7 @@ export const renderDataCell = (attributeValue, workspace) => {
   };
 
   const parseAzureUri = (datum) => {
-    if (datum === undefined || datum.split('/').length < 4) {
+    if (typeof datum !== 'string' || datum.split('/').length < 4) {
       return null;
     }
     return datum.split('/')[3].replace('sc-', '');

--- a/src/workspace-data/data-table/entity-service/renderDataCell.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.js
@@ -45,6 +45,12 @@ export const renderDataCell = (attributeValue, workspace) => {
   } = workspace;
 
   const renderCell = (datum) => {
+    // handle nested arrays, where datum is itself an array. Recurse back to renderArray() for this, but surround its
+    // result with [] to indicate to the end user where the nested arrays start and stop
+    if (_.isArray(datum)) {
+      return [span({}, '['), renderArray(datum), span({}, ']')];
+    }
+    // handle non-nested arrays:
     const stringDatum = Utils.convertValue('string', datum);
     return isViewableUri(datum, workspace) ? h(UriViewerLink, { uri: datum, workspace }) : stringDatum;
   };

--- a/src/workspace-data/data-table/entity-service/renderDataCell.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.js
@@ -48,7 +48,7 @@ export const renderDataCell = (attributeValue, workspace) => {
     // handle nested arrays, where datum is itself an array. Recurse back to renderArray() for this, but surround its
     // result with [] to indicate to the end user where the nested arrays start and stop
     if (_.isArray(datum)) {
-      return [span({}, '['), renderArray(datum), span({}, ']')];
+      return span({}, ['[', renderArray(datum), ']']);
     }
     // handle non-nested arrays:
     const stringDatum = Utils.convertValue('string', datum);

--- a/src/workspace-data/data-table/entity-service/renderDataCell.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.js
@@ -93,7 +93,7 @@ export const renderDataCell = (attributeValue, workspace) => {
 
   const hasNonCurrentWorkspaceUrls = Utils.cond(
     [type === 'json' && _.isArray(attributeValue), () => _.some(isNonCurrentWorkspaceUrls, attributeValue)],
-    [type === 'string' && isList, () => _.some(isNonCurrentWorkspaceUrls, attributeValue.items)],
+    [(type === 'string' || type === 'object') && isList, () => _.some(isNonCurrentWorkspaceUrls, attributeValue.items)],
     [type === 'string', () => isNonCurrentWorkspaceUrls(attributeValue)],
     () => false
   );

--- a/src/workspace-data/data-table/entity-service/renderDataCell.test.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.test.js
@@ -163,6 +163,65 @@ describe('renderDataCell', () => {
       expect(_.map('href', links)).toEqual(['gs://bucket/file1.txt', 'gs://bucket/file2.txt', 'gs://bucket/file3.txt']);
     });
 
+    it('renders nested lists of GCS URLs', () => {
+      const { getAllByRole } = render(
+        renderDataCell(
+          {
+            itemsType: 'AttributeValue',
+            items: [
+              ['gs://bucket/file1.txt', 'gs://bucket/file2.txt'],
+              ['gs://bucket/file3.txt', 'gs://bucket/file4.txt'],
+            ],
+          },
+          testGoogleWorkspace
+        )
+      );
+      const links = getAllByRole('link');
+      expect(_.map('textContent', links)).toEqual(['file1.txt', 'file2.txt', 'file3.txt', 'file4.txt']);
+      expect(_.map('href', links)).toEqual(['gs://bucket/file1.txt', 'gs://bucket/file2.txt', 'gs://bucket/file3.txt', 'gs://bucket/file4.txt']);
+    });
+
+    it('renders lists of Azure URLs', () => {
+      const { getAllByRole } = render(
+        renderDataCell(
+          {
+            itemsType: 'AttributeValue',
+            items: ['https://foo.blob.core.windows.net/testContainer/file1.txt', 'https://foo.blob.core.windows.net/testContainer/file2.txt'],
+          },
+          testAzureWorkspace
+        )
+      );
+      const links = getAllByRole('link');
+      expect(_.map('textContent', links)).toEqual(['file1.txt', 'file2.txt']);
+      expect(_.map('href', links)).toEqual([
+        'https://foo.blob.core.windows.net/testContainer/file1.txt',
+        'https://foo.blob.core.windows.net/testContainer/file2.txt',
+      ]);
+    });
+
+    it('renders nested lists of Azure URLs', () => {
+      const { getAllByRole } = render(
+        renderDataCell(
+          {
+            itemsType: 'AttributeValue',
+            items: [
+              ['https://foo.blob.core.windows.net/testContainer/file1.txt', 'https://foo.blob.core.windows.net/testContainer/file2.txt'],
+              ['https://foo.blob.core.windows.net/testContainer/file3.txt', 'https://foo.blob.core.windows.net/testContainer/file4.txt'],
+            ],
+          },
+          testAzureWorkspace
+        )
+      );
+      const links = getAllByRole('link');
+      expect(_.map('textContent', links)).toEqual(['file1.txt', 'file2.txt', 'file3.txt', 'file4.txt']);
+      expect(_.map('href', links)).toEqual([
+        'https://foo.blob.core.windows.net/testContainer/file1.txt',
+        'https://foo.blob.core.windows.net/testContainer/file2.txt',
+        'https://foo.blob.core.windows.net/testContainer/file3.txt',
+        'https://foo.blob.core.windows.net/testContainer/file4.txt',
+      ]);
+    });
+
     it.each([{ testWorkspace: testGoogleWorkspace }, { testWorkspace: testAzureWorkspace }])('renders links to DRS URLs', ({ testWorkspace }) => {
       const { container, getByRole } = render(renderDataCell('drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce', testWorkspace));
       expect(container).toHaveTextContent('drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce');

--- a/src/workspace-data/data-table/entity-service/renderDataCell.test.js
+++ b/src/workspace-data/data-table/entity-service/renderDataCell.test.js
@@ -49,6 +49,23 @@ describe('renderDataCell', () => {
     expect(render(renderDataCell({ items: [], itemsType: 'AttributeValue' }, testWorkspace)).container).toHaveTextContent('');
   });
 
+  it.each([{ testWorkspace: testGoogleWorkspace }, { testWorkspace: testAzureWorkspace }])('renders nested lists', ({ testWorkspace }) => {
+    expect(
+      render(
+        renderDataCell(
+          {
+            items: [
+              ['foo', 'bar'],
+              ['baz', 'qux'],
+            ],
+            itemsType: 'AttributeValue',
+          },
+          testWorkspace
+        )
+      ).container
+    ).toHaveTextContent('[foo,bar],[baz,qux]');
+  });
+
   it.each([{ testWorkspace: testGoogleWorkspace }, { testWorkspace: testAzureWorkspace }])(
     'limits the number of list items rendered',
     ({ testWorkspace }) => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1911


## Summary of changes:
* Improve rendering of nested arrays in data tables
* Unbreak url linking for nested arrays in data tables

### What

*Improve rendering*: previously, the values in nested arrays appeared flattened. A nested array of `[["foo", "bar"], ["baz", "qux"]]` would appear in the UI as "foo,bar,baz,qux"; there was no indication of where the nested arrays stop and start. Now, it will render as "[foo,bar],[baz,qux]".

*Unbreak url linking*: previously, urls in nested arrays got smushed together, and the linking was broken; the UI would attempt to link "url1,url2" as a single (invalid) url. Now, "url1" and "url2" are each linked separately, and each link is valid (assuming the individual urls are valid).

See screenshots below to help visualize this.

### Testing strategy
* added unit tests for all cases.

### Before
* nested arrays display flattened; there is no indication of where the nested arrays start and stop
* urls in nested arrays are smushed together. The red arrow indicates where one url stops and the next starts.
![Screenshot 15-07-2024 at 12 07 (1)](https://github.com/user-attachments/assets/c6dc9ed7-f4e2-484e-ae09-d775979c8120)

![Screenshot 15-07-2024 at 12 03 (1)](https://github.com/user-attachments/assets/fae25982-2831-4850-bd3d-5527a941a59d)


### After
* nested arrays are surrounded by `[]` to show where they start and stop
* urls in nested arrays are handled individually
![Screenshot 15-07-2024 at 12 07](https://github.com/user-attachments/assets/c75136b1-cc88-4d97-85fa-61cb4fe5a436)

![Screenshot 15-07-2024 at 12 03](https://github.com/user-attachments/assets/e0601f30-9811-4470-88ca-4600d7a58161)



