### PR TITLE
AJ-1167: show column datatype for WDS data tables

### DIFF
--- a/src/libs/ajax/data-table-providers/DataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/DataTableProvider.ts
@@ -141,6 +141,7 @@ export interface DataTableFeatures {
   supportsPointCorrection: boolean;
   supportsFiltering: boolean;
   supportsRowSelection: boolean;
+  supportsPerColumnDatatype: boolean;
 }
 
 export interface TSVFeatures {

--- a/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
@@ -44,6 +44,7 @@ export class EntityServiceDataTableProvider implements DataTableProvider {
     supportsPointCorrection: true,
     supportsFiltering: true,
     supportsRowSelection: true,
+    supportsPerColumnDatatype: false,
   };
 
   tsvFeatures: TSVFeatures = {

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -178,6 +178,7 @@ export class WdsDataTableProvider implements DataTableProvider {
       supportsPointCorrection: false,
       supportsFiltering: false,
       supportsRowSelection: false,
+      supportsPerColumnDatatype: true,
     };
   }
 

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -187,8 +187,8 @@ const DataTable = (props) => {
   };
 
   const getColumnDatatype = (entityType, columnName) => {
-    const foundColumn = _.find({ name: columnName }, entityMetadata[entityType].attributes);
-    return foundColumn ? foundColumn.datatype : undefined;
+    const foundColumn = _.find({ name: columnName }, entityMetadata[entityType]?.attributes);
+    return foundColumn && foundColumn.datatype ? foundColumn.datatype : undefined;
   };
 
   // Helpers

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -186,6 +186,11 @@ const DataTable = (props) => {
     return !!columnFilter.filterColAttr && !!columnFilter.filterColTerm ? `${columnFilter.filterColAttr}=${columnFilter.filterColTerm}` : '';
   };
 
+  const getColumnDatatype = (entityType, columnName) => {
+    const foundColumn = _.find({ name: columnName }, entityMetadata[entityType].attributes);
+    return foundColumn ? foundColumn.datatype : undefined;
+  };
+
   // Helpers
   const loadData =
     !!entityMetadata &&
@@ -507,7 +512,7 @@ const DataTable = (props) => {
                           {
                             sort,
                             field: 'name',
-                            datatype: 'foo',
+                            datatype: dataProvider.features.supportsPerColumnDatatype ? 'STRING' : undefined, // primary keys are always strings.
                             onSort: setSort,
                             renderSearch: !!googleProject,
                             searchByColumn: (v) => searchByColumn(entityMetadata[entityType].idName, v),
@@ -560,7 +565,7 @@ const DataTable = (props) => {
                             {
                               sort,
                               field: attributeName,
-                              datatype: 'dunno',
+                              datatype: dataProvider.features.supportsPerColumnDatatype ? getColumnDatatype(entityType, attributeName) : undefined,
                               onSort: setSort,
                               renderSearch: !!googleProject,
                               searchByColumn: (v) => searchByColumn(attributeName, v),

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -188,7 +188,7 @@ const DataTable = (props) => {
 
   const getColumnDatatype = (entityType, columnName) => {
     const foundColumn = _.find({ name: columnName }, entityMetadata[entityType]?.attributes);
-    return foundColumn && foundColumn.datatype ? foundColumn.datatype : undefined;
+    return foundColumn?.datatype;
   };
 
   // Helpers

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -507,6 +507,7 @@ const DataTable = (props) => {
                           {
                             sort,
                             field: 'name',
+                            datatype: 'foo',
                             onSort: setSort,
                             renderSearch: !!googleProject,
                             searchByColumn: (v) => searchByColumn(entityMetadata[entityType].idName, v),
@@ -559,6 +560,7 @@ const DataTable = (props) => {
                             {
                               sort,
                               field: attributeName,
+                              datatype: 'dunno',
                               onSort: setSort,
                               renderSearch: !!googleProject,
                               searchByColumn: (v) => searchByColumn(attributeName, v),

--- a/src/workspace-data/data-table/shared/HeaderOptions.js
+++ b/src/workspace-data/data-table/shared/HeaderOptions.js
@@ -1,7 +1,7 @@
 import { PopupTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useRef } from 'react';
-import { div, h } from 'react-hyperscript-helpers';
+import { div, h, span } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { ConfirmedSearchInput } from 'src/components/input';
@@ -9,7 +9,7 @@ import { MenuButton } from 'src/components/MenuButton';
 import { MenuDivider } from 'src/components/PopupTrigger';
 import { Sortable } from 'src/components/table';
 
-export const HeaderOptions = ({ sort, field, onSort, extraActions, renderSearch, searchByColumn, children }) => {
+export const HeaderOptions = ({ sort, field, datatype, onSort, extraActions, renderSearch, searchByColumn, children }) => {
   const popup = useRef();
   const columnMenu = h(
     PopupTrigger,
@@ -18,6 +18,14 @@ export const HeaderOptions = ({ sort, field, onSort, extraActions, renderSearch,
       closeOnClick: true,
       side: 'bottom',
       content: h(Fragment, [
+        datatype &&
+          h(Fragment, [
+            h(MenuButton, { disabled: true }, [
+              h(span, { style: { fontWeight: 'bold' } }, ['Column Type:']),
+              h(span, { style: { marginLeft: '.25rem' } }, [datatype]),
+            ]),
+            h(MenuDivider),
+          ]),
         h(MenuButton, { onClick: () => onSort({ field, direction: 'asc' }) }, ['Sort Ascending']),
         h(MenuButton, { onClick: () => onSort({ field, direction: 'desc' }) }, ['Sort Descending']),
         renderSearch &&

--- a/src/workspace-data/data-table/wds/WDSContent.test.ts
+++ b/src/workspace-data/data-table/wds/WDSContent.test.ts
@@ -77,6 +77,7 @@ const defaultFeatures: DataTableFeatures = {
   supportsPointCorrection: false,
   supportsFiltering: false,
   supportsRowSelection: false,
+  supportsPerColumnDatatype: true,
 };
 
 const defaultSetupOptions: SetupOptions = {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1167

## Summary of changes:
For WDS-powered (i.e. Azure) workspaces, display the datatype for each column of a data table, according to UX's guidance in https://dspuxteam.invisionapp.com/console/share/JP47XHQ6EFR/986412090.

### What
For WDS/Azure workspaces only, the data table column header now includes the datatype.

### Why
Column datatypes are important for WDS/Azure, whereas Entity Service/GCP supports different datatypes in the same column. Given the importance for WDS/Azure, we want to display the datatypes.

### Testing strategy
Tested manually. The files containing the business logic changes are .js files (not .ts) so I don't want to invest too much in tests for them, nor do I want to rewrite them as part of this PR.

### Visual Aids

_Azure workspace shows datatypes:_
![Screenshot 07-08-2024 at 16 27](https://github.com/user-attachments/assets/74a0eb24-62fa-437f-a6f9-75f3a881f69d)
![Screenshot 07-08-2024 at 16 28](https://github.com/user-attachments/assets/f12000e4-6deb-4d4a-bee7-9fa8526c0f94)

_Google workspaces are unchanged:_
![Screenshot 07-08-2024 at 16 29](https://github.com/user-attachments/assets/5bc89f14-ff50-4b89-a9e3-f11f8155967f)
![Screenshot 07-08-2024 at 16 29 (1)](https://github.com/user-attachments/assets/f56e5bab-9974-49a7-b04d-d0092723578d)

