### PR TITLE
[WOR-1774] Support writer with canCompute for requesterPays GCP workspace data access.

### DIFF
--- a/src/components/RequesterPaysModal.test.tsx
+++ b/src/components/RequesterPaysModal.test.tsx
@@ -1,65 +1,86 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { useWorkspaces } from 'src/workspaces/common/state/useWorkspaces';
 import { WorkspaceWrapper } from 'src/workspaces/utils';
 
 import RequesterPaysModal from './RequesterPaysModal';
 
-jest.mock('src/workspaces/common/state/useWorkspaces', () => ({
-  ...jest.requireActual('src/workspaces/common/state/useWorkspaces'),
-  useWorkspaces: jest.fn().mockReturnValue({
-    loading: false,
-    workspaces: [
-      {
-        workspace: {
-          namespace: 'test-namespace',
-          name: 'workspace-1',
-          cloudPlatform: 'Gcp',
-          googleProject: 'test-project-1',
-        },
-        accessLevel: 'PROJECT_OWNER',
-      },
-      {
-        workspace: {
-          namespace: 'test-namespace',
-          name: 'workspace-2',
-          cloudPlatform: 'Gcp',
-          googleProject: 'test-project-2',
-        },
-        accessLevel: 'OWNER',
-      },
-      {
-        workspace: {
-          namespace: 'test-namespace',
-          name: 'workspace-3',
-          cloudPlatform: 'Gcp',
-          googleProject: 'test-project-3',
-        },
-        accessLevel: 'WRITER',
-      },
-      {
-        workspace: {
-          namespace: 'test-namespace',
-          name: 'workspace-4',
-          cloudPlatform: 'Gcp',
-          googleProject: 'test-project-4',
-        },
-        accessLevel: 'READER',
-      },
-      {
-        workspace: { namespace: 'test-namespace', name: 'workspace-5', cloudPlatform: 'Azure' },
-        accessLevel: 'OWNER',
-      },
-    ] as WorkspaceWrapper[],
-  }),
-}));
+type UseWorkspacesExports = typeof import('src/workspaces/common/state/useWorkspaces');
+jest.mock('src/workspaces/common/state/useWorkspaces', (): UseWorkspacesExports => {
+  return {
+    ...jest.requireActual<UseWorkspacesExports>('src/workspaces/common/state/useWorkspaces'),
+    useWorkspaces: jest.fn(),
+  };
+});
 
 describe('RequesterPaysModal', () => {
-  it('lists GCP workspaces that the user owns', async () => {
+  it('lists GCP workspaces that the user owns or is writer with canCompute', async () => {
     // Arrange
+    asMockedFn(useWorkspaces).mockReturnValue({
+      refresh: jest.fn(),
+      status: 'Ready',
+      loading: false,
+      workspaces: [
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-project-owner',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-1',
+          },
+          accessLevel: 'PROJECT_OWNER',
+          canCompute: true,
+        },
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-owner',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-2',
+          },
+          accessLevel: 'OWNER',
+          canCompute: true,
+        },
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-writer-no-compute',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-3',
+          },
+          accessLevel: 'WRITER',
+          canCompute: false,
+        },
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-writer-can-compute',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-4',
+          },
+          accessLevel: 'WRITER',
+          canCompute: true,
+        },
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-reader',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-5',
+          },
+          accessLevel: 'READER',
+          canCompute: false,
+        },
+        {
+          workspace: { namespace: 'test-namespace', name: 'azure-owner', cloudPlatform: 'Azure' },
+          accessLevel: 'OWNER',
+          canCompute: true,
+        },
+      ] as WorkspaceWrapper[],
+    });
     const user = userEvent.setup();
-
     render(<RequesterPaysModal onDismiss={() => {}} onSuccess={() => {}} />);
 
     // Act
