### PR TITLE
[DDO-3704] Allow deletion of GCP workspaces with inactive projects

### DIFF
--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -268,4 +268,43 @@ describe('useDeleteWorkspaceState', () => {
     expect(mockDelete).toHaveBeenCalledTimes(1);
     expect(reportError).toHaveBeenCalledTimes(1);
   });
+
+  it('can delete a google workspace with no google project', async () => {
+    // Arrange
+    const mockApps: Partial<AjaxAppsContract> = {
+      listWithoutProject: jest.fn(),
+    };
+    asMockedFn((mockApps as AjaxAppsContract).listWithoutProject).mockResolvedValue([]);
+
+    const mockGetAcl = jest.fn().mockResolvedValue([]);
+    const mockGetBucketUsage = jest.fn().mockRejectedValue(new Error('error no project'));
+    const mockDelete = jest.fn().mockResolvedValue([]);
+    const mockWorkspaces: DeepPartial<AjaxWorkspacesContract> = {
+      workspace: () => ({
+        getAcl: mockGetAcl,
+        bucketUsage: mockGetBucketUsage,
+      }),
+      workspaceV2: () => ({
+        delete: mockDelete,
+      }),
+    };
+
+    const mockAjax: Partial<AjaxContract> = {
+      Apps: mockApps as AjaxAppsContract,
+      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    // Act
+    const { result } = await renderHookInAct(() =>
+      useDeleteWorkspaceState({ workspace: googleWorkspace, onDismiss: mockOnDismiss, onSuccess: mockOnSuccess })
+    );
+
+    await act(() => result.current.deleteWorkspace());
+
+    // Assert
+    expect(result.current.deleting).toBe(false);
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -277,7 +277,7 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn((mockApps as AjaxAppsContract).listWithoutProject).mockResolvedValue([]);
 
     const mockGetAcl = jest.fn().mockResolvedValue([]);
-    const mockGetBucketUsage = jest.fn().mockRejectedValue(new Error('error no project'));
+    const mockGetBucketUsage = jest.fn().mockRejectedValue(new Error('no project!'));
     const mockDelete = jest.fn().mockResolvedValue([]);
     const mockWorkspaces: DeepPartial<AjaxWorkspacesContract> = {
       workspace: () => ({
@@ -303,8 +303,7 @@ describe('useDeleteWorkspaceState', () => {
     await act(() => result.current.deleteWorkspace());
 
     // Assert
-    expect(result.current.deleting).toBe(false);
+    expect(result.current.deleting).toBe(true);
     expect(mockDelete).toHaveBeenCalledTimes(1);
-    expect(reportError).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.ts
@@ -85,12 +85,15 @@ export const useDeleteWorkspaceState = (hookArgs: DeleteWorkspaceHookArgs): Dele
       setWorkspaceResources(appsInfo);
 
       if (isGoogleWorkspace(hookArgs.workspace)) {
-        const [{ acl }, { usageInBytes }] = await Promise.all([
+        const [{ acl }, bucketUsage] = await Promise.all([
           Ajax(signal).Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name).getAcl(),
-          Ajax(signal).Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name).bucketUsage(),
+          Ajax(signal)
+            .Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name)
+            .bucketUsage()
+            .catch((_error) => undefined),
         ]);
         setCollaboratorEmails(_.without([getTerraUser().email!], _.keys(acl)));
-        setWorkspaceBucketUsageInBytes(usageInBytes);
+        setWorkspaceBucketUsageInBytes(bucketUsage?.usageInBytes);
       }
     });
     load();


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DDO-3704

### Dependencies
Sam: https://github.com/broadinstitute/sam/pull/1493
Rawls: https://github.com/broadinstitute/rawls/pull/2954

## Summary of changes:
Allow workspaces to be deleted whose GCP projects are inactive (deleted by Janitor).

### What
- Recover from Rawls `bucketUsage` API failures and still allow the workspace deletion to proceed.

### Why
- Janitor deletes projects in GCP workspaces in BEEs to save costs. We want users to still be able to delete these workspaces in Terra UI.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] Unit testing
- [ ] Tested workspace deletion of a Janitorized GCP and Azure workspace in a BEE

TODO: add screenshot

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
