### PR TITLE
DC-1013: Debounce an async calls in cohort builder

### DIFF
--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -61,18 +61,19 @@ export const CriteriaView = (props: CriteriaViewProps) => {
   const updateCriteriaCount = useRef(
     debounceAsync((snapshotId: string, criteria: AnyCriteria) =>
       setCriteriaCount(
-        withErrorReporting('Error getting criteria group count')(async () =>
-          DataRepo()
-            .snapshot(snapshotId)
-            .getSnapshotBuilderCount(
-              createSnapshotBuilderCountRequest([
-                {
-                  // Create a "cohort" to get the count of participants for these criteria on its own.
-                  criteriaGroups: [{ id: 0, criteria: [criteria], meetAll: true, mustMeet: true }],
-                  name: '',
-                },
-              ])
-            )
+        withErrorReporting('Error getting criteria group count')(
+          async () =>
+            await DataRepo()
+              .snapshot(snapshotId)
+              .getSnapshotBuilderCount(
+                createSnapshotBuilderCountRequest([
+                  {
+                    // Create a "cohort" to get the count of participants for these criteria on its own.
+                    criteriaGroups: [{ id: 0, criteria: [criteria], meetAll: true, mustMeet: true }],
+                    name: '',
+                  },
+                ])
+              )
         )
       )
     )
@@ -339,10 +340,13 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
   const updateGroupParticipantCount = useRef(
     debounceAsync((snapshotId: string, criteriaGroup: CriteriaGroup) =>
       setGroupParticipantCount(
-        withErrorReporting('Error getting criteria group count')(async () =>
-          DataRepo()
-            .snapshot(snapshotId)
-            .getSnapshotBuilderCount(createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }]))
+        withErrorReporting('Error getting criteria group count')(
+          async () =>
+            await DataRepo()
+              .snapshot(snapshotId)
+              .getSnapshotBuilderCount(
+                createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }])
+              )
         )
       )
     )

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -1,4 +1,5 @@
 import { Spinner, useLoadedData } from '@terra-ui-packages/components';
+import debouncePromise from 'debounce-promise';
 import _ from 'lodash/fp';
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 import { div, h, h2, h3, strong } from 'react-hyperscript-helpers';
@@ -29,6 +30,7 @@ import {
 } from 'src/libs/ajax/DataRepo';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
+import { useCancellation } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 
 import { domainCriteriaSearchState, homepageState, newCriteriaGroup, Updater } from './dataset-builder-types';
