### PR TITLE
[DC-1180]Change "Roll up Count" Label to "Number of Participants"

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -112,7 +112,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
               { header: strong(['Concept name']), width: 710, key: 'name' },
               { header: strong(['Concept ID']), width: 195, key: 'id' },
               { header: strong(['Code']), width: 195, key: 'code' },
-              { header: strong(['Roll-up count']), width: 205, key: 'count' },
+              { header: strong(['Number of Participants']), width: 205, key: 'count' },
               { width: 100, key: 'hierarchy' },
             ],
             rows: _.map((concept) => {

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -91,7 +91,7 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
           { name: 'Concept ID', width: 195, render: _.get('id') },
           { name: 'Code', width: 195, render: _.get('code') },
           {
-            name: 'Roll-up count',
+            name: 'Number of Participants',
             width: 205,
             render: (row) => formatCount(row.count),
           },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-1180

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Changed the "Roll-up Count" labels in concept selectors and hierarchy pages to say "Number of Participants"

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
Ran the UI to make sure the changes happened in both places for each concept.
 <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

<img width="1307" alt="Screenshot 2024-07-18 at 2 02 44 PM" src="https://github.com/user-attachments/assets/035287cb-1da7-44bd-a910-151083f649b3">

<img width="1478" alt="Screenshot 2024-07-18 at 2 04 21 PM" src="https://github.com/user-attachments/assets/88901dfc-c0be-4024-9ede-ea5a7fe13c15">

