### PR TITLE
AJ-1930 toggle with switch

### DIFF
--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -1,9 +1,10 @@
-import { Modal, Spinner, Switch } from '@terra-ui-packages/components';
+import { Modal, Spinner } from '@terra-ui-packages/components';
 import filesize from 'filesize';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
 import { div, h, p, pre, span } from 'react-hyperscript-helpers';
 import { bucketBrowserUrl } from 'src/auth/auth';
+import { LabeledRadioButton, LabeledRadioGroup } from 'src/billing/NewBillingProjectWizard/StepWizard/LabeledRadioButton';
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/components/bucket-utils';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import Collapse from 'src/components/Collapse';
@@ -104,6 +105,22 @@ export const UriViewer = _.flow(
 
     return h(Fragment, [
       p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, ['Terminal download command']),
+      p({ style: { marginBottom: '0.5rem', fontWeight: 200 } }, ['Download to:']),
+      div({ marginBottom: '0.5rem', fontWeight: 200 }, [
+        h(LabeledRadioGroup, { style: { marginTop: 0, marginBottom: 0 } }, [
+          LabeledRadioButton({
+            text: 'Current Directory',
+            name: 'current-directory',
+            checked: !useFileName,
+            onChange: toggleUseFileName,
+          }),
+          LabeledRadioButton({
+            text: 'New Subdirectory',
+            name: 'new-subdirectory',
+            onChange: toggleUseFileName,
+          }),
+        ]),
+      ]),
       pre(
         {
           style: {
@@ -135,17 +152,6 @@ export const UriViewer = _.flow(
           }),
         ]
       ),
-      div({ style: { flexGrow: 1, display: 'flex', alignItems: 'center', height: '2.25rem' } }, [
-        h(Switch, {
-          onLabel: ' ',
-          offLabel: ' ',
-          onChange: toggleUseFileName,
-          checked: useFileName,
-          width: 40,
-          height: 20,
-        }),
-        ['Download to current directory or mirror file directory'],
-      ]),
     ]);
   };
 

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -9,6 +9,7 @@ import { ClipboardButton } from 'src/components/ClipboardButton';
 import Collapse from 'src/components/Collapse';
 import { Link } from 'src/components/common';
 import { parseGsUri } from 'src/components/data/data-utils';
