### PR TITLE
[DC-865]Change Column Widths and Padding in ConceptSearch

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -109,10 +109,10 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
               paddingBottom: 10,
             },
             columns: [
-              { header: strong(['Concept name']), key: 'name', size: { grow: 2.2 } },
+              { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
               { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
               { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
-              { header: strong(['Number of Participants']), key: 'count', size: { grow: 0.75 } },
+              { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
               { key: 'hierarchy', size: { grow: 0.5 } },
             ],
             rows: _.map((concept) => {

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -109,11 +109,11 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
               paddingBottom: 10,
             },
             columns: [
-              { header: strong(['Concept name']), width: 710, key: 'name' },
-              { header: strong(['Concept ID']), width: 195, key: 'id' },
-              { header: strong(['Code']), width: 195, key: 'code' },
-              { header: strong(['Number of Participants']), width: 205, key: 'count' },
-              { width: 100, key: 'hierarchy' },
+              { header: strong(['Concept name']), key: 'name', size: { grow: 2.2 } },
+              { header: strong(['Concept ID']), key: 'id', size: { grow: 1 } },
+              { header: strong(['Code']), key: 'code', size: { grow: 1 } },
+              { header: strong(['Number of Participants']), key: 'count', size: { grow: 1 } },
+              { key: 'hierarchy', size: { grow: 0.5 } },
             ],
             rows: _.map((concept) => {
               return {

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -110,9 +110,9 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
             },
             columns: [
               { header: strong(['Concept name']), key: 'name', size: { grow: 2.2 } },
-              { header: strong(['Concept ID']), key: 'id', size: { grow: 1 } },
-              { header: strong(['Code']), key: 'code', size: { grow: 1 } },
-              { header: strong(['Number of Participants']), key: 'count', size: { grow: 1 } },
+              { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
+              { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
+              { header: strong(['Number of Participants']), key: 'count', size: { grow: 0.75 } },
               { key: 'hierarchy', size: { grow: 0.5 } },
             ],
             rows: _.map((concept) => {

--- a/src/dataset-builder/ConceptSelector.ts
+++ b/src/dataset-builder/ConceptSelector.ts
@@ -88,11 +88,11 @@ export const ConceptSelector = (props: ConceptSelectorProps) => {
               ]);
             },
           },
-          { name: 'Concept ID', width: 195, render: _.get('id') },
-          { name: 'Code', width: 195, render: _.get('code') },
+          { name: 'Concept ID', width: 205, render: _.get('id') },
+          { name: 'Code', width: 205, render: _.get('code') },
           {
-            name: 'Number of Participants',
-            width: 205,
+            name: '# Participants',
+            width: 185,
             render: (row) => formatCount(row.count),
           },
         ],


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-865

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Changed column widths in Concept Search so that Concept Name has more room.

### Why
Concept names are much longer than IDs, codes, and participant counts, so a wider column makes the names easier to read.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

Manually checked the UI locally.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/2f9d62d4-b973-488f-bfd1-e8dc05b83755">
Example with longer concept names and codes:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/efba4af9-5a64-47ee-9534-02fd668d81b8">

Hierarchy page:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/56253935-4aef-4971-91f8-fccc66a0ed23">




