### PR TITLE
ID-1362 Better NIH Account Linking Flow

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -17,7 +17,7 @@
   "isProd": false,
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
-  "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
+  "orchestrationUrlRoot": "https://local.broadinstitute.org:10443",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",

--- a/config/dev.json
+++ b/config/dev.json
@@ -17,7 +17,7 @@
   "isProd": false,
   "jobManagerUrlRoot": "https://job-manager.dsde-dev.broadinstitute.org/jobs",
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
-  "orchestrationUrlRoot": "https://local.broadinstitute.org:10443",
+  "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",

--- a/src/profile/Profile.ts
+++ b/src/profile/Profile.ts
@@ -47,7 +47,11 @@ export const Profile = (): ReactNode => {
     coalescedQuery = query;
   }
   const callbacks = ['fence-callback', 'ecm-callback', 'oauth-callback'];
-  const tab: string = query.tab || (callbacks.includes(name) ? 'externalIdentities' : 'personalInfo');
+  let tab: string = query.tab || (callbacks.includes(name) ? 'externalIdentities' : 'personalInfo');
+  const { 'nih-username-token': nihUsernameToken } = query;
+  if (nihUsernameToken !== undefined) {
+    tab = 'externalIdentities';
+  }
 
   const tabs = [
     { key: 'personalInfo', title: 'Personal Information' },

--- a/src/profile/external-identities/NihAccount.ts
+++ b/src/profile/external-identities/NihAccount.ts
@@ -40,7 +40,7 @@ export const NihAccount = ({ nihToken }) => {
 
     if (nihToken) {
       // Clear the query string, but use replace so the back button doesn't take the user back to the token
-      Nav.history.replace({ search: '' });
+      Nav.history.replace({ search: 'tab=externalIdentities' });
       linkNihAccount();
     }
   });
@@ -70,7 +70,7 @@ export const NihAccount = ({ nihToken }) => {
       ]),
       Utils.cond(
         [!nihStatusLoaded, () => h(SpacedSpinner, ['Loading NIH account status...'])],
-        [isLinking, () => h(SpacedSpinner, ['Linking NIH account...'])],
+        [isLinking, () => h(SpacedSpinner, ['Linking NIH account... (This can take a minute or two)'])],
         [!linkedNihUsername, () => div([h(ShibbolethLink, { button: true }, ['Log in to NIH'])])],
         () =>
           h(Fragment, [


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1362

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

Currently, to compete the NIH Account linking flow, a user needs to link their NIH Account, then when re-directed to the profile page, click on “External Identities”, and then re-load the page to see the results. 

This is BAD, so let’s fix it!

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] Manual testing

<!-- ### Visual Aids -->

Before:

https://github.com/user-attachments/assets/25f26db7-bfb7-4271-b1b9-f231364d0fcd

After:

https://github.com/user-attachments/assets/029b4335-a821-4f4e-9784-4e483e757229