@@ -68,11 +89,43 @@ describe('RequesterPaysModal', () => {
     const options = screen.getAllByRole('option').map((el) => el.textContent);
 
     // Assert
-    expect(options).toEqual(['test-namespace/workspace-1', 'test-namespace/workspace-2']);
+    expect(useWorkspaces).toBeCalledWith(['accessLevel', 'canCompute', 'workspace']);
+    expect(options).toEqual([
+      'test-namespace/gcp-owner',
+      'test-namespace/gcp-project-owner',
+      'test-namespace/gcp-writer-can-compute',
+    ]);
   });
 
   it('calls onSuccess callback with Google project from selected workspace', async () => {
     // Arrange
+    asMockedFn(useWorkspaces).mockReturnValue({
+      refresh: jest.fn(),
+      status: 'Ready',
+      loading: false,
+      workspaces: [
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-project-owner',
+            cloudPlatform: 'Gcp',
+            googleProject: 'test-project-1',
+          },
+          accessLevel: 'PROJECT_OWNER',
+          canCompute: true,
+        },
+        {
+          workspace: {
+            namespace: 'test-namespace',
+            name: 'gcp-owner',
+            cloudPlatform: 'Gcp',
+            googleProject: 'gcp-owner-googleProject',
+          },
+          accessLevel: 'OWNER',
+          canCompute: true,
+        },
+      ] as WorkspaceWrapper[],
+    });
     const user = userEvent.setup();
 
     const onSuccess = jest.fn();
@@ -82,13 +135,13 @@ describe('RequesterPaysModal', () => {
     await user.click(workspaceInput);
 
     // Act
-    const workspaceOption = screen.getByText('test-namespace/workspace-2');
+    const workspaceOption = screen.getByText('test-namespace/gcp-owner');
     await user.click(workspaceOption);
 
     const okButton = screen.getByText('Ok');
     await user.click(okButton);
 
     // Assert
-    expect(onSuccess).toHaveBeenCalledWith('test-project-2');
+    expect(onSuccess).toHaveBeenCalledWith('gcp-owner-googleProject');
   });
 });

--- a/src/components/RequesterPaysModal.tsx
+++ b/src/components/RequesterPaysModal.tsx
@@ -2,6 +2,7 @@ import { ButtonPrimary, ExternalLink, Modal, useUniqueId } from '@terra-ui-packa
 import * as _ from 'lodash/fp';
 import React, { useState } from 'react';
 import { spinnerOverlay, VirtualizedSelect } from 'src/components/common';
+import { FieldsArg } from 'src/libs/ajax/workspaces/providers/WorkspaceProvider';
 import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { requesterPaysProjectStore } from 'src/libs/state';
@@ -24,10 +25,14 @@ interface RequesterPaysModalProps {
 }
 
 const RequesterPaysModal: React.FC<RequesterPaysModalProps> = ({ onDismiss, onSuccess }) => {
-  const { workspaces, loading } = useWorkspaces();
+  const { workspaces, loading } = useWorkspaces(['accessLevel', 'canCompute', 'workspace'] as FieldsArg);
+
   const billableWorkspaces = _.filter(
     (workspace: WorkspaceWrapper) =>
-      isGoogleWorkspace(workspace) && (workspace.accessLevel === 'OWNER' || workspace.accessLevel === 'PROJECT_OWNER'),
+      isGoogleWorkspace(workspace) &&
+      (workspace.accessLevel === 'OWNER' ||
+        workspace.accessLevel === 'PROJECT_OWNER' ||
+        (workspace.accessLevel === 'WRITER' && workspace.canCompute)),
     workspaces
   );
   const selectId = useUniqueId('select');

--- a/src/components/RequesterPaysModal.tsx
+++ b/src/components/RequesterPaysModal.tsx
@@ -25,7 +25,7 @@ interface RequesterPaysModalProps {
 }
 
 const RequesterPaysModal: React.FC<RequesterPaysModalProps> = ({ onDismiss, onSuccess }) => {
-  const { workspaces, loading } = useWorkspaces(['accessLevel', 'canCompute', 'workspace'] as FieldsArg);
+  const { workspaces, loading } = useWorkspaces(['accessLevel', 'canCompute', 'workspace'] satisfies FieldsArg);
 
   const billableWorkspaces = _.filter(
     (workspace: WorkspaceWrapper) =>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1774

Depends on Rawls change in https://github.com/broadinstitute/rawls/pull/2972, which is currently in dev.

Allows the user to charge a requesterPays GCP workspace to the billing account associated with a workspace that the user is a writer with `canCompute` privileges.

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/bbfe587d-315b-4ba7-9023-42f7812ad0d6">
