### PR TITLE
UIE-190 Auth Fetch Breakout part-4

### DIFF
--- a/src/auth/auth-fetch.test.ts
+++ b/src/auth/auth-fetch.test.ts
@@ -3,7 +3,8 @@ import { asMockedFn } from 'src/testing/test-utils';
 
 import { getAuthToken, getAuthTokenFromLocalStorage, loadAuthToken } from './auth';
 import { sessionExpirationErrorMessage } from './auth-errors';
-import { authOpts, withRetryAfterReloadingExpiredAuthToken } from './auth-fetch';
+import { withRetryAfterReloadingExpiredAuthToken } from './auth-fetch';
+import { authOpts } from './auth-session';
 import { signOut } from './signout/sign-out';
 
 let mockOidcUser: OidcUser;

--- a/src/auth/auth-fetch.ts
+++ b/src/auth/auth-fetch.ts
@@ -6,10 +6,6 @@ import { sessionExpirationErrorMessage } from './auth-errors';
 import { authOpts } from './auth-session';
 import { signOut, SignOutCause } from './signout/sign-out';
 
-//
-// Auth mechanics for use on typical auth-session scoped application data requests.
-//
-
 const isUnauthorizedResponse = (error: unknown): boolean => error instanceof Response && error.status === 401;
 
 const createRequestWithStoredAuthToken = async (

--- a/src/auth/auth-fetch.ts
+++ b/src/auth/auth-fetch.ts
@@ -3,19 +3,12 @@ import _ from 'lodash/fp';
 
 import { AuthTokenState, getAuthToken, getAuthTokenFromLocalStorage, loadAuthToken, sendRetryMetric } from './auth';
 import { sessionExpirationErrorMessage } from './auth-errors';
+import { authOpts } from './auth-session';
 import { signOut, SignOutCause } from './signout/sign-out';
 
 //
 // Auth mechanics for use on typical auth-session scoped application data requests.
 //
-
-export const authOpts = (token = getAuthToken()) => ({ headers: { Authorization: `Bearer ${token}` } });
-
-export const withAuthSession =
-  (wrappedFetch: FetchFn): FetchFn =>
-  (url, options) => {
-    return wrappedFetch(url, _.merge(options, authOpts()));
-  };
 
 const isUnauthorizedResponse = (error: unknown): boolean => error instanceof Response && error.status === 401;
 

--- a/src/auth/auth-session.ts
+++ b/src/auth/auth-session.ts
@@ -1,0 +1,15 @@
+import { FetchFn } from '@terra-ui-packages/data-client-core';
+import _ from 'lodash/fp';
+
+import { getAuthToken } from './auth';
+
+//
+// Auth mechanics for use on typical auth-session scoped application data requests.
+//
+export const authOpts = (token = getAuthToken()) => ({ headers: { Authorization: `Bearer ${token}` } });
+
+export const withAuthSession =
+  (wrappedFetch: FetchFn): FetchFn =>
+  (url, options) => {
+    return wrappedFetch(url, _.merge(options, authOpts()));
+  };

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,7 +1,7 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { appIdentifier, fetchAgora, fetchDrsHub, fetchGoogleForms, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { Billing } from 'src/libs/ajax/Billing';

--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -2,7 +2,7 @@ import _ from 'lodash/fp';
 import { AnalysisFile, AnalysisFileMetadata } from 'src/analysis/useAnalysisFiles';
 import { AbsolutePath, getDisplayName, getExtension, getFileName } from 'src/analysis/utils/file-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { Ajax } from 'src/libs/ajax';
 import { fetchWorkspaceManager } from 'src/libs/ajax/ajax-common';
 import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';

--- a/src/libs/ajax/Billing.ts
+++ b/src/libs/ajax/Billing.ts
@@ -1,7 +1,7 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchBillingProfileManager, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { WorkspacePolicy } from 'src/workspaces/utils';
 

--- a/src/libs/ajax/Catalog.ts
+++ b/src/libs/ajax/Catalog.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import * as _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchCatalog } from 'src/libs/ajax/ajax-common';
 
 // Types are pulled from https://github.com/DataBiosphere/terra-data-catalog/blob/main/common/src/main/resources/schema/development/schema.json

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import * as _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchDataRepo } from 'src/libs/ajax/ajax-common';
 
 /** API types represent the data of UI types in the format expected by the backend.

--- a/src/libs/ajax/ExternalCredentials.ts
+++ b/src/libs/ajax/ExternalCredentials.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import * as qs from 'qs';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchEcm } from 'src/libs/ajax/ajax-common';
 import { OAuth2Provider } from 'src/profile/external-identities/OAuth2Providers';
 

--- a/src/libs/ajax/GoogleStorage.ts
+++ b/src/libs/ajax/GoogleStorage.ts
@@ -10,7 +10,7 @@ import {
   ToolLabel,
 } from 'src/analysis/utils/tool-utils';
 import { getAuthToken } from 'src/auth/auth';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { checkRequesterPaysError, fetchSam } from 'src/libs/ajax/ajax-common';
 import { canUseWorkspaceProject } from 'src/libs/ajax/Billing';
 import { fetchOk, withMaybeRetry, withUrlPrefix } from 'src/libs/ajax/fetch/fetch-core';

--- a/src/libs/ajax/Groups.ts
+++ b/src/libs/ajax/Groups.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchSam } from 'src/libs/ajax/ajax-common';
 import { SupportSummary } from 'src/support/SupportResourceType';
 

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -2,7 +2,7 @@ import { getDefaultProperties } from '@databiosphere/bard-client';
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import { ensureAuthSettled } from 'src/auth/auth';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchBard } from 'src/libs/ajax/fetch/fetchBard';
 import { getConfig } from 'src/libs/config';
 import { withErrorIgnoring } from 'src/libs/error';

--- a/src/libs/ajax/SamResources.ts
+++ b/src/libs/ajax/SamResources.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { Ajax } from 'src/libs/ajax';
 import { appIdentifier, fetchSam } from 'src/libs/ajax/ajax-common';
 

--- a/src/libs/ajax/TermsOfService.ts
+++ b/src/libs/ajax/TermsOfService.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchSam } from 'src/libs/ajax/ajax-common';
 
 export interface SamUserTermsOfServiceDetails {

--- a/src/libs/ajax/User.test.ts
+++ b/src/libs/ajax/User.test.ts
@@ -11,7 +11,6 @@ type AuthFetchExports = typeof import('src/auth/auth-fetch');
 jest.mock(
   'src/auth/auth-fetch',
   (): Partial<AuthFetchExports> => ({
-    authOpts: jest.fn().mockReturnValue({ headers: { Authorization: 'testToken' } }),
     withRetryAfterReloadingExpiredAuthToken: jest.fn().mockImplementation((fn) => fn),
   })
 );

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchOrchestration, fetchSam } from 'src/libs/ajax/ajax-common';
 import { SamUserTermsOfServiceDetails } from 'src/libs/ajax/TermsOfService';
 import { TerraUserProfile } from 'src/libs/state';

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -1,6 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchWDS } from 'src/libs/ajax/ajax-common';
 import {
   RecordQueryResponse,

--- a/src/libs/ajax/WorkspaceManagerResources.ts
+++ b/src/libs/ajax/WorkspaceManagerResources.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchWorkspaceManager } from 'src/libs/ajax/ajax-common';
 
 export const WorkspaceManagerResources = (signal) => ({

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -3,7 +3,7 @@ import { LeoResourceLabels } from '@terra-ui-packages/leonardo-data-client';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { AppAccessScope, AppToolLabel } from 'src/analysis/utils/tool-utils';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { appIdentifier, fetchLeo } from 'src/libs/ajax/ajax-common';
 import { CreateAppV1Request, GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 

--- a/src/libs/ajax/leonardo/Disks.test.ts
+++ b/src/libs/ajax/leonardo/Disks.test.ts
@@ -1,6 +1,6 @@
 import { FetchFn } from '@terra-ui-packages/data-client-core';
 import { azureDisk, galaxyDisk, undecoratePd } from 'src/analysis/_testData/testData';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchLeo } from 'src/libs/ajax/ajax-common';
 import { Disks } from 'src/libs/ajax/leonardo/Disks';
 import { asMockedFn } from 'src/testing/test-utils';
@@ -28,11 +28,11 @@ jest.mock('src/libs/ajax/ajax-common', (): Partial<AjaxCommonExports> => {
   return mocks;
 });
 
-type AuthFetchExports = typeof import('src/auth/auth-fetch');
-jest.mock('src/auth/auth-fetch', (): AuthFetchExports => {
+type AuthSessionExports = typeof import('src/auth/auth-session');
+jest.mock('src/auth/auth-session', (): AuthSessionExports => {
   const { asMockedFn } = jest.requireActual<TestUtilsExports>('src/testing/test-utils');
-  const mocks: AuthFetchExports = {
-    ...jest.requireActual<AuthFetchExports>('src/auth/auth-fetch'),
+  const mocks: AuthSessionExports = {
+    ...jest.requireActual<AuthSessionExports>('src/auth/auth-session'),
     authOpts: jest.fn(),
     withAuthSession: jest.fn(),
   };

--- a/src/libs/ajax/leonardo/Disks.ts
+++ b/src/libs/ajax/leonardo/Disks.ts
@@ -3,7 +3,7 @@ import {
   makeLeoDisksV1DataClient,
   makeLeoDisksV2DataClient,
 } from '@terra-ui-packages/leonardo-data-client';
-import { withAuthSession } from 'src/auth/auth-fetch';
+import { withAuthSession } from 'src/auth/auth-session';
 import { fetchLeo, withAppIdentifier } from 'src/libs/ajax/ajax-common';
 
 export const Disks = makeDisksHelper({

--- a/src/libs/ajax/leonardo/Runtimes.test.ts
+++ b/src/libs/ajax/leonardo/Runtimes.test.ts
@@ -1,5 +1,5 @@
 import { FetchFn } from '@terra-ui-packages/data-client-core';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchLeo } from 'src/libs/ajax/ajax-common';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { asMockedFn } from 'src/testing/test-utils';
@@ -25,12 +25,12 @@ jest.mock('src/libs/ajax/ajax-common', (): Partial<AjaxCommonExports> => {
   return mocks;
 });
 
-type AuthFetchExports = typeof import('src/auth/auth-fetch');
-jest.mock('src/auth/auth-fetch', (): AuthFetchExports => {
+type AuthSessionExports = typeof import('src/auth/auth-session');
+jest.mock('src/auth/auth-session', (): AuthSessionExports => {
   const { asMockedFn } = jest.requireActual<TestUtilsExports>('src/testing/test-utils');
 
-  const mocks: AuthFetchExports = {
-    ...jest.requireActual<AuthFetchExports>('src/auth/auth-fetch'),
+  const mocks: AuthSessionExports = {
+    ...jest.requireActual<AuthSessionExports>('src/auth/auth-session'),
     authOpts: jest.fn(),
     withAuthSession: jest.fn(),
   };

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -2,7 +2,7 @@ import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { version } from 'src/analysis/utils/gce-machines';
-import { authOpts, withAuthSession } from 'src/auth/auth-fetch';
+import { authOpts, withAuthSession } from 'src/auth/auth-session';
 import { appIdentifier, fetchLeo, withAppIdentifier } from 'src/libs/ajax/ajax-common';
 import { fetchOk, withRetry } from 'src/libs/ajax/fetch/fetch-core';
 import { LeoRuntimesV1DataClient, makeLeoRuntimesV1DataClient } from 'src/libs/ajax/leonardo/LeoRuntimesV1DataClient';

--- a/src/libs/ajax/workflows-app/Cbas.js
+++ b/src/libs/ajax/workflows-app/Cbas.js
@@ -1,7 +1,7 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import qs from 'qs';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchFromProxy } from 'src/libs/ajax/ajax-common';
 
 export const Cbas = (signal) => ({

--- a/src/libs/ajax/workflows-app/CbasPact.test.js
+++ b/src/libs/ajax/workflows-app/CbasPact.test.js
@@ -23,8 +23,8 @@ jest.mock('src/libs/ajax/fetch/fetch-core', () => ({
   fetchOk: jest.fn(),
 }));
 
-jest.mock('src/auth/auth-fetch', () => ({
-  ...jest.requireActual('src/auth/auth-fetch'),
+jest.mock('src/auth/auth-session', () => ({
+  ...jest.requireActual('src/auth/auth-session'),
   authOpts: jest.fn(),
 }));
 

--- a/src/libs/ajax/workflows-app/CromwellApp.js
+++ b/src/libs/ajax/workflows-app/CromwellApp.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import qs from 'qs';
-import { authOpts } from 'src/auth/auth-fetch';
+import { authOpts } from 'src/auth/auth-session';
 import { fetchFromProxy } from 'src/libs/ajax/ajax-common';
 
 export const CromwellApp = (signal) => ({


### PR DESCRIPTION
 - finished move of authOpts and withAuthSession references to now come from auth-session.ts module.
 - removed pass-thru exports for these in auth-fetch.ts and switched over import and mock references as needed.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
