### PR TITLE
[DC-1214][DC-1223] Add text and move loading to be with the header text

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -1,8 +1,8 @@
-import { useLoadedData } from '@terra-ui-packages/components';
+import { Spinner, useLoadedData } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { Fragment, useEffect, useState } from 'react';
 import { div, h, h2, strong } from 'react-hyperscript-helpers';
-import { LabeledCheckbox, Link, spinnerOverlay } from 'src/components/common';
+import { LabeledCheckbox, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { TextInput, withDebouncedChange } from 'src/components/input';
 import { SimpleTable } from 'src/components/table';
@@ -43,6 +43,9 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
   const [cart, setCart] = useState<Concept[]>(initialCart);
   const [concepts, enumerateConcepts] = useLoadedData<SnapshotBuilderConceptsResponse>();
 
+  const conceptsReady = concepts.status === 'Ready';
+  const conceptsLength = conceptsReady && concepts.state.result.length;
+
   useEffect(() => {
     if (searchText.length === 0 || searchText.length > 2) {
       void enumerateConcepts(
@@ -54,6 +57,19 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
   }, [searchText, snapshotId, domainOption.root, enumerateConcepts]);
   const tableLeftPadding = { paddingLeft: '2rem' };
   const iconSize = 18;
+
+  const conceptTableTextForSearch = `${conceptsReady && conceptsLength === 0 ? 'No ' : ''}Results for ${searchText}`;
+
+  const conceptTableTextForNoSearch = conceptsReady
+    ? `Top ${conceptsLength} results for ${domainOption.name}`
+    : 'Loading data table';
+
+  const conceptTableText = () => {
+    return div({ style: { display: 'flex', alignItems: 'center', padding: '2rem 0 0 2rem', fontWeight: 800 } }, [
+      searchText.length > 2 ? conceptTableTextForSearch : conceptTableTextForNoSearch,
+      ...(conceptsReady ? [] : [h(Spinner, { size: 20, style: { marginLeft: '1rem' } })]),
+    ]);
+  };
 
   return h(Fragment, [
     h(BuilderPageHeader, [
@@ -91,68 +107,68 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
           style: { position: 'absolute', left: 15, top: '50%', marginTop: -(iconSize / 2) },
         }),
       ]),
-      concepts.status === 'Ready'
-        ? h(SimpleTable, {
-            'aria-label': 'concept search results',
-            underRowKey: 'underRow',
-            rowStyle: {
-              backgroundColor: 'white',
-              ...tableLeftPadding,
-              paddingRight: '2rem',
-            },
-            headerRowStyle: {
-              ...tableHeaderStyle,
-              ...tableLeftPadding,
-              paddingRight: '2rem',
-              marginTop: '1rem',
-            },
-            cellStyle: {
-              paddingTop: 13,
-              paddingBottom: 13,
-            },
-            columns: [
-              { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
-              { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
-              { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
-              { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
-              { key: 'hierarchy', size: { grow: 0.4 } },
-            ],
-            rows: _.map((concept) => {
-              return {
-                name: div({ style: { display: 'flex' } }, [
-                  h(
-                    LabeledCheckbox,
-                    {
-                      style: { paddingRight: 22, marginTop: 1 },
-                      checked: _.contains(concept, cart),
-                      onChange: () => setCart(_.xor(cart, [concept])),
-                    },
-                    [
-                      h(HighlightConceptName, {
-                        conceptName: concept.name,
-                        searchFilter: searchText,
-                      }),
-                    ]
-                  ),
-                ]),
-                id: concept.id,
-                code: concept.code,
-                count: formatCount(concept.count),
-                hierarchy: div({ style: { display: 'flex' } }, [
-                  h(
-                    Link,
-                    {
-                      'aria-label': `open hierarchy ${concept.id}`,
-                      onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
-                    },
-                    [icon('view-list')]
-                  ),
-                  div({ style: { marginLeft: 5 } }, ['Hierarchy']),
-                ]),
-              };
-            }, concepts.state.result),
-          })
-        : spinnerOverlay,
+      conceptTableText(),
+      conceptsReady &&
+        h(SimpleTable, {
+          'aria-label': 'concept search results',
+          underRowKey: 'underRow',
+          rowStyle: {
+            backgroundColor: 'white',
+            ...tableLeftPadding,
+            paddingRight: '2rem',
+          },
+          headerRowStyle: {
+            ...tableHeaderStyle,
+            ...tableLeftPadding,
+            paddingRight: '2rem',
+            marginTop: '1rem',
+          },
+          cellStyle: {
+            paddingTop: 13,
+            paddingBottom: 13,
+          },
+          columns: [
+            { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
+            { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
+            { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
+            { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
+            { key: 'hierarchy', size: { grow: 0.4 } },
+          ],
+          rows: _.map((concept) => {
+            return {
+              name: div({ style: { display: 'flex' } }, [
+                h(
+                  LabeledCheckbox,
+                  {
+                    style: { paddingRight: 22, marginTop: 1 },
+                    checked: _.contains(concept, cart),
+                    onChange: () => setCart(_.xor(cart, [concept])),
+                  },
+                  [
+                    h(HighlightConceptName, {
+                      conceptName: concept.name,
+                      searchFilter: searchText,
+                    }),
+                  ]
+                ),
+              ]),
+              id: concept.id,
+              code: concept.code,
+              count: formatCount(concept.count),
+              hierarchy: div({ style: { display: 'flex' } }, [
+                h(
+                  Link,
+                  {
+                    'aria-label': `open hierarchy ${concept.id}`,
+                    onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
+                  },
+                  [icon('view-list')]
+                ),
+                div({ style: { marginLeft: 5 } }, ['Hierarchy']),
+              ]),
+            };
+          }, concepts.state.result),
+        }),
     ]),
     h(ConceptCart, { actionText, cart, onCommit }),
   ]);

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -144,40 +144,43 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
           { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
           { key: 'hierarchy', size: { grow: 0.4 } },
         ],
-        rows: _.map((concept) => {
-          return {
-            name: div({ style: { display: 'flex' } }, [
-              h(
-                LabeledCheckbox,
-                {
-                  style: { paddingRight: 22, marginTop: 1 },
-                  checked: _.contains(concept, cart),
-                  onChange: () => setCart(_.xor(cart, [concept])),
-                },
-                [
-                  h(HighlightConceptName, {
-                    conceptName: concept.name,
-                    searchFilter: searchText,
-                  }),
-                ]
-              ),
-            ]),
-            id: concept.id,
-            code: concept.code,
-            count: formatCount(concept.count),
-            hierarchy: div({ style: { display: 'flex' } }, [
-              h(
-                Link,
-                {
-                  'aria-label': `open hierarchy ${concept.id}`,
-                  onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
-                },
-                [icon('view-list')]
-              ),
-              div({ style: { marginLeft: 5 } }, ['Hierarchy']),
-            ]),
-          };
-        }, concepts?.state?.result || []),
+        rows: _.map(
+          (concept) => {
+            return {
+              name: div({ style: { display: 'flex' } }, [
+                h(
+                  LabeledCheckbox,
+                  {
+                    style: { paddingRight: 22, marginTop: 1 },
+                    checked: _.contains(concept, cart),
+                    onChange: () => setCart(_.xor(cart, [concept])),
+                  },
+                  [
+                    h(HighlightConceptName, {
+                      conceptName: concept.name,
+                      searchFilter: searchText,
+                    }),
+                  ]
+                ),
+              ]),
+              id: concept.id,
+              code: concept.code,
+              count: formatCount(concept.count),
+              hierarchy: div({ style: { display: 'flex' } }, [
+                h(
+                  Link,
+                  {
+                    'aria-label': `open hierarchy ${concept.id}`,
+                    onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
+                  },
+                  [icon('view-list')]
+                ),
+                div({ style: { marginLeft: 5 } }, ['Hierarchy']),
+              ]),
+            };
+          },
+          conceptsReady ? concepts.state.result : []
+        ),
       }),
     ]),
     h(ConceptCart, { actionText, cart, onCommit }),

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -65,10 +65,21 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
     : 'Loading data table';
 
   const conceptTableText = () => {
-    return div({ style: { display: 'flex', alignItems: 'center', padding: '2rem 0 0 2rem', fontWeight: 800 } }, [
-      searchText.length > 2 ? conceptTableTextForSearch : conceptTableTextForNoSearch,
-      ...(conceptsReady ? [] : [h(Spinner, { size: 20, style: { marginLeft: '1rem' } })]),
-    ]);
+    return div(
+      {
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          padding: '2rem 0 0 2rem',
+          fontWeight: 800,
+          height: '3.5rem',
+        },
+      },
+      [
+        searchText.length > 2 ? conceptTableTextForSearch : conceptTableTextForNoSearch,
+        ...(conceptsReady ? [] : [h(Spinner, { size: 20, style: { marginLeft: '1rem' } })]),
+      ]
+    );
   };
 
   return h(Fragment, [
@@ -108,67 +119,66 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
         }),
       ]),
       conceptTableText(),