+import { SimpleTabBar } from 'src/components/tabBars';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
@@ -32,6 +33,7 @@ export const UriViewer = _.flow(
   const signal = useCancellation();
   const [metadata, setMetadata] = useState();
   const [loadingError, setLoadingError] = useState(false);
+  const [useFileName, setUseFileName] = useState(true);
 
   const loadMetadata = async () => {
     try {
@@ -95,11 +97,22 @@ export const UriViewer = _.flow(
     const { bucket, name } = metadata;
     const gsUri = `gs://${bucket}/${name}`;
     const downloadCommand = isAzureUri(uri)
-      ? getDownloadCommand(metadata.name, getAzureStorageUrl(metadata), metadata.accessUrl)
-      : getDownloadCommand(metadata.name, gsUri, metadata.accessUrl);
+      ? getDownloadCommand(metadata.name, getAzureStorageUrl(metadata), useFileName, metadata.accessUrl)
+      : getDownloadCommand(metadata.name, gsUri, useFileName, metadata.accessUrl);
 
     return h(Fragment, [
       p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, ['Terminal download command']),
+      h(SimpleTabBar, {
+        'aria-label': 'import type',
+        tabs: [
+          { title: 'Download to Current Directory', key: 'current', width: 207 },
+          { title: 'Mirror File Directory', key: 'mirror', width: 207 },
+        ],
+        value: useFileName ? 'mirror' : 'current',
+        onChange: (value) => {
+          setUseFileName(value === 'mirror');
+        },
+      }),
       pre(
         {
           style: {
@@ -110,6 +123,7 @@ export const UriViewer = _.flow(
             background: colors.light(0.4),
           },
         },
+
         [
           span(
             {

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -1,4 +1,4 @@
-import { Modal, Spinner } from '@terra-ui-packages/components';
+import { Modal, Spinner, Switch } from '@terra-ui-packages/components';
 import filesize from 'filesize';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
@@ -9,7 +9,6 @@ import { ClipboardButton } from 'src/components/ClipboardButton';
 import Collapse from 'src/components/Collapse';
 import { Link } from 'src/components/common';
 import { parseGsUri } from 'src/components/data/data-utils';
-import { SimpleTabBar } from 'src/components/tabBars';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
@@ -34,6 +33,9 @@ export const UriViewer = _.flow(
   const [metadata, setMetadata] = useState();
   const [loadingError, setLoadingError] = useState(false);
   const [useFileName, setUseFileName] = useState(true);
+  const toggleUseFileName = () => {
+    setUseFileName((prevUseFileName) => !prevUseFileName);
+  };
 
   const loadMetadata = async () => {
     try {
@@ -102,17 +104,6 @@ export const UriViewer = _.flow(
 
     return h(Fragment, [
       p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, ['Terminal download command']),
-      h(SimpleTabBar, {
-        'aria-label': 'import type',
-        tabs: [
-          { title: 'Download to Current Directory', key: 'current', width: 207 },
-          { title: 'Mirror File Directory', key: 'mirror', width: 207 },
-        ],
-        value: useFileName ? 'mirror' : 'current',
-        onChange: (value) => {
-          setUseFileName(value === 'mirror');
-        },
-      }),
       pre(
         {
           style: {
@@ -144,6 +135,17 @@ export const UriViewer = _.flow(
           }),
         ]
       ),
+      div({ style: { flexGrow: 1, display: 'flex', alignItems: 'center', height: '2.25rem' } }, [
+        h(Switch, {
+          onLabel: ' ',
+          offLabel: ' ',
+          onChange: toggleUseFileName,
+          checked: useFileName,
+          width: 40,
+          height: 20,
+        }),
+        ['Download to current directory or mirror file directory'],
+      ]),
     ]);
   };
 

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -104,20 +104,23 @@ export const UriViewer = _.flow(
       : getDownloadCommand(metadata.name, gsUri, useFileName, metadata.accessUrl);
 
     return h(Fragment, [
-      p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, ['Terminal download command']),
-      p({ style: { marginBottom: '0.5rem', fontWeight: 200 } }, ['Download to:']),
-      div({ marginBottom: '0.5rem', fontWeight: 200 }, [
+      p({ style: { marginBottom: '0.5rem', fontWeight: 'bold' } }, ['Terminal download command']),
+      p({ style: { marginBottom: '0.5rem', fontWeight: 500 } }, ['Download to:']),
+      div({ marginBottom: '0.5rem' }, [
         h(LabeledRadioGroup, { style: { marginTop: 0, marginBottom: 0 } }, [
           LabeledRadioButton({
             text: 'Current Directory',
             name: 'current-directory',
             checked: !useFileName,
             onChange: toggleUseFileName,
+            labelStyle: { color: 'black', fontWeight: 250 },
           }),
           LabeledRadioButton({
             text: 'New Subdirectory',
             name: 'new-subdirectory',
+            checked: useFileName,
             onChange: toggleUseFileName,
+            labelStyle: { color: 'black', fontWeight: 250 },
           }),
         ]),
       ]),

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.test.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.test.ts
@@ -1,20 +1,39 @@
 import { getDownloadCommand } from './uri-viewer-utils';
 
 describe('getDownloadCommand', () => {
-  it('gets download command for gcloud storage', () => {
-    expect(getDownloadCommand('test.txt', 'gs://demo-data/test.txt')).toBe(
+  it('gets download command for gcloud storage using file directory', () => {
+    expect(getDownloadCommand('test.txt', 'gs://demo-data/test.txt', true)).toBe(
       "gcloud storage cp 'gs://demo-data/test.txt' test.txt"
     );
   });
 
-  it('gets download command for azcopy', () => {
+  it('gets download command for gcloud storage using current directory', () => {
+    expect(getDownloadCommand('test.txt', 'gs://demo-data/test.txt', false)).toBe(
+      "gcloud storage cp 'gs://demo-data/test.txt' ."
+    );
+  });
+
+  it('gets download command for azcopy using file directory', () => {
     expect(
       getDownloadCommand(
         'test.txt',
-        'https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-4b638f1f-b0a3-4161-a3fa-70e48edd981d/test.txt'
+        'https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-4b638f1f-b0a3-4161-a3fa-70e48edd981d/test.txt',
+        true
       )
     ).toBe(
       "azcopy copy 'https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-4b638f1f-b0a3-4161-a3fa-70e48edd981d/test.txt' test.txt"
+    );
+  });
+
+  it('gets download command for azcopy using current directory', () => {
+    expect(
+      getDownloadCommand(
+        'test.txt',
+        'https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-4b638f1f-b0a3-4161-a3fa-70e48edd981d/test.txt',
+        false
+      )
+    ).toBe(
+      "azcopy copy 'https://lz8a3d793f17ede9b79635cc.blob.core.windows.net/sc-4b638f1f-b0a3-4161-a3fa-70e48edd981d/test.txt' ."
     );
   });
 });

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
@@ -28,12 +28,13 @@ export const getDownloadCommand = (
     const output = fileName ? `-o '${fileName}' ` : '-O ';
     return `curl ${headers}${output}'${httpUrl}'`;
   }
+  const downloadDir = useFileName && fileName ? `${fileName}` : '.';
 
   if (isAzureUri(uri)) {
-    return `azcopy copy '${uri}' ${useFileName && fileName ? `${fileName}` : '.'}`;
+    return `azcopy copy '${uri}' ${downloadDir}`;
   }
 
   if (isGsUri(uri)) {
-    return `gcloud storage cp '${uri}' ${useFileName && fileName ? `${fileName}` : '.'}`;
+    return `gcloud storage cp '${uri}' ${downloadDir}`;
   }
 };

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
@@ -30,10 +30,10 @@ export const getDownloadCommand = (
   }
 
   if (isAzureUri(uri)) {
-    return `azcopy copy '${uri}' ${useFileName && fileName ? `'${fileName}'` : '.'}`;
+    return `azcopy copy '${uri}' ${useFileName && fileName ? `${fileName}` : '.'}`;
   }
 
   if (isGsUri(uri)) {
-    return `gcloud storage cp '${uri}' ${useFileName && fileName ? `'${fileName}'` : '.'}`;
+    return `gcloud storage cp '${uri}' ${useFileName && fileName ? `${fileName}` : '.'}`;
   }
 };

--- a/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
+++ b/src/workspace-data/data-table/uri-viewer/uri-viewer-utils.ts
@@ -12,7 +12,12 @@ type AccessUrl = {
   headers: { [key: string]: string };
 };
 
-export const getDownloadCommand = (fileName: string, uri: string, accessUrl?: AccessUrl): string | undefined => {
+export const getDownloadCommand = (
+  fileName: string,
+  uri: string,
+  useFileName: boolean,
+  accessUrl?: AccessUrl
+): string | undefined => {
   const { url: httpUrl, headers: httpHeaders } = accessUrl || {};
   if (httpUrl) {
     const headers = _.flow(
@@ -25,10 +30,10 @@ export const getDownloadCommand = (fileName: string, uri: string, accessUrl?: Ac
   }
 
   if (isAzureUri(uri)) {
-    return `azcopy copy '${uri}' ${fileName || '.'}`;
+    return `azcopy copy '${uri}' ${useFileName && fileName ? `'${fileName}'` : '.'}`;
   }
 
   if (isGsUri(uri)) {
-    return `gsutil cp '${uri}' ${fileName || '.'}`;
+    return `gsutil cp '${uri}' ${useFileName && fileName ? `'${fileName}'` : '.'}`;
   }
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1930

When generating a download command, gives users the options to target the download to the current directory, or to create new subdirectories to match the directory structure of the file.


https://github.com/user-attachments/assets/baea66cb-28ee-4647-b431-7cdb4faa894c




<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
