### PR TITLE
AJ-1929 use gcloud instead of gsutil

### DIFF
--- a/src/components/file-browser/DownloadFileCommand.test.ts
+++ b/src/components/file-browser/DownloadFileCommand.test.ts
@@ -28,14 +28,14 @@ describe('DownloadFileComamnd', () => {
     // Arrange
     asMockedFn(useFileDownloadCommand).mockReturnValue({
       status: 'Ready',
-      state: 'gsutil cp gs://test-bucket/path/to/example.txt example.txt',
+      state: 'gcloud storage cp gs://test-bucket/path/to/example.txt example.txt',
     });
 
     // Act
     render(h(DownloadFileCommand, { file, provider: mockProvider }));
 
     // Assert
-    screen.getByText('gsutil cp gs://test-bucket/path/to/example.txt example.txt');
+    screen.getByText('gcloud storage cp gs://test-bucket/path/to/example.txt example.txt');
   });
 
   it('renders a spinner while loading command', () => {

--- a/src/components/file-browser/useFileDownloadCommand.test.ts
+++ b/src/components/file-browser/useFileDownloadCommand.test.ts
@@ -36,12 +36,12 @@ describe('useFileDownloadCommand', () => {
     // Act
     const { result: hookReturnRef } = renderHook(() => useFileDownloadCommand({ file, provider: mockProvider }));
     await act(async () => {
-      getDownloadCommandForFileController.resolve('gsutil cp gs://test-bucket/path/to/example.txt .');
+      getDownloadCommandForFileController.resolve('gcloud storage cp gs://test-bucket/path/to/example.txt .');
     });
     const result = hookReturnRef.current;
 
     // Assert
-    expect(result).toEqual({ status: 'Ready', state: 'gsutil cp gs://test-bucket/path/to/example.txt .' });
+    expect(result).toEqual({ status: 'Ready', state: 'gcloud storage cp gs://test-bucket/path/to/example.txt .' });
   });
 
   it('handles errors', async () => {

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -165,7 +165,7 @@ describe('GCSFileBrowserProvider', () => {
     expect(downloadUrl).toBe('signedUrl');
   });
 
-  it('returns a gsutil download command', async () => {
+  it('returns a gcloud storage download command', async () => {
     // Arrange
     const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project' });
 
@@ -173,7 +173,7 @@ describe('GCSFileBrowserProvider', () => {
     const downloadCommand = await provider.getDownloadCommandForFile('path/to/example.txt');
 
     // Assert
-    expect(downloadCommand).toBe("gsutil cp 'gs://test-bucket/path/to/example.txt' .");
+    expect(downloadCommand).toBe("gcloud storage cp 'gs://test-bucket/path/to/example.txt' .");
   });
 
   it('uploads a file', async () => {

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -132,7 +132,7 @@ const GCSFileBrowserProvider = ({
       return await Ajax(signal).SamResources.getSignedUrl(bucket, path);
     },
     getDownloadCommandForFile: (path) => {
-      return Promise.resolve(`gsutil cp 'gs://${bucket}/${path}' .`);
+      return Promise.resolve(`gcloud storage cp 'gs://${bucket}/${path}' .`);
     },
     uploadFileToDirectory: (directoryPath, file) => {
       return Ajax().Buckets.upload(project, bucket, directoryPath, file);

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.test.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.test.ts
@@ -1,9 +1,9 @@
 import { getDownloadCommand } from './uri-viewer-utils';
 
 describe('getDownloadCommand', () => {
-  it('gets download command for gsutil', () => {
+  it('gets download command for gcloud storage', () => {
     expect(getDownloadCommand('test.txt', 'gs://demo-data/test.txt')).toBe(
-      "gsutil cp 'gs://demo-data/test.txt' test.txt"
+      "gcloud storage cp 'gs://demo-data/test.txt' test.txt"
     );
   });
 

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
@@ -29,6 +29,6 @@ export const getDownloadCommand = (fileName: string, uri: string, accessUrl?: Ac
   }
 
   if (isGsUri(uri)) {
-    return `gsutil cp '${uri}' ${fileName || '.'}`;
+    return `gcloud storage cp '${uri}' ${fileName || '.'}`;
   }
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1929
 Replaces `gsutil` in the download file command with `gcloud storage`.  Tested out the commands to see that they have the same syntax and both work.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
