### PR TITLE
[DC-825]Criteria Group IDs shown in UI are internal IDs

### DIFF
--- a/src/dataset-builder/CohortEditor.test.ts
+++ b/src/dataset-builder/CohortEditor.test.ts
@@ -520,7 +520,7 @@ describe('CohortEditor', () => {
     await user.click(screen.getByText('Add group'));
     await user.click(screen.getByText('Save cohort'));
     // Assert
-    // Don't compare name since it's generated.
+    // Don't compare id since it's generated.
     const { id: _unused, ...expectedCriteriaGroup } = newCriteriaGroup();
     expect(updateCohorts.mock.calls[0][0]([])).toMatchObject([
       { ...originalCohort, criteriaGroups: [expectedCriteriaGroup] },

--- a/src/dataset-builder/CohortEditor.test.ts
+++ b/src/dataset-builder/CohortEditor.test.ts
@@ -307,7 +307,7 @@ describe('CohortEditor', () => {
       ...args,
     };
     const cohort = newCohort('cohort');
-    const criteriaGroup = newCriteriaGroup();
+    const criteriaGroup = newCriteriaGroup(cohort.criteriaGroups.length + 1);
     if (initializeGroup) {
       initializeGroup(criteriaGroup);
     }
@@ -479,7 +479,7 @@ describe('CohortEditor', () => {
     await user.click(screen.getByText('Save cohort'));
     // Assert
     // Don't compare name since it's generated.
-    const { name: _unused, ...expectedCriteriaGroup } = newCriteriaGroup();
+    const { name: _unused, ...expectedCriteriaGroup } = newCriteriaGroup(originalCohort.criteriaGroups.length + 1);
     expect(updateCohorts.mock.calls[0][0]([])).toMatchObject([
       { ...originalCohort, criteriaGroups: [expectedCriteriaGroup] },
     ]);

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -68,7 +68,7 @@ export const CriteriaView = (props: CriteriaViewProps) => {
                 createSnapshotBuilderCountRequest([
                   {
                     // Create a "cohort" to get the count of participants for these criteria on its own.
-                    criteriaGroups: [{ criteria: [criteria], name: '', meetAll: true, mustMeet: true }],
+                    criteriaGroups: [{ id: 0, criteria: [criteria], meetAll: true, mustMeet: true }],
                     name: '',
                   },
                 ])
@@ -339,7 +339,7 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
   const updateGroupParticipantCount = useRef(
     _.debounce(250, (snapshotId: string, criteriaGroup: CriteriaGroup) =>
       setGroupParticipantCount(
-        withErrorReporting(`Error getting criteria group count for ${criteriaGroup.name}`)(async () =>
+        withErrorReporting('Error getting criteria group count')(async () =>
           DataRepo()
             .snapshot(snapshotId)
             .getSnapshotBuilderCount(createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }]))
@@ -391,24 +391,13 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
               ]
             ),
             div({ style: { alignItems: 'center', display: 'flex' } }, [
-              strong({ style: { marginRight: narrowMargin, fontSize: 16 } }, [criteriaGroup.name]),
+              strong({ style: { marginRight: narrowMargin, fontSize: 16 } }, [`Group ${index + 1}`]),
               h(
                 Link,
                 {
-                  'aria-label': 'delete group',
-                  onClick: () => {
-                    updateCohort(_.set('criteriaGroups', _.without([criteriaGroup], cohort.criteriaGroups)));
-                    if (cohort.criteriaGroups.indexOf(criteriaGroup) < cohort.criteriaGroups.length - 1) {
-                      // update names of all groups after it
-                      for (
-                        let i = cohort.criteriaGroups.indexOf(criteriaGroup) + 1;
-                        i < cohort.criteriaGroups.length;
-                        i++
-                      ) {
-                        cohort.criteriaGroups[i].name = `Group ${i}`;
-                      }
-                    }
-                  },
+                  'aria-label': `delete group ${index + 1}`,
+                  onClick: () =>
+                    updateCohort(_.set('criteriaGroups', _.without([criteriaGroup], cohort.criteriaGroups))),
                 },
                 [icon('trash-circle-filled', { size: 24 })]
               ),
@@ -486,7 +475,7 @@ const CohortGroups: React.FC<CohortGroupsProps> = (props) => {
       : div([
           _.map(
             ([index, criteriaGroup]) =>
-              h(Fragment, { key: criteriaGroup.name }, [
+              h(Fragment, { key: index }, [
                 h(CriteriaGroupView, {
                   index,
                   criteriaGroup,
@@ -567,12 +556,7 @@ const CohortEditorContents: React.FC<CohortEditorContentsProps> = (props) => {
         {
           style: { marginTop: wideMargin },
           onClick: (e) => {
-            updateCohort(
-              _.set(
-                `criteriaGroups.${cohort.criteriaGroups.length}`,
-                newCriteriaGroup(cohort.criteriaGroups.length + 1)
-              )
-            );
+            updateCohort(_.set(`criteriaGroups.${cohort.criteriaGroups.length}`, newCriteriaGroup()));
             // Lose button focus, since button moves out from under the user's cursor.
             e.currentTarget.blur();
           },

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -475,7 +475,7 @@ const CohortGroups: React.FC<CohortGroupsProps> = (props) => {
       : div([
           _.map(
             ([index, criteriaGroup]) =>
-              h(Fragment, { key: index }, [
+              h(Fragment, { key: index + 1 }, [
                 h(CriteriaGroupView, {
                   index,
                   criteriaGroup,

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -396,8 +396,20 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
                 Link,
                 {
                   'aria-label': 'delete group',
-                  onClick: () =>
-                    updateCohort(_.set('criteriaGroups', _.without([criteriaGroup], cohort.criteriaGroups))),
+                  onClick: () => {
+                    // set at 'criteriaGroups' the current [criteriaGroup] without the cohort.criteriaGroup
+                    updateCohort(_.set('criteriaGroups', _.without([criteriaGroup], cohort.criteriaGroups)));
+                    if (cohort.criteriaGroups.indexOf(criteriaGroup) < cohort.criteriaGroups.length - 1) {
+                      // update names of all groups after it
+                      for (
+                        let i = cohort.criteriaGroups.indexOf(criteriaGroup) + 1;
+                        i < cohort.criteriaGroups.length;
+                        i++
+                      ) {
+                        cohort.criteriaGroups[i].name = `Group ${i}`;
+                      }
+                    }
+                  },
                 },
                 [icon('trash-circle-filled', { size: 24 })]
               ),
@@ -556,7 +568,12 @@ const CohortEditorContents: React.FC<CohortEditorContentsProps> = (props) => {
         {
           style: { marginTop: wideMargin },
           onClick: (e) => {
-            updateCohort(_.set(`criteriaGroups.${cohort.criteriaGroups.length}`, newCriteriaGroup()));
+            updateCohort(
+              _.set(
+                `criteriaGroups.${cohort.criteriaGroups.length}`,
+                newCriteriaGroup(cohort.criteriaGroups.length + 1)
+              )
+            );
             // Lose button focus, since button moves out from under the user's cursor.
             e.currentTarget.blur();
           },

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -397,7 +397,6 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
                 {
                   'aria-label': 'delete group',
                   onClick: () => {
-                    // set at 'criteriaGroups' the current [criteriaGroup] without the cohort.criteriaGroup
                     updateCohort(_.set('criteriaGroups', _.without([criteriaGroup], cohort.criteriaGroups)));
                     if (cohort.criteriaGroups.indexOf(criteriaGroup) < cohort.criteriaGroups.length - 1) {
                       // update names of all groups after it

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -130,14 +130,13 @@ const anyCriteriaArray: AnyCriteria[] = [domainCriteria, rangeCriteria, listCrit
 const anyCriteriaArrayApi: AnySnapshotBuilderCriteria[] = [domainCriteriaApi, rangeCriteriaApi, listCriteriaApi];
 
 const criteriaGroup: CriteriaGroup = {
-  name: 'criteriaGroup',
+  id: 0,
   criteria: anyCriteriaArray,
   mustMeet: true,
   meetAll: false,
 };
 
 const criteriaGroupApi: SnapshotBuilderCriteriaGroup = {
-  name: 'criteriaGroup',
   criteria: anyCriteriaArrayApi,
   mustMeet: true,
   meetAll: false,

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -53,7 +53,7 @@ export type AnyCriteria = ProgramDomainCriteria | ProgramDataRangeCriteria | Pro
 
 /** A group of criteria. */
 export interface CriteriaGroup {
-  name: string;
+  id: number;
   criteria: AnyCriteria[];
   mustMeet: boolean;
   meetAll: boolean;
@@ -93,7 +93,6 @@ export const convertCohort = (cohort: Cohort): SnapshotBuilderCohort => {
     name: cohort.name,
     criteriaGroups: _.map(
       (criteriaGroup) => ({
-        name: criteriaGroup.name,
         mustMeet: criteriaGroup.mustMeet,
         meetAll: criteriaGroup.meetAll,
         criteria: _.map((criteria: AnyCriteria) => convertCriteria(criteria), criteriaGroup.criteria),

--- a/src/dataset-builder/DomainCriteriaSelector.test.ts
+++ b/src/dataset-builder/DomainCriteriaSelector.test.ts
@@ -37,7 +37,7 @@ describe('DomainCriteriaSelector', () => {
   const children = [dummyGetConceptForId(102)];
   const domainOption = testSnapshotBuilderSettings().domainOptions[0];
   const cohort = newCohort('cohort');
-  cohort.criteriaGroups.push(newCriteriaGroup(cohort.criteriaGroups.length + 1));
+  cohort.criteriaGroups.push(newCriteriaGroup());
   asMockedFn(DataRepo).mockImplementation(() => mockDataRepoContract as DataRepoContract);
   const state = domainCriteriaSelectorState.new(
     cohort,

--- a/src/dataset-builder/DomainCriteriaSelector.test.ts
+++ b/src/dataset-builder/DomainCriteriaSelector.test.ts
@@ -37,7 +37,7 @@ describe('DomainCriteriaSelector', () => {
   const children = [dummyGetConceptForId(102)];
   const domainOption = testSnapshotBuilderSettings().domainOptions[0];
   const cohort = newCohort('cohort');
-  cohort.criteriaGroups.push(newCriteriaGroup());
+  cohort.criteriaGroups.push(newCriteriaGroup(cohort.criteriaGroups.length + 1));
   asMockedFn(DataRepo).mockImplementation(() => mockDataRepoContract as DataRepoContract);
   const state = domainCriteriaSelectorState.new(
     cohort,

--- a/src/dataset-builder/DomainCriteriaSelector.ts
+++ b/src/dataset-builder/DomainCriteriaSelector.ts
@@ -50,7 +50,7 @@ export const saveSelected =
   ) =>
   (selected: SnapshotBuilderConcept[]) => {
     const cartCriteria = _.map(toCriteria(state.domainOption, getNextCriteriaIndex), selected);
-    const groupIndex = _.findIndex({ name: state.criteriaGroup.name }, state.cohort.criteriaGroups);
+    const groupIndex = _.findIndex({ id: state.criteriaGroup.id }, state.cohort.criteriaGroups);
     // add/remove all cart elements to the domain group's criteria list in the cohort
     _.flow(
       _.update(`criteriaGroups.${groupIndex}.criteria`, _.xor(cartCriteria)),

--- a/src/dataset-builder/dataset-builder-types.ts
+++ b/src/dataset-builder/dataset-builder-types.ts
@@ -5,9 +5,10 @@ import {
   SnapshotBuilderDomainOption,
 } from 'src/libs/ajax/DataRepo';
 
-export const newCriteriaGroup = (idx: number): CriteriaGroup => {
+let groupCount = 1;
+export const newCriteriaGroup = (): CriteriaGroup => {
   return {
-    name: `Group ${idx++}`,
+    id: groupCount++,
     criteria: [],
     mustMeet: true,
     meetAll: false,

--- a/src/dataset-builder/dataset-builder-types.ts
+++ b/src/dataset-builder/dataset-builder-types.ts
@@ -5,10 +5,9 @@ import {
   SnapshotBuilderDomainOption,
 } from 'src/libs/ajax/DataRepo';
 
-let groupCount = 1;
-export const newCriteriaGroup = (): CriteriaGroup => {
+export const newCriteriaGroup = (idx: number): CriteriaGroup => {
   return {
-    name: `Group ${groupCount++}`,
+    name: `Group ${idx++}`,
     criteria: [],
     mustMeet: true,
     meetAll: false,

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -104,7 +104,6 @@ export type AnySnapshotBuilderCriteria =
   | SnapshotBuilderProgramDataRangeCriteria
   | SnapshotBuilderProgramDataListCriteria;
 export interface SnapshotBuilderCriteriaGroup {
-  name: string;
   criteria: AnySnapshotBuilderCriteria[];
   mustMeet: boolean;
   meetAll: boolean;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-825

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Updated the UI so that when adding a new criteria group, leaving the page, then coming back, the group name resets to 1
- Made it so that when a group is deleted, the names of the groups following it are updated to the correct number

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

<!-- Test case 1 -->
Tested the UI by making multiple groups, exiting the page, then coming back to make sure the name resets to 1. Also tested adding groups, deleting groups at the end of the list, and deleting groups in the beginning and middle of the list to make sure the names updated correctly. 

Additionally, added some of my own tests that check:
- The first group added is always called 'Group 1' after deleting all groups
- Groups can be added and deleted from beginning/middle/end of the list of groups and the names stay understandable (i.e., in numeric order incrementing by 1)
<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

https://github.com/user-attachments/assets/0b671795-8e5e-4cdb-a3f9-c508c97cd701