-      conceptsReady &&
-        h(SimpleTable, {
-          'aria-label': 'concept search results',
-          underRowKey: 'underRow',
-          rowStyle: {
-            backgroundColor: 'white',
-            ...tableLeftPadding,
-            paddingRight: '2rem',
-          },
-          headerRowStyle: {
-            ...tableHeaderStyle,
-            ...tableLeftPadding,
-            paddingRight: '2rem',
-            marginTop: '1rem',
-          },
-          cellStyle: {
-            paddingTop: 13,
-            paddingBottom: 13,
-          },
-          columns: [
-            { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
-            { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
-            { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
-            { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
-            { key: 'hierarchy', size: { grow: 0.4 } },
-          ],
-          rows: _.map((concept) => {
-            return {
-              name: div({ style: { display: 'flex' } }, [
-                h(
-                  LabeledCheckbox,
-                  {
-                    style: { paddingRight: 22, marginTop: 1 },
-                    checked: _.contains(concept, cart),
-                    onChange: () => setCart(_.xor(cart, [concept])),
-                  },
-                  [
-                    h(HighlightConceptName, {
-                      conceptName: concept.name,
-                      searchFilter: searchText,
-                    }),
-                  ]
-                ),
-              ]),
-              id: concept.id,
-              code: concept.code,
-              count: formatCount(concept.count),
-              hierarchy: div({ style: { display: 'flex' } }, [
-                h(
-                  Link,
-                  {
-                    'aria-label': `open hierarchy ${concept.id}`,
-                    onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
-                  },
-                  [icon('view-list')]
-                ),
-                div({ style: { marginLeft: 5 } }, ['Hierarchy']),
-              ]),
-            };
-          }, concepts.state.result),
-        }),
+      h(SimpleTable, {
+        'aria-label': 'concept search results',
+        underRowKey: 'underRow',
+        rowStyle: {
+          backgroundColor: 'white',
+          ...tableLeftPadding,
+          paddingRight: '2rem',
+        },
+        headerRowStyle: {
+          ...tableHeaderStyle,
+          ...tableLeftPadding,
+          paddingRight: '2rem',
+          marginTop: '1rem',
+        },
+        cellStyle: {
+          paddingTop: 13,
+          paddingBottom: 13,
+        },
+        columns: [
+          { header: strong(['Concept name']), key: 'name', size: { grow: 2.3 } },
+          { header: strong(['Concept ID']), key: 'id', size: { grow: 0.5 } },
+          { header: strong(['Code']), key: 'code', size: { grow: 0.75 } },
+          { header: strong(['# Participants']), key: 'count', size: { grow: 0.5 } },
+          { key: 'hierarchy', size: { grow: 0.4 } },
+        ],
+        rows: _.map((concept) => {
+          return {
+            name: div({ style: { display: 'flex' } }, [
+              h(
+                LabeledCheckbox,
+                {
+                  style: { paddingRight: 22, marginTop: 1 },
+                  checked: _.contains(concept, cart),
+                  onChange: () => setCart(_.xor(cart, [concept])),
+                },
+                [
+                  h(HighlightConceptName, {
+                    conceptName: concept.name,
+                    searchFilter: searchText,
+                  }),
+                ]
+              ),
+            ]),
+            id: concept.id,
+            code: concept.code,
+            count: formatCount(concept.count),
+            hierarchy: div({ style: { display: 'flex' } }, [
+              h(
+                Link,
+                {
+                  'aria-label': `open hierarchy ${concept.id}`,
+                  onClick: () => onOpenHierarchy(domainOption, cart, searchText, concept),
+                },
+                [icon('view-list')]
+              ),
+              div({ style: { marginLeft: 5 } }, ['Hierarchy']),
+            ]),
+          };
+        }, concepts.state?.result || []),
+      }),
     ]),
     h(ConceptCart, { actionText, cart, onCommit }),
   ]);

--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -177,7 +177,7 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
               div({ style: { marginLeft: 5 } }, ['Hierarchy']),
             ]),
           };
-        }, concepts.state?.result || []),
+        }, concepts?.state?.result || []),
       }),
     ]),
     h(ConceptCart, { actionText, cart, onCommit }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-1214
### Jira Ticket: https://broadworkbench.atlassian.net/browse/dc-1223

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Adds a header above the ConceptSearch table and moves the loading spinner to the that header





### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
