### PR TITLE
[WOR-1779] Add bucket name to workspace search filter

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -34,7 +34,7 @@ const testPreviewDrsUriFn = _.flow(
 
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await waitForNoSpinners(page);
-  await fillIn(page, input({ placeholder: 'Search by name or project' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name, project, or bucket' }), workspaceName);
   await click(page, clickable({ textContains: workspaceName }), { timeout: Millis.ofMinute });
 
   await noSpinnersAfter(page, {

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -501,7 +501,7 @@ const viewWorkspaceDashboard = async (page, token, workspaceName) => {
   await signIntoTerra(page, { token });
   await click(page, clickable({ textContains: 'View Workspaces' }));
   await dismissInfoNotifications(page);
-  await fillIn(page, input({ placeholder: 'Search by name or project' }), workspaceName);
+  await fillIn(page, input({ placeholder: 'Search by name, project, or bucket' }), workspaceName);
   // Wait for workspace table to rerender filtered items
   await delay(Millis.ofSecond);
   await noSpinnersAfter(page, { action: () => click(page, clickable({ textContains: workspaceName })) });

--- a/src/workspaces/list/WorkspaceFilters.test.ts
+++ b/src/workspaces/list/WorkspaceFilters.test.ts
@@ -1,6 +1,5 @@
 import { DeepPartial, delay } from '@terra-ui-packages/core-utils';
-import { act } from '@testing-library/react';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
@@ -109,7 +108,7 @@ describe('WorkspaceFilters', () => {
       render(h(WorkspaceFilters, { workspaces: [defaultGoogleWorkspace] }));
     });
 
-    const filterSelector = screen.getByLabelText('Search workspaces by name or project');
+    const filterSelector = screen.getByLabelText('Search workspaces by name, project, or bucket');
     await filterSelector.click();
     await user.type(filterSelector, 'x');
     await act(() => delay(300)); // debounced search

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -38,8 +38,8 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
   return div({ style: { display: 'flex', margin: '1rem 0' } }, [
     div({ style: { ...styles.filter, flexGrow: 1.5 } }, [
       h(DelayedSearchInput, {
-        placeholder: 'Search by name or project',
-        'aria-label': 'Search workspaces by name or project',
+        placeholder: 'Search by name, project, or bucket',
+        'aria-label': 'Search workspaces by name, project, or bucket',
         onChange: (newFilter) => {
           // Store in a state variable to make unit testing possible (as opposed to onBlur comparing the current
           // value to what exists in filters.nameFilter).

--- a/src/workspaces/list/WorkspacesListTabs.test.ts
+++ b/src/workspaces/list/WorkspacesListTabs.test.ts
@@ -141,6 +141,30 @@ describe('The filterWorkspaces method', () => {
     expect(filteredWorkspaces.myWorkspaces).toEqual([deleteFailedWorkspace, cloningFailedWorkspace]);
   });
 
+  it('should filter based on bucket name', () => {
+    // Arrange
+    const workspaces: CategorizedWorkspaces = {
+      myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
+      public: [defaultAzureWorkspace, defaultGoogleWorkspace],
+      newAndInteresting: [defaultAzureWorkspace, defaultGoogleWorkspace],
+      featured: [defaultAzureWorkspace, defaultGoogleWorkspace],
+    };
+    const filters = getWorkspaceFiltersFromQuery({
+      tab: 'myWorkspaces',
+      filter: defaultGoogleWorkspace.workspace.bucketName,
+    });
+
+    // Act
+    const filteredWorkspaces = filterWorkspaces(workspaces, filters);
+
+    // Assert
+    expect(filteredWorkspaces.myWorkspaces).toEqual([defaultGoogleWorkspace]);
+    // All categories should be filtered
+    expect(filteredWorkspaces.public).toEqual([defaultGoogleWorkspace]);
+    expect(filteredWorkspaces.newAndInteresting).toEqual([defaultGoogleWorkspace]);
+    expect(filteredWorkspaces.featured).toEqual([defaultGoogleWorkspace]);
+  });
+
   it('should filter based on namespace (project search)', () => {
     // Arrange
     const workspaces: CategorizedWorkspaces = {

--- a/src/workspaces/list/WorkspacesListTabs.ts
+++ b/src/workspaces/list/WorkspacesListTabs.ts
@@ -72,7 +72,7 @@ export const filterWorkspaces = (
   const filterWorkspacesCategory = (workspaces: Workspace[], filters: WorkspaceFilterValues): Workspace[] => {
     const matches = (ws: Workspace): boolean => {
       const {
-        workspace: { namespace, name, attributes, state, googleProject },
+        workspace: { namespace, name, attributes, state, googleProject, bucketName },
       } = ws;
 
       const containsKeywordFilter = (textToMatchWithin: string | undefined): boolean => {
@@ -82,7 +82,8 @@ export const filterWorkspaces = (
       return !!(
         (containsKeywordFilter(`${namespace}/${name}`) ||
           containsKeywordFilter(googleProject) ||
-          containsKeywordFilter(state)) &&
+          containsKeywordFilter(state) ||
+          containsKeywordFilter(bucketName)) &&
         (_.isEmpty(filters.accessLevels) || filters.accessLevels.includes(ws.accessLevel)) &&
         (_.isEmpty(filters.projects) || filters.projects === namespace) &&
         (_.isEmpty(filters.cloudPlatform) || getCloudProviderFromWorkspace(ws) === filters.cloudPlatform) &&


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1779

When searching the workspace list, the search term will also be matched against (full or partial, case-insensitive) bucket names.

<img width="1489" alt="Workspace list search with bucket name" src="https://github.com/user-attachments/assets/a64cfa95-df42-4c41-9c92-a47f85169b21">