### PR TITLE
[DC-987]Checkboxes aren't lining up with concept name

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -98,30 +98,32 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
             rowStyle: {
               backgroundColor: 'white',
               ...tableLeftPadding,
+              paddingRight: '2rem',
             },
             headerRowStyle: {
               ...tableHeaderStyle,
               ...tableLeftPadding,
+              paddingRight: '2rem',
               marginTop: '1rem',
             },
             cellStyle: {
-              paddingTop: 10,
-              paddingBottom: 10,
+              paddingTop: 13,
+              paddingBottom: 13,
             },
             columns: [
               { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
               { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
               { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
               { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
-              { key: 'hierarchy', size: { grow: 0.5 } },
+              { key: 'hierarchy', size: { grow: 0.4 } },
             ],
             rows: _.map((concept) => {
               return {
-                name: div({ style: { display: 'flex' } }, [
+                name: div({ style: { display: 'flex', alignItems: 'start' } }, [
                   h(
                     LabeledCheckbox,
                     {
-                      style: { padding: 12 },
+                      style: { marginRight: 5, marginTop: 1 },
                       checked: _.contains(concept, cart),
                       onChange: () => setCart(_.xor(cart, [concept])),
                     },

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -119,7 +119,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
             ],
             rows: _.map((concept) => {
               return {
-                name: div({ style: { display: 'flex', alignItems: 'start' } }, [
+                name: div({ style: { display: 'flex', alignItems: 'flex-start' } }, [
                   h(
                     LabeledCheckbox,
                     {

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -119,11 +119,11 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
             ],
             rows: _.map((concept) => {
               return {
-                name: div({ style: { display: 'flex', alignItems: 'flex-start' } }, [
+                name: div({ style: { display: 'flex' } }, [
                   h(
                     LabeledCheckbox,
                     {
-                      style: { marginRight: 5, marginTop: 1 },
+                      style: { paddingRight: 22, marginTop: 1 },
                       checked: _.contains(concept, cart),
                       onChange: () => setCart(_.xor(cart, [concept])),
                     },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-987

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Making the checkboxes on the Concept Search page line up with the text in the table. Also re-added the padding on the right hand side of the table after losing it when changing the column widths.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

Manually tested the UI locally.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/706f91a9-1ba3-4546-ad89-1015fa3b72fb">
For longer concept names that take up multiple lines, checkbox lines up with the first line of text:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/37d966e0-0739-4383-b9d4-09fc57950d0b">
**EDIT** I noticed this issue with the three-lined concept names, where the check in the checkbox was misaligned and the text was too close to the checkbox
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9f021137-39d6-4783-891b-af31b98a667a">
This is what it looks like after the fix:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4227a2e9-c751-496c-98d4-4a1a240b12d1">
