### PR TITLE
[WOR-1764] Remove reader "can compute" sharing option

### DIFF
--- a/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
@@ -281,30 +281,44 @@ describe('a Collaborator component', () => {
     });
   });
 
-  it('hides the Can Compute option when giving a collaborator Reader access', async () => {
+  describe('hides the Can Compute option for collaborators with Reader access', () => {
     // Arrange
     const setAcl = jest.fn();
-    const item: AccessEntry = {
+    const item1: AccessEntry = {
       email: 'user1@test.com',
-      pending: false,
+      pending: true,
       canShare: true,
       canCompute: false,
       accessLevel: 'READER',
     };
-    const acl = [item];
+    const item2: AccessEntry = {
+      email: 'user2@test.com',
+      pending: false,
+      canShare: false,
+      canCompute: false,
+      accessLevel: 'READER',
+    };
 
-    // Act
-    render(
-      h(Collaborator, {
-        aclItem: item,
-        acl,
-        setAcl,
-        originalAcl: acl,
-        workspace: { ...workspace, accessLevel: 'OWNER' },
-      })
+    test.each([{ item: item1 }, { item: item2 }])(
+      'hides Can Compute when pending is $item.pending and Can Share is $item.canShare',
+      ({ item }) => {
+        const acl = [item];
+
+        // Act
+        render(
+          h(Collaborator, {
+            aclItem: item,
+            acl,
+            setAcl,
+            originalAcl: acl,
+            workspace: { ...workspace, accessLevel: 'OWNER' },
+          })
+        );
+
+        // Assert
+        expect(screen.queryByText('Can compute')).not.toBeInTheDocument();
+        expect(screen.queryByText('Can share')).toBeInTheDocument();
+      }
     );
-
-    // Assert
-    expect(screen.queryByText('Can compute')).not.toBeInTheDocument();
   });
 });

--- a/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
@@ -280,4 +280,31 @@ describe('a Collaborator component', () => {
       }
     });
   });
+
+  it('hides the Can Compute option when giving a collaborator Reader access', async () => {
+    // Arrange
+    const setAcl = jest.fn();
+    const item: AccessEntry = {
+      email: 'user1@test.com',
+      pending: false,
+      canShare: true,
+      canCompute: false,
+      accessLevel: 'READER',
+    };
+    const acl = [item];
+
+    // Act
+    render(
+      h(Collaborator, {
+        aclItem: item,
+        acl,
+        setAcl,
+        originalAcl: acl,
+        workspace: { ...workspace, accessLevel: 'OWNER' },
+      })
+    );
+
+    // Assert
+    expect(screen.queryByText('Can compute')).not.toBeInTheDocument();
+  });
 });

--- a/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.test.ts
@@ -281,7 +281,7 @@ describe('a Collaborator component', () => {
     });
   });
 
-  describe('hides the Can Compute option for collaborators with Reader access', () => {
+  describe('the Can Compute option', () => {
     // Arrange
     const setAcl = jest.fn();
     const item1: AccessEntry = {
@@ -300,7 +300,7 @@ describe('a Collaborator component', () => {
     };
 
     test.each([{ item: item1 }, { item: item2 }])(
-      'hides Can Compute when pending is $item.pending and Can Share is $item.canShare',
+      'is hidden for readers when pending is $item.pending and Can Share is $item.canShare',
       ({ item }) => {
         const acl = [item];
 

--- a/src/workspaces/ShareWorkspaceModal/Collaborator.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.ts
@@ -7,9 +7,8 @@ import { getPopupRoot } from 'src/components/popup-utils';
 import colors from 'src/libs/colors';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
-import { cond } from 'src/libs/utils';
 import { AccessEntry, WorkspaceAcl } from 'src/workspaces/acl-utils';
-import { BaseWorkspace, hasAccessLevel, isAzureWorkspace, WorkspaceAccessLevel } from 'src/workspaces/utils';
+import { BaseWorkspace, canWrite, hasAccessLevel, isAzureWorkspace, WorkspaceAccessLevel } from 'src/workspaces/utils';
 
 /**
  * @param aclItem {AccessEntry} the item to render
@@ -139,20 +138,17 @@ export const AclInput: React.FC<AclInputProps> = (props: AclInputProps) => {
           ),
         ]),
         div([
-          cond([
-            !(accessLevel === 'READER'),
-            () =>
-              h(
-                LabeledCheckbox,
-                {
-                  disabled: disabled || !userCanShareAdditionalPerms,
-                  checked: canCompute,
-                  onChange: () => onChange(_.update('canCompute', (b) => !b, value)),
-                  ...tooltipProps,
-                },
-                [' Can compute']
-              ),
-          ]),
+          canWrite(accessLevel) &&
+            h(
+              LabeledCheckbox,
+              {
+                disabled: disabled || !userCanShareAdditionalPerms,
+                checked: canCompute,
+                onChange: () => onChange(_.update('canCompute', (b) => !b, value)),
+                ...tooltipProps,
+              },
+              [' Can compute']
+            ),
         ]),
       ]),
   ]);

--- a/src/workspaces/ShareWorkspaceModal/Collaborator.ts
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.ts
@@ -7,6 +7,7 @@ import { getPopupRoot } from 'src/components/popup-utils';
 import colors from 'src/libs/colors';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
+import { cond } from 'src/libs/utils';
 import { AccessEntry, WorkspaceAcl } from 'src/workspaces/acl-utils';
 import { BaseWorkspace, hasAccessLevel, isAzureWorkspace, WorkspaceAccessLevel } from 'src/workspaces/utils';
 
@@ -138,16 +139,20 @@ export const AclInput: React.FC<AclInputProps> = (props: AclInputProps) => {
           ),
         ]),
         div([
-          h(
-            LabeledCheckbox,
-            {
-              disabled: disabled || !userCanShareAdditionalPerms,
-              checked: canCompute,
-              onChange: () => onChange(_.update('canCompute', (b) => !b, value)),
-              ...tooltipProps,
-            },
-            [' Can compute']
-          ),
+          cond([
+            !(accessLevel === 'READER'),
+            () =>
+              h(
+                LabeledCheckbox,
+                {
+                  disabled: disabled || !userCanShareAdditionalPerms,
+                  checked: canCompute,
+                  onChange: () => onChange(_.update('canCompute', (b) => !b, value)),
+                  ...tooltipProps,
+                },
+                [' Can compute']
+              ),
+          ]),
         ]),
       ]),
   ]);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1764

When "reader" access level is selected in the workspace sharing modal, an option no longer shows up for the "Can compute" role ("Can share" remains). Selecting this role previously produced an error. Now the UI reflects that the combination is not possible.

The role is still available for writers and owners.

<img width="280" alt="Screenshot 2024-07-24 at 9 16 36 AM" src="https://github.com/user-attachments/assets/6a62f9ed-45a9-4048-bbae-6246103dd204">
<img width="280" alt="Screenshot 2024-07-24 at 9 17 09 AM" src="https://github.com/user-attachments/assets/9a8afe2f-501b-49b2-83c7-34385746bdcb">
