### PR TITLE
[WOR-1609] Add info button to describe Estimated Storage Cost

### DIFF
--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -182,4 +182,33 @@ describe('CloudInformation', () => {
     );
     expect(clipboard.writeText).toHaveBeenCalledWith(defaultGoogleWorkspace.workspace.bucketName);
   });
+
+  it('can use the info button to display additional information about cost', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const mockBucketUsage = jest.fn().mockResolvedValue({ usageInBytes: 15, lastUpdated: '2024-07-15' });
+    const mockStorageCostEstimate = jest.fn().mockResolvedValue({
+      estimate: '2 dollars',
+      lastUpdated: '2024-07-15',
+    });
+    asMockedFn(Ajax).mockReturnValue({
+      Workspaces: {
+        workspace: jest.fn().mockReturnValue({
+          storageCostEstimate: mockStorageCostEstimate,
+          bucketUsage: mockBucketUsage,
+        }),
+      },
+    } as DeepPartial<AjaxContract> as AjaxContract);
+
+    // Act
+    render(
+      h(CloudInformation, { workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true }, storageDetails })
+    );
+    await user.click(screen.getByLabelText('More info'));
+
+    // Assert
+    expect(
+      screen.getAllByText('Based on list price. Does not include savings from Autoclass or other discounts.')
+    ).not.toBeNull();
+  });
 });

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -1,4 +1,4 @@
-import { Link } from '@terra-ui-packages/components';
+import { InfoBox, Link } from '@terra-ui-packages/components';
 import { cond } from '@terra-ui-packages/core-utils';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, dl, h } from 'react-hyperscript-helpers';
@@ -170,7 +170,12 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               ]
             ),
           },
-          [storageCost?.estimate || '$ ...']
+          [
+            storageCost?.estimate || '$ ...',
+            h(InfoBox, { style: { marginLeft: '1ch' }, side: 'top' }, [
+              'Based on list price. Does not include savings from Autoclass or other discounts.',
+            ]),
+          ]
         ),
       canWrite(accessLevel) &&
         h(

--- a/src/workspaces/dashboard/WorkspaceInformation.ts
+++ b/src/workspaces/dashboard/WorkspaceInformation.ts
@@ -31,7 +31,7 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
         [
           'Yes',
           !!policyDescription.longDescription &&
-            h(InfoBox, { style: { marginLeft: '0.50rem' }, side: 'bottom' }, [policyDescription.longDescription]),
+            h(InfoBox, { style: { marginLeft: '1ch' }, side: 'bottom' }, [policyDescription.longDescription]),
         ]
       );
     }, policyDescriptions),

--- a/src/workspaces/dashboard/WorkspaceTags.ts
+++ b/src/workspaces/dashboard/WorkspaceTags.ts
@@ -83,7 +83,7 @@ export const WorkspaceTags = (props: WorkspaceTagsProps): ReactNode => {
       div({ style: { margin: '0.5rem' } }, [
         div({ style: { marginBottom: '0.5rem', fontSize: 12 } }, [
           `${brand.name} is not intended to host personally identifiable information.`,
-          h(InfoBox, { style: { marginLeft: '0.25rem' } }, [
+          h(InfoBox, { style: { marginLeft: '1ch' } }, [
             `${brand.name} is not intended to host personally identifiable information. Do not use any patient identifier including name,
               social security number, or medical record number.`,
           ]),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1609

There is now an info button next to the estimated cost. When selected, it displays a caveat about the cost estimation.

I also edited the left margins of other info buttons in the Workspaces dashboard to be consistent with those in Workspace Notifications.

![image](https://github.com/user-attachments/assets/fe4e72cc-0e98-4000-86af-758cc90c91ca)