### PR TITLE
Change name of paginator component to Paginator

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -44,7 +44,7 @@ const paginatorButton = (props, label) =>
  * @param {number} props.itemsPerPage
  * @param {number[]} [props.itemsPerPageOptions=[10,25,50,100]]
  */
-export const paginator = ({
+export const Paginator = ({
   filteredDataLength,
   unfilteredDataLength,
   pageNumber,

--- a/src/workflows-app/SubmissionHistory.js
+++ b/src/workflows-app/SubmissionHistory.js
@@ -6,7 +6,7 @@ import { Clickable, Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
 import { MenuButton } from 'src/components/MenuButton';
 import { MenuTrigger } from 'src/components/PopupTrigger';
-import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
+import { FlexTable, Paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
@@ -443,7 +443,7 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
               ]),
             !_.isEmpty(sortedRunSets) &&
               div({ style: { bottom: 0, position: 'absolute', marginBottom: '1.5rem', right: '4rem' } }, [
-                paginator({
+                Paginator({
                   filteredDataLength: sortedRunSets.length,
                   unfilteredDataLength: sortedRunSets.length,
                   pageNumber,

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -6,7 +6,7 @@ import { AutoSizer } from 'react-virtualized';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonPrimary, Clickable, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
-import { FlexTable, paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
+import { FlexTable, Paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
@@ -537,7 +537,7 @@ const FilterableWorkflowTable = ({
       !_.isEmpty(sortedPreviousRuns) &&
         div({ style: { marginBottom: '1.5rem', right: '4rem' } }, [
           // @ts-expect-error
-          paginator({
+          Paginator({
             filteredDataLength: sortedPreviousRuns.length,
             unfilteredDataLength: sortedPreviousRuns.length,
             pageNumber,

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -18,7 +18,7 @@ import { icon } from 'src/components/icons';
 import { ConfirmedSearchInput } from 'src/components/input';
 import { MenuButton } from 'src/components/MenuButton';
 import { MenuTrigger } from 'src/components/PopupTrigger';
-import { GridTable, HeaderCell, paginator, Resizable, TooltipCell } from 'src/components/table';
+import { GridTable, HeaderCell, Paginator, Resizable, TooltipCell } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
 import { wdsProviderName } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
 import colors from 'src/libs/colors';
@@ -700,7 +700,7 @@ const DataTable = (props) => {
         ]),
         !_.isEmpty(entities) &&
           div({ style: { flex: 'none', margin: '1rem' } }, [
-            paginator({
+            Paginator({
               filteredDataLength: filteredCount,
               unfilteredDataLength: totalRowCount,
               pageNumber,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1735

### What
- Updated the name of the `paginator` component to `Paginator`

### Why
- To follow correct React component naming conventions and enable the component to be used in TSX without import aliases.
- Refactoring work was done in preparation for the improvements listed in the ticket, which will be completed in a separate PR. The purpose of the ticket is to continue migrating Firecloud UI's methods list functionality to Terra UI.

### Testing strategy

- [x] Manually smoke tested affected pages
- [x] Ran existing unit tests on affected pages
- [x] Performed a string search to ensure no usages were missed
