### PR TITLE
[WOR-899] Display bucket size for workspace readers

### DIFF
--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -211,4 +211,29 @@ describe('CloudInformation', () => {
       screen.getAllByText('Based on list price. Does not include savings from Autoclass or other discounts.')
     ).not.toBeNull();
   });
+
+  it('displays bucket size for users with reader access', async () => {
+    // Arrange
+    const mockBucketUsage = jest.fn().mockResolvedValue({ usageInBytes: 50, lastUpdated: '2024-07-26' });
+    asMockedFn(Ajax).mockReturnValue({
+      Workspaces: {
+        workspace: jest.fn().mockReturnValue({ bucketUsage: mockBucketUsage }),
+      },
+    } as DeepPartial<AjaxContract> as AjaxContract);
+
+    // Act
+    await act(() =>
+      render(
+        h(CloudInformation, {
+          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
+          storageDetails,
+        })
+      )
+    );
+
+    // Assert
+    expect(screen.getByText('Updated on 7/26/2024')).not.toBeNull();
+    expect(screen.getByText('50 B')).not.toBeNull();
+    expect(mockBucketUsage).toHaveBeenCalled();
+  });
 });

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -16,7 +16,14 @@ import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/wo
 import { AzureStorageDetails } from 'src/workspaces/dashboard/AzureStorageDetails';
 import { BucketLocation } from 'src/workspaces/dashboard/BucketLocation';
 import { InfoRow } from 'src/workspaces/dashboard/InfoRow';
-import { AzureWorkspace, canWrite, GoogleWorkspace, isAzureWorkspace, isGoogleWorkspace } from 'src/workspaces/utils';
+import {
+  AzureWorkspace,
+  canRead,
+  canWrite,
+  GoogleWorkspace,
+  isAzureWorkspace,
+  isGoogleWorkspace,
+} from 'src/workspaces/utils';
 
 interface CloudInformationProps {
   storageDetails: StorageDetails;
@@ -114,9 +121,13 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
       }
     });
 
-    if (workspace.workspaceInitialized && canWrite(accessLevel)) {
-      loadStorageCost();
-      loadBucketSize();
+    if (workspace.workspaceInitialized) {
+      if (canRead(accessLevel)) {
+        loadBucketSize();
+      }
+      if (canWrite(accessLevel)) {
+        loadStorageCost();
+      }
     }
   }, [workspace, accessLevel, signal]);
 
@@ -177,7 +188,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
             ]),
           ]
         ),
-      canWrite(accessLevel) &&
+      canRead(accessLevel) &&
         h(
           InfoRow,
           {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-899

Allows users with reader access to see bucket usage information. This is coupled with a Rawls change which does the same ([link](https://github.com/broadinstitute/rawls/commit/fa9f3adde4de820b55797ceb40a6290c524dac14)).

<img width="517" alt="Screenshot of UI with reader access and bucket size visible" src="https://github.com/user-attachments/assets/d731b985-29b8-4867-8ac5-9853827fef6a">