@@ -52,43 +54,18 @@ type CriteriaViewProps = {
 
 const addCriteriaText = 'Add criteria';
 
-// Debounce next calls until result's promise resolve
-// Code from stackoverflow answer: https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality
-const debounceAsync = (fn: any) => {
-  let activePromise: any = null;
-  let cancel: any = null;
-  const debouncedFn = (...args: any) => {
-    cancel?.();
-    if (activePromise) {
-      const abortController = new AbortController();
-      cancel = abortController.abort.bind(abortController);
-      activePromise.then(() => {
-        if (abortController.signal.aborted) return;
-        debouncedFn(...args);
-      });
-      return;
-    }
-
-    activePromise = Promise.resolve(fn(...args));
-    activePromise.finally(() => {
-      activePromise = null;
-    });
-  };
-  return debouncedFn;
-};
-
 export const CriteriaView = (props: CriteriaViewProps) => {
   const { snapshotId, criteria, deleteCriteria, updateCriteria } = props;
 
   const [criteriaCount, setCriteriaCount] = useLoadedData<SnapshotBuilderCountResponse>();
 
+  const signal = useCancellation();
   const updateCriteriaCount = useRef(
-    _.debounce(
-      250,
-      debounceAsync((snapshotId: string, criteria: AnyCriteria) =>
+    debouncePromise(
+      (snapshotId: string, criteria: AnyCriteria) =>
         setCriteriaCount(
           withErrorReporting('Error getting criteria group count')(async () =>
-            DataRepo()
+            DataRepo(signal)
               .snapshot(snapshotId)
               .getSnapshotBuilderCount(
                 createSnapshotBuilderCountRequest([
@@ -100,8 +77,8 @@ export const CriteriaView = (props: CriteriaViewProps) => {
                 ])
               )
           )
-        )
-      )
+        ),
+      250
     )
   );
 
@@ -362,21 +339,20 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
   };
 
   const [groupParticipantCount, setGroupParticipantCount] = useLoadedData<SnapshotBuilderCountResponse>();
-
+  const signal = useCancellation();
   const updateGroupParticipantCount = useRef(
-    _.debounce(
-      250,
-      debounceAsync((snapshotId: string, criteriaGroup: CriteriaGroup) =>
+    debouncePromise(
+      (snapshotId: string, criteriaGroup: CriteriaGroup) =>
         setGroupParticipantCount(
           withErrorReporting('Error getting criteria group count')(async () =>
-            DataRepo()
+            DataRepo(signal)
               .snapshot(snapshotId)
               .getSnapshotBuilderCount(
                 createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }])
               )
           )
-        )
-      )
+        ),
+      250
     )
   );
 

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -12,6 +12,7 @@ import {
   Cohort,
   createSnapshotBuilderCountRequest,
   CriteriaGroup,
+  debounceAsync,
   formatCount,
   ProgramDataListCriteria,
   ProgramDataRangeCriteria,
@@ -51,31 +52,6 @@ type CriteriaViewProps = {
 };
 
 const addCriteriaText = 'Add criteria';
-
-// Debounce next calls until result's promise resolve
-// Code from stackoverflow answer: https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality
-const debounceAsync = (fn: any) => {
-  let activePromise: any = null;
-  let cancel: any = null;
-  const debouncedFn = (...args: any) => {
-    cancel?.();
-    if (activePromise) {
-      const abortController = new AbortController();
-      cancel = abortController.abort.bind(abortController);
-      activePromise.then(() => {
-        if (abortController.signal.aborted) return;
-        debouncedFn(...args);
-      });
-      return;
-    }
-
-    activePromise = Promise.resolve(fn(...args));
-    activePromise.finally(() => {
-      activePromise = null;
-    });
-  };
-  return debouncedFn;
-};
 
 export const CriteriaView = (props: CriteriaViewProps) => {
   const { snapshotId, criteria, deleteCriteria, updateCriteria } = props;

--- a/src/dataset-builder/CohortEditor.ts
+++ b/src/dataset-builder/CohortEditor.ts
@@ -59,23 +59,20 @@ export const CriteriaView = (props: CriteriaViewProps) => {
   const [criteriaCount, setCriteriaCount] = useLoadedData<SnapshotBuilderCountResponse>();
 
   const updateCriteriaCount = useRef(
-    _.debounce(
-      250,
-      debounceAsync((snapshotId: string, criteria: AnyCriteria) =>
-        setCriteriaCount(
-          withErrorReporting('Error getting criteria group count')(async () =>
-            DataRepo()
-              .snapshot(snapshotId)
-              .getSnapshotBuilderCount(
-                createSnapshotBuilderCountRequest([
-                  {
-                    // Create a "cohort" to get the count of participants for these criteria on its own.
-                    criteriaGroups: [{ id: 0, criteria: [criteria], meetAll: true, mustMeet: true }],
-                    name: '',
-                  },
-                ])
-              )
-          )
+    debounceAsync((snapshotId: string, criteria: AnyCriteria) =>
+      setCriteriaCount(
+        withErrorReporting('Error getting criteria group count')(async () =>
+          DataRepo()
+            .snapshot(snapshotId)
+            .getSnapshotBuilderCount(
+              createSnapshotBuilderCountRequest([
+                {
+                  // Create a "cohort" to get the count of participants for these criteria on its own.
+                  criteriaGroups: [{ id: 0, criteria: [criteria], meetAll: true, mustMeet: true }],
+                  name: '',
+                },
+              ])
+            )
         )
       )
     )
@@ -340,17 +337,12 @@ export const CriteriaGroupView: React.FC<CriteriaGroupViewProps> = (props) => {
   const [groupParticipantCount, setGroupParticipantCount] = useLoadedData<SnapshotBuilderCountResponse>();
 
   const updateGroupParticipantCount = useRef(
-    _.debounce(
-      250,
-      debounceAsync((snapshotId: string, criteriaGroup: CriteriaGroup) =>
-        setGroupParticipantCount(
-          withErrorReporting('Error getting criteria group count')(async () =>
-            DataRepo()
-              .snapshot(snapshotId)
-              .getSnapshotBuilderCount(
-                createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }])
-              )
-          )
+    debounceAsync((snapshotId: string, criteriaGroup: CriteriaGroup) =>
+      setGroupParticipantCount(
+        withErrorReporting('Error getting criteria group count')(async () =>
+          DataRepo()
+            .snapshot(snapshotId)
+            .getSnapshotBuilderCount(createSnapshotBuilderCountRequest([{ criteriaGroups: [criteriaGroup], name: '' }]))
         )
       )
     )

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -7,6 +7,7 @@ import {
   convertOutputTable,
   createSnapshotAccessRequest,
   CriteriaGroup,
+  debounceAsync,
   formatCount,
   HighlightConceptName,
   OutputTable,
@@ -283,5 +284,24 @@ describe('test formatCount', () => {
 
   test('count is 20', () => {
     expect(formatCount(20)).toStrictEqual('20');
+  });
+});
+
+describe('test debounceAsync', () => {
+  test('debounce should mean that the example function is only called once', () => {
+    const exampleFunction = jest.fn();
+    const exampleCall = debounceAsync(
+      (param1: string) =>
+        new Promise((resolve) => {
+          exampleFunction();
+          setTimeout(() => {
+            resolve(param1);
+          }, 0);
+        })
+    );
+    exampleCall('first');
+    exampleCall('second');
+    exampleCall('third');
+    expect(exampleFunction).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -185,17 +185,18 @@ export const addSelectableObjectToGroup = <T extends DatasetBuilderType>(
 };
 
 // Debounce next calls until result's promise resolve
-// Code from stackoverflow answer: https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality
-export const debounceAsync = (fn: any) => {
-  let activePromise: any = null;
-  let cancel: any = null;
+export const debounceAsync = <T>(fn: (...args: any[]) => T) => {
+  let activePromise: Promise<T> | undefined;
+  let cancel: () => void | undefined;
   const debouncedFn = (...args: any) => {
     cancel?.();
     if (activePromise) {
       const abortController = new AbortController();
       cancel = abortController.abort.bind(abortController);
       activePromise.then(() => {
-        if (abortController.signal.aborted) return;
+        if (abortController.signal.aborted) {
+          return;
+        }
         debouncedFn(...args);
       });
       return;
@@ -203,7 +204,7 @@ export const debounceAsync = (fn: any) => {
 
     activePromise = Promise.resolve(fn(...args));
     activePromise.finally(() => {
-      activePromise = null;
+      activePromise = undefined;
     });
   };
   return debouncedFn;

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -185,6 +185,7 @@ export const addSelectableObjectToGroup = <T extends DatasetBuilderType>(
 };
 
 // Debounce next calls until result's promise resolve
+// Code from stackoverflow answer: https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality
 export const debounceAsync = <T>(fn: (...args: any[]) => T) => {
   let activePromise: Promise<T> | undefined;
   let cancel: () => void | undefined;

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -183,3 +183,28 @@ export const addSelectableObjectToGroup = <T extends DatasetBuilderType>(
       : _.set(`[${index}].values`, _.xorWith(_.isEqual, group[index].values, [selectableObject]), group)
   );
 };
+
+// Debounce next calls until result's promise resolve
+// Code from stackoverflow answer: https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality
+export const debounceAsync = (fn: any) => {
+  let activePromise: any = null;
+  let cancel: any = null;
+  const debouncedFn = (...args: any) => {
+    cancel?.();
+    if (activePromise) {
+      const abortController = new AbortController();
+      cancel = abortController.abort.bind(abortController);
+      activePromise.then(() => {
+        if (abortController.signal.aborted) return;
+        debouncedFn(...args);
+      });
+      return;
+    }
+
+    activePromise = Promise.resolve(fn(...args));
+    activePromise.finally(() => {
+      activePromise = null;
+    });
+  };
+  return debouncedFn;
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-1013

## Notes:
- Utilized a method from a [stack overflow answer](https://stackoverflow.com/questions/74800112/debounce-async-function-and-ensure-sequentiality), so we may want to rework the debounce async method
- If we keep the async debounce method, we should move it into a common utils file

## Summary of changes:
We were seeing some inconsistent behavior on debounce. See example in video:

https://github.com/user-attachments/assets/d2536dd2-2909-4cb3-8639-53f552a90c1f

I think the issue was that call of the async method was debounced, but that the async call was not completing before another debounce call was kicked off again. 

We can instead debounce until the promise of the async call resolves. 
With changes in place:

https://github.com/user-attachments/assets/2be6b3cf-254a-47e4-a880-f645a8873388



### Testing strategy
- click testing in UI


