### PR TITLE
[WOR-1800] Conversion of Project.js to TSX with test

### DIFF
--- a/src/billing/BillingAccount/BillingAccountControls.test.tsx
+++ b/src/billing/BillingAccount/BillingAccountControls.test.tsx
@@ -162,7 +162,7 @@ describe('BillingAccountControls', () => {
     }: {
       billingAccounts: Record<string, GoogleBillingAccount>;
       billingProject: GCPBillingProject;
-      reloadBillingProject: () => void;
+      reloadBillingProject: () => Promise<void>;
     }): ReactNode => {
       const [showBillingModal, setShowBillingModal] = useState<boolean>(false);
 

--- a/src/billing/BillingAccount/BillingAccountControls.test.tsx
+++ b/src/billing/BillingAccount/BillingAccountControls.test.tsx
@@ -162,7 +162,7 @@ describe('BillingAccountControls', () => {
     }: {
       billingAccounts: Record<string, GoogleBillingAccount>;
       billingProject: GCPBillingProject;
-      reloadBillingProject: () => Promise<void>;
+      reloadBillingProject: () => Promise<unknown>;
     }): ReactNode => {
       const [showBillingModal, setShowBillingModal] = useState<boolean>(false);
 

--- a/src/billing/BillingAccount/BillingAccountControls.tsx
+++ b/src/billing/BillingAccount/BillingAccountControls.tsx
@@ -23,7 +23,7 @@ interface BillingAccountControlsProps {
   isOwner: boolean;
   getShowBillingModal: () => boolean;
   setShowBillingModal: (v: boolean) => void;
-  reloadBillingProject: () => void;
+  reloadBillingProject: () => Promise<unknown>;
   setUpdating: (v: boolean) => void;
 }
 export const BillingAccountControls = (props: BillingAccountControlsProps) => {

--- a/src/billing/BillingAccount/BillingAccountSummary.tsx
+++ b/src/billing/BillingAccount/BillingAccountSummary.tsx
@@ -5,7 +5,7 @@ import colors from 'src/libs/colors';
 import { contactUsActive } from 'src/libs/state';
 import { topBarHeight } from 'src/libs/style';
 
-interface BillingAccountSummaryProps {
+export interface BillingAccountSummaryProps {
   done: number;
   error: number;
   updating: number;

--- a/src/billing/List/BillingList.ts
+++ b/src/billing/List/BillingList.ts
@@ -286,11 +286,13 @@ export const BillingList = (props: BillingListProps) => {
               const billingProject = _.find({ projectName: selectedName }, billingProjects);
               return h(ProjectDetail, {
                 key: selectedName,
+                // We know from the condition that the billingProject does exist.
+                // @ts-ignore
                 billingProject,
                 billingAccounts,
                 authorizeAndLoadAccounts,
                 reloadBillingProject: () => reloadBillingProject(billingProject).catch(loadProjects),
-                isOwner: _.find({ projectName: selectedName }, projectsOwned),
+                isOwner: _.some({ projectName: selectedName }, projectsOwned),
                 workspaces: allWorkspaces,
                 refreshWorkspaces,
               });

--- a/src/billing/Project.test.tsx
+++ b/src/billing/Project.test.tsx
@@ -1,0 +1,412 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { act, screen } from '@testing-library/react';
+import React from 'react';
+import Project, { groupByBillingAccountStatus } from 'src/billing/Project';
+import { Ajax } from 'src/libs/ajax';
+import { GCPBillingProject, GoogleBillingAccount } from 'src/libs/ajax/Billing';
+import { azureBillingProject, gcpBillingProject } from 'src/testing/billing-project-fixtures';
+import { renderWithAppContexts } from 'src/testing/test-utils';
+import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+type AjaxContract = ReturnType<typeof Ajax>;
+jest.mock('src/libs/ajax');
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    getLink: jest.fn(() => '/'),
+    goToPath: jest.fn(),
+    useRoute: jest.fn().mockReturnValue({ query: {} }),
+    updateSearch: jest.fn(),
+  })
+);
+
+describe('groupByBillingAccountStatus', () => {
+  it('returns an empty mapping if there are no workspaces', () => {
+    // Act
+    const result = groupByBillingAccountStatus(gcpBillingProject, []);
+
+    // Assert
+    expect(result).toEqual({});
+  });
+
+  it('groups Azure workspaces as done', () => {
+    // Act
+    const result = groupByBillingAccountStatus(azureBillingProject, [defaultAzureWorkspace.workspace]);
+
+    // Assert
+    expect(result).toEqual({ done: new Set([defaultAzureWorkspace.workspace]) });
+  });
+
+  it('groups workspaces with matching billing account as done', () => {
+    // Arrange
+    const testBillingAccount: GoogleBillingAccount = {
+      accountName: defaultGoogleWorkspace.workspace.billingAccount,
+      displayName: 'Test Billing Account',
+    };
+    const googleBillingProject: GCPBillingProject = {
+      billingAccount: testBillingAccount.accountName,
+      cloudPlatform: 'GCP',
+      invalidBillingAccount: false,
+      projectName: 'Google Billing Project',
+      roles: ['Owner'],
+      status: 'Ready',
+    };
+    // Act
+    const result = groupByBillingAccountStatus(googleBillingProject, [defaultGoogleWorkspace.workspace]);
+
+    // Assert
+    expect(result).toEqual({ done: new Set([defaultGoogleWorkspace.workspace]) });
+  });
+
+  it('groups workspaces without matching billing account and no errorMessage as updating', () => {
+    // Arrange
+    const googleBillingProject: GCPBillingProject = {
+      billingAccount: 'billingAccounts/does-not-match',
+      cloudPlatform: 'GCP',
+      invalidBillingAccount: false,
+      projectName: 'Google Billing Project',
+      roles: ['Owner'],
+      status: 'Ready',
+    };
+    // Act
+    const result = groupByBillingAccountStatus(googleBillingProject, [defaultGoogleWorkspace.workspace]);
+
+    // Assert
+    expect(result).toEqual({ updating: new Set([defaultGoogleWorkspace.workspace]) });
+  });
+
+  it('groups workspaces without matching billing account and errorMessage as error', () => {
+    // Arrange
+    const googleBillingProject: GCPBillingProject = {
+      billingAccount: 'billingAccounts/does-not-match',
+      cloudPlatform: 'GCP',
+      invalidBillingAccount: false,
+      projectName: 'Google Billing Project',
+      roles: ['Owner'],
+      status: 'Ready',
+    };
+    const workspace = { ...defaultGoogleWorkspace.workspace, errorMessage: 'billing error message' };
+    // Act
+    const result = groupByBillingAccountStatus(googleBillingProject, [workspace]);
+
+    // Assert
+    expect(result).toEqual({ error: new Set([workspace]) });
+  });
+
+  it('can group multiple workspaces of the same type', () => {
+    // Arrange
+    const googleBillingProject: GCPBillingProject = {
+      billingAccount: 'billingAccounts/does-not-match',
+      cloudPlatform: 'GCP',
+      invalidBillingAccount: false,
+      projectName: 'Google Billing Project',
+      roles: ['Owner'],
+      status: 'Ready',
+    };
+    const firstWorkspace = { ...defaultGoogleWorkspace.workspace, errorMessage: 'billing error message' };
+    const secondWorkspace = {
+      ...defaultGoogleWorkspace.workspace,
+      name: 'secondWorkspace',
+      errorMessage: 'billing error message 2',
+    };
+    const updatingWorkspace = { ...defaultGoogleWorkspace.workspace, name: 'updatingWorkspace' };
+    const secondUpdatingWorkspace = { ...defaultGoogleWorkspace.workspace, name: 'secondUpdatingWorkspace' };
+    // Act
+    const result = groupByBillingAccountStatus(googleBillingProject, [
+      firstWorkspace,
+      secondWorkspace,
+      updatingWorkspace,
+      secondUpdatingWorkspace,
+    ]);
+
+    // Assert
+    expect(result).toEqual({
+      error: new Set([firstWorkspace, secondWorkspace]),
+      updating: new Set([updatingWorkspace, secondUpdatingWorkspace]),
+    });
+  });
+});
+
+// interface ProjectDetailProps {
+//   authorizeAndLoadAccounts: () => Promise<void>;
+//   billingAccounts: Record<string, GoogleBillingAccount>;
+//   billingProject: BillingProject;
+//   isOwner: boolean;
+//   reloadBillingProject: () => Promise<void>;
+//   workspaces: WorkspaceInfo[];
+//   refreshWorkspaces: () => void;
+// }
+
+describe('Project', () => {
+  it('shows all tabs if the user is an owner', async () => {
+    // Arrange
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+      {
+        email: 'testuser3@example.com',
+        role: 'User',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    // Verify that the tab has the correct name ("Members" since user is owner);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.length).toEqual(3);
+    expect(tabs[0]).toHaveTextContent('Workspaces');
+    expect(tabs[1]).toHaveTextContent('Members');
+    expect(tabs[2]).toHaveTextContent('Spend report');
+  });
+
+  it('shows only the workspaces and owners tab is the user is not an owner', async () => {
+    // Arrange
+    // Returns only owners if the user is not an owner.
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+      {
+        email: 'testuser2@example.com',
+        role: 'Owner',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner={false}
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    // Verify that the tab has the correct name ("Owners");
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.length).toEqual(2);
+    expect(tabs[0]).toHaveTextContent('Workspaces');
+    expect(tabs[1]).toHaveTextContent('Owners');
+    // Verify warning about a single owner is not shown.
+    expect(screen.queryByText(/This shared billing project has only one owner/)).toBeNull();
+  });
+
+  it('does not show a warning if the user is the only owner of a billing project with no other users', async () => {
+    // Arrange
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+    ]);
+
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    expect(screen.queryByText(/You are the only owner of this shared billing project/)).toBeNull();
+  });
+
+  it('shows a warning if the user is the only owner of a billing project that has other users', async () => {
+    // Arrange
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+      {
+        email: 'testuser2@example.com',
+        role: 'User',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    screen.getByText(/You are the only owner of this shared billing project/);
+  });
+
+  it('shows a warning if the billing project has only one owner, and the user is not an owner', async () => {
+    // Arrange
+    // This method only returns owners if the user is not an owner.
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner={false}
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    screen.getByText(/This shared billing project has only one owner/);
+  });
+
+  it('shows a link to the Azure portal for Azure billing projects', async () => {
+    // Arrange
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={azureBillingProject}
+          isOwner
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    screen.getByText(/View project resources in Azure Portal/);
+  });
+
+  it('does not show a link to the Azure portal for GCP billing projects', async () => {
+    // Arrange
+    const listProjectUsers = jest.fn().mockResolvedValue([
+      {
+        email: 'testuser1@example.com',
+        role: 'Owner',
+      },
+    ]);
+    asMockedFn(Ajax).mockImplementation(
+      () =>
+        ({
+          Billing: { listProjectUsers, removeProjectUser: jest.fn() } as Partial<AjaxContract['Billing']>,
+          Metrics: { captureEvent: jest.fn() } as Partial<AjaxContract['Metrics']>,
+        } as Partial<AjaxContract> as AjaxContract)
+    );
+
+    // Act
+    await act(async () =>
+      renderWithAppContexts(
+        <Project
+          authorizeAndLoadAccounts={jest.fn()}
+          billingAccounts={{}}
+          billingProject={gcpBillingProject}
+          isOwner
+          reloadBillingProject={jest.fn()}
+          workspaces={[]}
+          refreshWorkspaces={jest.fn()}
+        />
+      )
+    );
+
+    // Assert
+    expect(screen.queryByText(/View project resources in Azure Portal/)).toBeNull();
+  });
+});

--- a/src/billing/Project.test.tsx
+++ b/src/billing/Project.test.tsx
@@ -129,16 +129,6 @@ describe('groupByBillingAccountStatus', () => {
   });
 });
 
-// interface ProjectDetailProps {
-//   authorizeAndLoadAccounts: () => Promise<void>;
-//   billingAccounts: Record<string, GoogleBillingAccount>;
-//   billingProject: BillingProject;
-//   isOwner: boolean;
-//   reloadBillingProject: () => Promise<void>;
-//   workspaces: WorkspaceInfo[];
-//   refreshWorkspaces: () => void;
-// }
-
 describe('Project', () => {
   it('shows all tabs if the user is an owner', async () => {
     // Arrange

--- a/src/billing/Project.tsx
+++ b/src/billing/Project.tsx
@@ -289,6 +289,7 @@ const ProjectDetail = (props: ProjectDetailProps): ReactNode => {
         )}
         <SimpleTabBar
           aria-label='project details'
+          // @ts-ignore
           metricsPrefix={Events.billingProjectSelectTab}
           metricsData={extractBillingDetails(billingProject)}
           style={{ marginTop: '2rem', textTransform: 'none', padding: '0 1rem', height: '1.5rem' }}

--- a/src/billing/Project.tsx
+++ b/src/billing/Project.tsx
@@ -161,6 +161,7 @@ const ProjectDetail = (props: ProjectDetailProps): ReactNode => {
     (key: string) => ({
       key,
       title: (
+        // Rewrite the 'Members' tab to say 'Owners' if the user has the User role
         <span style={{ padding: '0 0.5rem' }}>{_.capitalize(key === 'members' && !isOwner ? 'owners' : key)}</span>
       ),
       tableName: _.lowerCase(key),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1800

This PR doe the following:
* Converts the remainder of Projects.js -> Projects.tsx. **I recommend you look at individual commits as it actually shows what has changed that way! Also, I added commit-specific comments.**
* Adds unit test coverage for most all the bits of `Project.tsx` (at least what was covered via integration tests).
* Deletes integration test coverage (that used mocked Ajax responses) that is now redundant.

SCREENSHOTS

Azure billing project, I tested that the links still go to the correct places in the Azure portal:
<img width="818" alt="image" src="https://github.com/user-attachments/assets/1735d5ad-a324-4bda-8786-a6eda71b3691">

Project is owned by user, single owner, has other users:
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/99128940-c25a-4edc-9ae0-8b3ceffeab01">

Project is shared with user (not owner), single owner:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/d430cd07-4466-4ac6-a3a7-f2354742abac">
