### PR TITLE
WOR-1775 - Fix workspaces list locking

### DIFF
--- a/src/workspaces/list/WorkspacesList.ts
+++ b/src/workspaces/list/WorkspacesList.ts
@@ -55,6 +55,7 @@ export const WorkspacesList = (): ReactNode => {
       'workspace.workspaceId',
       'workspace.state',
       'workspace.errorMessage',
+      'workspace.isLocked',
     ],
     250
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1775

* add isLocked to fields requested for workspace list

The `WorkspacesList` previously did not fetch the lock status of  the workspace, but the locking modal was used with the workspace, not the dynamic fields from the menu. Since it was available on the list workspaces endpoint, and doesn't add significant overhead to the request, I just added it to the fields requested.

It would be good to clean this up in the future, but for now, it's possible to unlock workspaces from the list view.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
