### PR TITLE
AJ-962: fix data table column resizing when zero rows

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -536,7 +536,9 @@ export const GridTable = forwardRefWithName(
       recomputeColumnSizes: () => {
         header.current.recomputeGridSize();
         body.current.recomputeGridSize();
-        body.current.measureAllCells();
+        if (rowCount > 0) {
+          body.current.measureAllCells();
+        }
       },
       scrollToTop: () => {
         body.current.scrollToPosition({ scrollTop: 0, scrollLeft: 0 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-962


## Summary of changes:
Eliminated a page crash when resizing columns in a data table, if that data table contained zero rows due to search filtering. There are a couple other ways to reach a zero-row data table, such as snapshot-by-reference or an empty Azure/WDS table.

### Testing strategy
Tested manually; no additional unit tests due to complexity.

### Before
[Screen Recording 17-07-2024 at 16.43.webm](https://github.com/user-attachments/assets/47a311d3-ddda-44f6-b567-d21be1705e87)

### After
[Screen Recording 17-07-2024 at 16.44.webm](https://github.com/user-attachments/assets/0e7a0ea0-4939-4af1-a508-edb79733f626)


