### PR TITLE
[DC-1124] Make name actually be sent

### DIFF
--- a/src/dataset-builder/DatasetBuilder.ts
+++ b/src/dataset-builder/DatasetBuilder.ts
@@ -619,7 +619,7 @@ export const DatasetBuilderContents = ({
                     .snapshotAccessRequest()
                     .createSnapshotAccessRequest(
                       createSnapshotAccessRequest(
-                        '',
+                        snapshotRequestName,
                         '',
                         snapshotId,
                         _.flatMap((cohortSet) => cohortSet.values, selectedCohorts),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-1124

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
The props weren't actually wired up to be sent along with the request. This is a small change to add that.

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
