### PR TITLE
[WOR-1801] Convert RecentlyViewedWorkspaceCard to TSX

### DIFF
--- a/src/workspaces/common/state/recentlyViewedWorkspaces.test.tsx
+++ b/src/workspaces/common/state/recentlyViewedWorkspaces.test.tsx
@@ -1,0 +1,93 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { getLocalPref } from 'src/libs/prefs';
+
+import { recentlyViewedPersistenceId, updateRecentlyViewedWorkspaces } from './recentlyViewedWorkspaces';
+
+const mockSetLocalPref = jest.fn();
+jest.mock('src/libs/prefs', () => {
+  return {
+    ...jest.requireActual('src/libs/prefs'),
+    getLocalPref: jest.fn(),
+    setLocalPref: (...args) => mockSetLocalPref(...args),
+  };
+});
+
+describe('recentlyViewedWorkspaces', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    Date.now = jest.fn(() => 4);
+  });
+
+  it('adds a recently viewed workspace to an empty list', () => {
+    asMockedFn(getLocalPref).mockReturnValue(undefined);
+
+    updateRecentlyViewedWorkspaces('test-id');
+
+    expect(mockSetLocalPref).toHaveBeenCalledWith(recentlyViewedPersistenceId, {
+      recentlyViewed: [{ workspaceId: 'test-id', timestamp: 4 }],
+    });
+  });
+
+  it('adds a recently viewed workspace to a non-empty list', () => {
+    asMockedFn(getLocalPref).mockReturnValue({
+      recentlyViewed: [
+        { workspaceId: 'ws-2', timestamp: 2 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+      ],
+    });
+
+    updateRecentlyViewedWorkspaces('test-id');
+
+    expect(mockSetLocalPref).toHaveBeenCalledWith(recentlyViewedPersistenceId, {
+      recentlyViewed: [
+        { workspaceId: 'test-id', timestamp: 4 },
+        { workspaceId: 'ws-2', timestamp: 2 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+      ],
+    });
+  });
+
+  it('caps the recently viewed list at four workspaces', () => {
+    asMockedFn(getLocalPref).mockReturnValue({
+      recentlyViewed: [
+        { workspaceId: 'ws-3', timestamp: 3 },
+        { workspaceId: 'ws-2', timestamp: 2 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+        { workspaceId: 'ws-0', timestamp: 0 },
+      ],
+    });
+
+    updateRecentlyViewedWorkspaces('test-id');
+
+    expect(mockSetLocalPref).toHaveBeenCalledWith(recentlyViewedPersistenceId, {
+      recentlyViewed: [
+        { workspaceId: 'test-id', timestamp: 4 },
+        { workspaceId: 'ws-3', timestamp: 3 },
+        { workspaceId: 'ws-2', timestamp: 2 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+      ],
+    });
+  });
+
+  it('re-orders the recently viewed list if the new workspace is already in it and does not duplicate the entry', () => {
+    asMockedFn(getLocalPref).mockReturnValue({
+      recentlyViewed: [
+        { workspaceId: 'ws-3', timestamp: 3 },
+        { workspaceId: 'test-id', timestamp: 2 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+        { workspaceId: 'ws-0', timestamp: 0 },
+      ],
+    });
+
+    updateRecentlyViewedWorkspaces('test-id');
+
+    expect(mockSetLocalPref).toHaveBeenCalledWith(recentlyViewedPersistenceId, {
+      recentlyViewed: [
+        { workspaceId: 'test-id', timestamp: 4 },
+        { workspaceId: 'ws-3', timestamp: 3 },
+        { workspaceId: 'ws-1', timestamp: 1 },
+        { workspaceId: 'ws-0', timestamp: 0 },
+      ],
+    });
+  });
+});

--- a/src/workspaces/common/state/recentlyViewedWorkspaces.tsx
+++ b/src/workspaces/common/state/recentlyViewedWorkspaces.tsx
@@ -3,11 +3,13 @@ import { getLocalPref, setLocalPref } from 'src/libs/prefs';
 
 export const recentlyViewedPersistenceId = 'workspaces/recentlyViewed';
 
-export const updateRecentlyViewedWorkspaces = (workspaceId) => {
-  const recentlyViewed = getLocalPref(recentlyViewedPersistenceId)?.recentlyViewed || [];
+type RecentlyViewed = { workspaceId: string; timestamp: number };
+
+export const updateRecentlyViewedWorkspaces = (workspaceId: string) => {
+  const recentlyViewed: RecentlyViewed[] = getLocalPref(recentlyViewedPersistenceId)?.recentlyViewed || [];
   // Recently viewed workspaces are limited to 4. Additionally, if a user clicks a workspace multiple times,
   // we only want the most recent instance stored in the list.
-  const updatedRecentlyViewed = _.flow(
+  const updatedRecentlyViewed: RecentlyViewed[] = _.flow(
     _.remove({ workspaceId }),
     _.concat([{ workspaceId, timestamp: Date.now() }]),
     _.orderBy(['timestamp'], ['desc']),

--- a/src/workspaces/list/RecentlyViewedWorkspaceCard.ts
+++ b/src/workspaces/list/RecentlyViewedWorkspaceCard.ts
@@ -7,9 +7,15 @@ import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
-import { getCloudProviderFromWorkspace } from 'src/workspaces/utils';
+import { getCloudProviderFromWorkspace, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
-export const RecentlyViewedWorkspaceCard = ({ workspace, timestamp }) => {
+interface RecentlyViewedWorkspaceCardProps {
+  workspace: Workspace;
+  timestamp: string;
+}
+
+export const RecentlyViewedWorkspaceCard = (props: RecentlyViewedWorkspaceCardProps): React.ReactNode => {
+  const { workspace, timestamp } = props;
   const {
     workspace: { namespace, name },
   } = workspace;
@@ -28,14 +34,19 @@ export const RecentlyViewedWorkspaceCard = ({ workspace, timestamp }) => {
       },
       href: Nav.getLink('workspace-dashboard', { namespace, name }),
       onClick: () => {
-        Ajax().Metrics.captureEvent(Events.workspaceOpenFromRecentlyViewed, extractWorkspaceDetails(workspace.workspace));
+        Ajax().Metrics.captureEvent(
+          Events.workspaceOpenFromRecentlyViewed,
+          extractWorkspaceDetails(workspace.workspace)
+        );
       },
     },
     [
       div({ style: { flex: 'none' } }, [
-        div({ style: { color: colors.accent(), ...Style.noWrapEllipsis, fontSize: 16, marginBottom: 7 } }, name),
+        div({ style: { color: colors.accent(), ...Style.noWrapEllipsis, fontSize: 16, marginBottom: 7 } }, [name]),
         div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
-          div({ style: { ...Style.noWrapEllipsis, whiteSpace: 'pre-wrap', fontStyle: 'italic' } }, [`Viewed ${dateViewed}`]),
+          div({ style: { ...Style.noWrapEllipsis, whiteSpace: 'pre-wrap', fontStyle: 'italic' } }, [
+            `Viewed ${dateViewed}`,
+          ]),
           div({ style: { display: 'flex', alignItems: 'center' } }, [
             h(CloudProviderIcon, { cloudProvider: getCloudProviderFromWorkspace(workspace), style: { marginLeft: 5 } }),
           ]),

--- a/src/workspaces/list/RecentlyViewedWorkspaceCard.tsx
+++ b/src/workspaces/list/RecentlyViewedWorkspaceCard.tsx
@@ -1,5 +1,5 @@
 import { Clickable } from '@terra-ui-packages/components';
-import { div, h } from 'react-hyperscript-helpers';
+import React from 'react';
 import { CloudProviderIcon } from 'src/components/CloudProviderIcon';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
@@ -22,36 +22,34 @@ export const RecentlyViewedWorkspaceCard = (props: RecentlyViewedWorkspaceCardPr
 
   const dateViewed = Utils.makeCompleteDate(new Date(parseInt(timestamp)).toString());
 
-  return h(
-    Clickable,
-    {
-      style: {
+  return (
+    <Clickable
+      style={{
         ...Style.elements.card.container,
         maxWidth: 'calc(25% - 10px)',
         margin: '0 0.25rem',
         lineHeight: '1.5rem',
         flex: '0 1 calc(25% - 10px)',
-      },
-      href: Nav.getLink('workspace-dashboard', { namespace, name }),
-      onClick: () => {
+      }}
+      href={Nav.getLink('workspace-dashboard', { namespace, name })}
+      onClick={() => {
         Ajax().Metrics.captureEvent(
           Events.workspaceOpenFromRecentlyViewed,
           extractWorkspaceDetails(workspace.workspace)
         );
-      },
-    },
-    [
-      div({ style: { flex: 'none' } }, [
-        div({ style: { color: colors.accent(), ...Style.noWrapEllipsis, fontSize: 16, marginBottom: 7 } }, [name]),
-        div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
-          div({ style: { ...Style.noWrapEllipsis, whiteSpace: 'pre-wrap', fontStyle: 'italic' } }, [
-            `Viewed ${dateViewed}`,
-          ]),
-          div({ style: { display: 'flex', alignItems: 'center' } }, [
-            h(CloudProviderIcon, { cloudProvider: getCloudProviderFromWorkspace(workspace), style: { marginLeft: 5 } }),
-          ]),
-        ]),
-      ]),
-    ]
+      }}
+    >
+      <div style={{ flex: 'none' }}>
+        <div style={{ color: colors.accent(), ...Style.noWrapEllipsis, fontSize: 16, marginBottom: 7 }}>{name}</div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={{ ...Style.noWrapEllipsis, whiteSpace: 'pre-wrap', fontStyle: 'italic' }}>
+            Viewed {dateViewed}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <CloudProviderIcon cloudProvider={getCloudProviderFromWorkspace(workspace)} style={{ marginLeft: 5 }} />
+          </div>
+        </div>
+      </div>
+    </Clickable>
   );
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1801

These changes convert RecentlyViewedWorkspaceCard from JS to TS to TSX. No change in functionality is intended.

After/Before:

<img width="400" alt="Recently viewed workspaces local" src="https://github.com/user-attachments/assets/3d9127e8-3d28-449d-afc0-eb5b7d8d13dc"><img width="400" alt="Recently viewed workspaces dev" src="https://github.com/user-attachments/assets/a9831ff5-3d66-4a91-881c-b70790071bb6">
