### PR TITLE
[WOR-1761] Fix bug with workspace description extending width

### DIFF
--- a/src/libs/style.ts
+++ b/src/libs/style.ts
@@ -214,6 +214,7 @@ export const dashboard = {
   leftBox: {
     flex: 1,
     padding: '0 2rem 2rem 2rem',
+    overflow: 'hidden',
   },
   rightBox: {
     flex: 'none',

--- a/src/workspaces/dashboard/WorkspaceDashboard.ts
+++ b/src/workspaces/dashboard/WorkspaceDashboard.ts
@@ -43,7 +43,7 @@ export const WorkspaceDashboard = forwardRef(
     // @ts-expect-error
     const { value: canEdit } = canEditWorkspace(workspace);
 
-    return div({ style: { flex: 1, display: 'flex' } }, [
+    return div({ style: { gridTemplateColumns: 'auto min-content', display: 'grid' } }, [
       div({ style: Style.dashboard.leftBox }, [
         h(WorkspaceDescription, { workspace, refreshWorkspace }),
         h(DatasetAttributes, { attributes }),

--- a/src/workspaces/dashboard/WorkspaceDashboard.ts
+++ b/src/workspaces/dashboard/WorkspaceDashboard.ts
@@ -43,7 +43,7 @@ export const WorkspaceDashboard = forwardRef(
     // @ts-expect-error
     const { value: canEdit } = canEditWorkspace(workspace);
 
-    return div({ style: { gridTemplateColumns: 'auto min-content', display: 'grid' } }, [
+    return div({ style: { gridTemplateColumns: 'auto min-content', gridTemplateRows: '1fr 2fr', display: 'grid' } }, [
       div({ style: Style.dashboard.leftBox }, [
         h(WorkspaceDescription, { workspace, refreshWorkspace }),
         h(DatasetAttributes, { attributes }),
@@ -106,6 +106,9 @@ export const WorkspaceDashboard = forwardRef(
           [h(WorkspaceNotifications, { workspace })]
         ),
       ]),
+      // "dummy" div to make background color below the right box sections the same if they do not
+      // fill the full height of the dashboard
+      div({ style: { ...Style.dashboard.rightBox, gridRow: '2', gridColumn: '2' } }, []),
     ]);
   }
 );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1761

Workspace descriptions with code blocks that contain create very long lines had the ability to distort the Workspace Dashboard. This PR changes the layout to force such blocks to break so that the right-hand box components and the cloud context bar are always visible.

Before:
<img width="1639" alt="image" src="https://github.com/user-attachments/assets/db9cac43-8e92-45e4-a70e-47900807762e">

And then if you scroll over to the right….
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/c737a054-580f-49f9-b5c0-06229aefd7d7">

After:
<img width="1642" alt="image" src="https://github.com/user-attachments/assets/59d58b38-0fb8-42b9-a69f-4e6881b7a37f">

This also fixes the public dashboard.
Before:
<img width="1217" alt="image" src="https://github.com/user-attachments/assets/643aed70-9958-4961-81d1-d08afd16b09e">

After:
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/34aeeb52-5ddc-4c5b-a168-895def254927">

