### PR TITLE
[WOR-1800] Move member modal dialog usages to Members file

### DIFF
--- a/src/billing/Members/Members.test.tsx
+++ b/src/billing/Members/Members.test.tsx
@@ -11,10 +11,6 @@ import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
 type AjaxContract = ReturnType<typeof Ajax>;
 jest.mock('src/libs/ajax');
 describe('Members', () => {
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
   it('renders a list of members in the billing project with no accessibility errors', async () => {
     // Arrange
     const projectUsers: User[] = [
@@ -85,6 +81,7 @@ describe('Members', () => {
     const addProjectUser = jest.fn();
     const mockAjax: DeepPartial<AjaxContract> = {
       Billing: { addProjectUser } as Partial<AjaxContract['Billing']>,
+      // Next 2 mocks are needed for suggestions in the NewUserModal.
       Workspaces: { getShareLog: jest.fn(() => Promise.resolve([])) },
       Groups: { list: jest.fn(() => Promise.resolve([])) },
     };
@@ -109,7 +106,7 @@ describe('Members', () => {
     // so we need to select the second one.
     const emailInput = screen.getAllByLabelText('User email *')[1];
     await user.type(emailInput, 'test-user@company.com');
-    // Save button within the dialog, as opposed to the one that opened the dailog.
+    // Save button ("Add User") within the dialog, as opposed to the one that opened the dialog.
     const saveButton = within(screen.getByRole('dialog')).getByText('Add User');
     await user.click(saveButton);
 

--- a/src/billing/Members/Members.test.tsx
+++ b/src/billing/Members/Members.test.tsx
@@ -1,14 +1,23 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import React from 'react';
 import { Members } from 'src/billing/Members/Members';
-import { renderWithAppContexts } from 'src/testing/test-utils';
+import { User } from 'src/components/group-common';
+import { Ajax } from 'src/libs/ajax';
+import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
 
+type AjaxContract = ReturnType<typeof Ajax>;
+jest.mock('src/libs/ajax');
 describe('Members', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('renders a list of members in the billing project with no accessibility errors', async () => {
     // Arrange
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: 'x_owner@test.email.org', roles: ['Owner'] },
       { email: 'user@test.email.org', roles: ['User'] },
     ];
@@ -19,9 +28,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
 
@@ -39,7 +48,7 @@ describe('Members', () => {
 
   it('supports sorting members', async () => {
     // Arrange
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: 'x_owner@test.email.org', roles: ['Owner'] },
       { email: 'user@test.email.org', roles: ['User'] },
     ];
@@ -51,9 +60,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
 
@@ -70,9 +79,17 @@ describe('Members', () => {
 
   it('supports adding a member for owners', async () => {
     // Arrange
-    const projectUsers = [{ email: 'owner@test.email.org', roles: ['Owner'] }];
+    const projectUsers: User[] = [{ email: 'owner@test.email.org', roles: ['Owner'] }];
     const user = userEvent.setup();
-    const addUserCallback = jest.fn();
+
+    const addProjectUser = jest.fn();
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Billing: { addProjectUser } as Partial<AjaxContract['Billing']>,
+      Workspaces: { getShareLog: jest.fn(() => Promise.resolve([])) },
+      Groups: { list: jest.fn(() => Promise.resolve([])) },
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    const userAddedCallback = jest.fn();
 
     // Act
     renderWithAppContexts(
@@ -80,22 +97,32 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={addUserCallback}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={userAddedCallback}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
+    // Open add user dialog
     const addUserButton = screen.getByText('Add User');
     await user.click(addUserButton);
+    // Both the combobox and the input field have the same label (which is not ideal, but already existing),
+    // so we need to select the second one.
+    const emailInput = screen.getAllByLabelText('User email *')[1];
+    await user.type(emailInput, 'test-user@company.com');
+    // Save button within the dialog, as opposed to the one that opened the dailog.
+    const saveButton = within(screen.getByRole('dialog')).getByText('Add User');
+    await user.click(saveButton);
 
     // Assert
-    expect(addUserCallback).toHaveBeenCalledWith(true);
+    expect(userAddedCallback).toHaveBeenCalled();
+    expect(addProjectUser).toHaveBeenCalledWith('test-project', ['User'], 'test-user@company.com');
+
     // The actual display of the dialog to add a user is done in the parent file.
   });
 
   it('does not show the Add User button for non-owners', async () => {
     // Arrange
-    const projectUsers = [{ email: 'owner@test.email.org', roles: ['Owner'] }];
+    const projectUsers: User[] = [{ email: 'owner@test.email.org', roles: ['Owner'] }];
 
     // Act
     renderWithAppContexts(
@@ -103,9 +130,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner={false}
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
 
@@ -116,7 +143,7 @@ describe('Members', () => {
   it('disables the action menu for an owner if there are not multiple owners', async () => {
     // Arrange
     const ownerEmail = 'owner@test.email.org';
-    const projectUsers = [{ email: ownerEmail, roles: ['Owner'] }];
+    const projectUsers: User[] = [{ email: ownerEmail, roles: ['Owner'] }];
 
     // Act
     renderWithAppContexts(
@@ -124,9 +151,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
 
@@ -137,9 +164,9 @@ describe('Members', () => {
   it('does not show an action menu if the user is not an owner', async () => {
     // Arrange
     const userEmail = 'user@test.email.org';
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: 'owner@test.email.org', roles: ['Owner'] },
-      { email: userEmail, roles: ['user'] },
+      { email: userEmail, roles: ['User'] },
     ];
 
     // Act
@@ -148,9 +175,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner={false}
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={jest.fn()}
       />
     );
 
@@ -161,12 +188,12 @@ describe('Members', () => {
   it('supports deleting an owner if there are multiple owners', async () => {
     // Arrange
     const ownerEmail = 'owner@test.email.org';
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: ownerEmail, roles: ['Owner'] },
       { email: 'owner2@test.email.org', roles: ['Owner'] },
     ];
     const user = userEvent.setup();
-    const deletingUserCallback = jest.fn();
+    const deleteUserCallback = jest.fn();
 
     // Act
     renderWithAppContexts(
@@ -174,9 +201,9 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={deletingUserCallback}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={deleteUserCallback}
       />
     );
     const menu = screen.getByLabelText(`Menu for User: ${ownerEmail}`);
@@ -184,20 +211,22 @@ describe('Members', () => {
     await user.click(menu);
     const removeButton = screen.getByText('Remove User');
     await user.click(removeButton);
+    // Confirm the remove
+    await user.click(screen.getByText('Remove'));
 
     // Assert
-    expect(deletingUserCallback).toHaveBeenCalledWith({ email: ownerEmail, roles: ['Owner'] });
+    expect(deleteUserCallback).toHaveBeenCalledWith({ email: ownerEmail, roles: ['Owner'] });
   });
 
   it('supports deleting a non-owner', async () => {
     // Arrange
     const userEmail = 'user@test.email.org';
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: 'owner@test.email.org', roles: ['Owner'] },
-      { email: userEmail, roles: ['user'] },
+      { email: userEmail, roles: ['User'] },
     ];
     const user = userEvent.setup();
-    const deletingUserCallback = jest.fn();
+    const deleteUserCallback = jest.fn();
 
     // Act
     renderWithAppContexts(
@@ -205,28 +234,35 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={jest.fn()}
-        setDeletingUser={deletingUserCallback}
+        userAdded={jest.fn()}
+        userEdited={jest.fn()}
+        deleteUser={deleteUserCallback}
       />
     );
     const menu = screen.getByLabelText(`Menu for User: ${userEmail}`);
     await user.click(menu);
     const removeButton = screen.getByText('Remove User');
     await user.click(removeButton);
+    // Confirm the remove
+    await user.click(screen.getByText('Remove'));
 
     // Assert
-    expect(deletingUserCallback).toHaveBeenCalledWith({ email: userEmail, roles: ['user'] });
+    expect(deleteUserCallback).toHaveBeenCalledWith({ email: userEmail, roles: ['User'] });
   });
 
   it('supports editing a non-owner', async () => {
     // Arrange
     const userEmail = 'user@test.email.org';
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: 'owner@test.email.org', roles: ['Owner'] },
-      { email: userEmail, roles: ['user'] },
+      { email: userEmail, roles: ['User'] },
     ];
     const user = userEvent.setup();
+    const changeUserRoles = jest.fn();
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Billing: { changeUserRoles } as Partial<AjaxContract['Billing']>,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
     const editingUserCallback = jest.fn();
 
     // Act
@@ -235,29 +271,40 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={editingUserCallback}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={editingUserCallback}
+        deleteUser={jest.fn()}
       />
     );
     const menu = screen.getByLabelText(`Menu for User: ${userEmail}`);
     await user.click(menu);
     const editButton = screen.getByText('Edit Role');
     await user.click(editButton);
+    // Toggle the checkbox
+    const changeRoleButton = screen.getByLabelText('Can manage users (Owner)');
+    await user.click(changeRoleButton);
+    // Save the change.
+    await user.click(screen.getByText('Change Role'));
 
     // Assert
-    expect(editingUserCallback).toHaveBeenCalledWith({ email: userEmail, roles: ['user'] });
+    expect(editingUserCallback).toHaveBeenCalled();
+    expect(changeUserRoles).toHaveBeenCalledWith('test-project', userEmail, ['User'], ['Owner']);
   });
 
   it('supports editing an owner if there are multiple owners', async () => {
     // Arrange
     const ownerEmail = 'owner@test.email.org';
-    const projectUsers = [
+    const projectUsers: User[] = [
       { email: ownerEmail, roles: ['Owner'] },
       { email: 'owner2@test.email.org', roles: ['Owner'] },
     ];
     const user = userEvent.setup();
-    const editingUserCallback = jest.fn();
+    const changeUserRoles = jest.fn();
+    const mockAjax: DeepPartial<AjaxContract> = {
+      Billing: { changeUserRoles } as Partial<AjaxContract['Billing']>,
+    };
+    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    const userEditedCallback = jest.fn();
 
     // Act
     renderWithAppContexts(
@@ -265,17 +312,23 @@ describe('Members', () => {
         billingProjectName='test-project'
         isOwner
         projectUsers={projectUsers}
-        setAddingUser={jest.fn()}
-        setEditingUser={editingUserCallback}
-        setDeletingUser={jest.fn()}
+        userAdded={jest.fn()}
+        userEdited={userEditedCallback}
+        deleteUser={jest.fn()}
       />
     );
     const menu = screen.getByLabelText(`Menu for User: ${ownerEmail}`);
     await user.click(menu);
     const editButton = screen.getByText('Edit Role');
     await user.click(editButton);
+    // Toggle the checkbox
+    const changeRoleButton = screen.getByLabelText('Can manage users (Owner)');
+    await user.click(changeRoleButton);
+    // Save the change.
+    await user.click(screen.getByText('Change Role'));
 
     // Assert
-    expect(editingUserCallback).toHaveBeenCalledWith({ email: ownerEmail, roles: ['Owner'] });
+    expect(userEditedCallback).toHaveBeenCalled();
+    expect(changeUserRoles).toHaveBeenCalledWith('test-project', ownerEmail, ['Owner'], ['User']);
   });
 });

--- a/src/billing/Members/Members.tsx
+++ b/src/billing/Members/Members.tsx
@@ -1,20 +1,35 @@
 import _ from 'lodash/fp';
 import React, { ReactNode, useState } from 'react';
 import { billingRoles } from 'src/billing/utils';
-import { MemberCard, MemberCardHeaders, NewUserCard, Sort, User } from 'src/components/group-common';
+import {
+  DeleteUserModal,
+  EditUserModal,
+  MemberCard,
+  MemberCardHeaders,
+  NewUserCard,
+  NewUserModal,
+  Sort,
+  User,
+} from 'src/components/group-common';
+import { Ajax } from 'src/libs/ajax';
+import { BillingRole } from 'src/libs/ajax/Billing';
 
 interface MembersProps {
   billingProjectName: string;
   isOwner: boolean;
   projectUsers: User[];
-  setAddingUser: (arg: boolean) => void;
-  setEditingUser: (arg: User) => void;
-  setDeletingUser: (arg: User) => void;
+  userAdded: () => void;
+  userEdited: () => void;
+  deleteUser: (arg: User) => void;
 }
 
 export const Members = (props: MembersProps): ReactNode => {
-  const { billingProjectName, isOwner, projectUsers, setAddingUser, setEditingUser, setDeletingUser } = props;
+  const { billingProjectName, isOwner, projectUsers, userEdited, deleteUser, userAdded } = props;
   const [sort, setSort] = useState<Sort>({ field: 'email', direction: 'asc' });
+  const [addingUser, setAddingUser] = useState(false);
+  const [editingUser, setEditingUser] = useState<User | false>(false);
+  const [deletingUser, setDeletingUser] = useState<User | false>(false);
+
   const projectHasMultipleOwners =
     _.filter(({ roles }) => _.includes(billingRoles.owner, roles), projectUsers).length > 1;
 
@@ -43,6 +58,49 @@ export const Members = (props: MembersProps): ReactNode => {
           )}
         </div>
       </div>
+      {addingUser && (
+        <NewUserModal
+          adminLabel={billingRoles.owner}
+          userLabel={billingRoles.user}
+          title='Add user to Billing Project'
+          footer={[
+            'Warning: Adding any user to this project will mean they can incur costs to the billing associated with this project.',
+          ]}
+          addFunction={(roles: BillingRole[], email: string) =>
+            Ajax().Billing.addProjectUser(billingProjectName, roles, email)
+          }
+          onDismiss={() => setAddingUser(false)}
+          onSuccess={() => {
+            setAddingUser(false);
+            userAdded();
+          }}
+        />
+      )}
+      {!!editingUser && (
+        <EditUserModal
+          adminLabel={billingRoles.owner}
+          userLabel={billingRoles.user}
+          user={editingUser}
+          saveFunction={(email: string, roles: BillingRole[], newRoles: BillingRole[]) =>
+            Ajax().Billing.changeUserRoles(billingProjectName, email, roles, newRoles)
+          }
+          onDismiss={() => setEditingUser(false)}
+          onSuccess={() => {
+            setEditingUser(false);
+            userEdited();
+          }}
+        />
+      )}
+      {!!deletingUser && (
+        <DeleteUserModal
+          userEmail={deletingUser.email}
+          onDismiss={() => setDeletingUser(false)}
+          onSubmit={() => {
+            deleteUser(deletingUser);
+            setDeletingUser(false);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/billing/Members/Members.tsx
+++ b/src/billing/Members/Members.tsx
@@ -66,8 +66,8 @@ export const Members = (props: MembersProps): ReactNode => {
           footer={[
             'Warning: Adding any user to this project will mean they can incur costs to the billing associated with this project.',
           ]}
-          addFunction={(roles: BillingRole[], email: string) =>
-            Ajax().Billing.addProjectUser(billingProjectName, roles, email)
+          addFunction={(roles: string[], email: string) =>
+            Ajax().Billing.addProjectUser(billingProjectName, roles as BillingRole[], email)
           }
           onDismiss={() => setAddingUser(false)}
           onSuccess={() => {
@@ -81,8 +81,8 @@ export const Members = (props: MembersProps): ReactNode => {
           adminLabel={billingRoles.owner}
           userLabel={billingRoles.user}
           user={editingUser}
-          saveFunction={(email: string, roles: BillingRole[], newRoles: BillingRole[]) =>
-            Ajax().Billing.changeUserRoles(billingProjectName, email, roles, newRoles)
+          saveFunction={(email: string, roles: string[], newRoles: string[]) =>
+            Ajax().Billing.changeUserRoles(billingProjectName, email, roles as BillingRole[], newRoles as BillingRole[])
           }
           onDismiss={() => setEditingUser(false)}
           onSuccess={() => {

--- a/src/components/group-common.ts
+++ b/src/components/group-common.ts
@@ -10,6 +10,7 @@ import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
+import { BillingRole } from 'src/libs/ajax/Billing';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';
@@ -125,7 +126,7 @@ export const MemberCardHeaders: React.FC<MemberCardHeadersProps> = memoWithName(
 
 export interface User {
   email: string;
-  roles: string[];
+  roles: BillingRole[];
 }
 
 interface MemberCardProps {
@@ -189,7 +190,7 @@ export const MemberCard: React.FC<MemberCardProps> = memoWithName('MemberCard', 
 });
 
 interface NewUserModalProps {
-  addFunction: (roles: string[], email: string) => Promise<void>;
+  addFunction: (roles: BillingRole[], email: string) => Promise<void>;
   addUnregisteredUser?: boolean;
   adminLabel: string;
   userLabel: string;
@@ -358,7 +359,7 @@ interface EditUserModalProps {
   user: User;
   onSuccess: () => void;
   onDismiss: () => void;
-  saveFunction: (email: string, roles: string[], newRoles: string[]) => Promise<void>;
+  saveFunction: (email: string, roles: BillingRole[], newRoles: BillingRole[]) => void;
 }
 export const EditUserModal = (props: EditUserModalProps) => {
   const {

--- a/src/components/group-common.ts
+++ b/src/components/group-common.ts
@@ -10,7 +10,6 @@ import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
 import { Ajax } from 'src/libs/ajax';
-import { BillingRole } from 'src/libs/ajax/Billing';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import { FormLabel } from 'src/libs/forms';
@@ -126,7 +125,7 @@ export const MemberCardHeaders: React.FC<MemberCardHeadersProps> = memoWithName(
 
 export interface User {
   email: string;
-  roles: BillingRole[];
+  roles: string[]; // In practice will be BillingRole or GroupRole
 }
 
 interface MemberCardProps {
@@ -190,7 +189,7 @@ export const MemberCard: React.FC<MemberCardProps> = memoWithName('MemberCard', 
 });
 
 interface NewUserModalProps {
-  addFunction: (roles: BillingRole[], email: string) => Promise<void>;
+  addFunction: (roles: string[], email: string) => Promise<void>;
   addUnregisteredUser?: boolean;
   adminLabel: string;
   userLabel: string;
@@ -213,7 +212,7 @@ export const NewUserModal = (props: NewUserModalProps) => {
   const [userEmail, setUserEmail] = useState('');
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [confirmAddUser, setConfirmAddUser] = useState(false);
-  const [roles, setRoles] = useState([userLabel]);
+  const [roles, setRoles] = useState<string[]>([userLabel]);
   const [submitError, setSubmitError] = useState(undefined);
   const [busy, setBusy] = useState(false);
 
@@ -359,7 +358,7 @@ interface EditUserModalProps {
   user: User;
   onSuccess: () => void;
   onDismiss: () => void;
-  saveFunction: (email: string, roles: BillingRole[], newRoles: BillingRole[]) => void;
+  saveFunction: (email: string, roles: string[], newRoles: string[]) => Promise<void | void[]>;
 }
 export const EditUserModal = (props: EditUserModalProps) => {
   const {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1800

Moves the state variables and display of the 3 modals related to billing project members into `Members.tsx`. This simplifies testing when they are displayed and their callbacks.

For manual testing, make sure you can add a user, change the user's role, and delete the user.
<img width="554" alt="image" src="https://github.com/user-attachments/assets/3d63d7fb-3880-4ef1-ae92-debfca85d572">
<img width="568" alt="image" src="https://github.com/user-attachments/assets/d9dff981-aff1-47a4-a169-c1b19a8db9bf">
<img width="561" alt="image" src="https://github.com/user-attachments/assets/d3393317-565a-47f4-8b7f-6d17771af2e6">
