### PR TITLE
[DC-1215]Add bold match on concept strings, codes, and ID search results

### DIFF
--- a/src/dataset-builder/ConceptSearch.ts
+++ b/src/dataset-builder/ConceptSearch.ts
@@ -9,7 +9,7 @@ import { SimpleTable } from 'src/components/table';
 import { ConceptCart } from 'src/dataset-builder/ConceptCart';
 import { tableHeaderStyle } from 'src/dataset-builder/ConceptSelector';
 import { BuilderPageHeader } from 'src/dataset-builder/DatasetBuilderHeader';
-import { formatCount, HighlightConceptName } from 'src/dataset-builder/DatasetBuilderUtils';
+import { formatCount, HighlightSearchText } from 'src/dataset-builder/DatasetBuilderUtils';
 import {
   DataRepo,
   SnapshotBuilderConcept as Concept,
@@ -157,15 +157,22 @@ export const ConceptSearch = (props: ConceptSearchProps) => {
                     onChange: () => setCart(_.xor(cart, [concept])),
                   },
                   [
-                    h(HighlightConceptName, {
-                      conceptName: concept.name,
+                    h(HighlightSearchText, {
+                      columnItem: concept.name,
                       searchFilter: searchText,
                     }),
                   ]
                 ),
               ]),
-              id: concept.id,
-              code: div({ style: { overflowX: 'hidden', textOverflow: 'ellipsis', paddingRight: 14 } }, [concept.code]),
+              id: h(HighlightSearchText, {
+                columnItem: concept.id.toString(),
+                searchFilter: searchText,
+              }),
+              code: h(HighlightSearchText, {
+                columnItem: concept.code,
+                searchFilter: searchText,
+                style: { overflowX: 'hidden', textOverflow: 'ellipsis', paddingRight: 14 },
+              }),
               count: formatCount(concept.count),
               hierarchy: div({ style: { display: 'flex' } }, [
                 h(

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -203,8 +203,8 @@ describe('test conversion of DatasetAccessRequest', () => {
 });
 
 describe('test HighlightSearchText', () => {
-  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
-    return div({ style: {} }, [
+  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight, style) => {
+    return div({ style: { ...style } }, [
       span([beforeHighlight]),
       span({ style: { fontWeight: 600 } }, [highlightWord]),
       span([afterHighlight]),
@@ -214,28 +214,32 @@ describe('test HighlightSearchText', () => {
   test('searching beginning of conceptName', () => {
     const searchFilter = 'Clinic';
     const columnItem = 'Clinical Finding';
-    const result = createHighlightSearchText('', 'Clinic', 'al Finding');
+    const afterHighlight = div({ style: { display: 'inline' } }, ['al Finding']);
+    const result = createHighlightSearchText('', 'Clinic', afterHighlight);
     expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test("Testing to make sure capitalization doesn't change", () => {
     const searchFilter = 'clin';
     const columnItem = 'Clinical Finding';
-    const result = createHighlightSearchText('', 'Clin', 'ical Finding');
+    const afterHighlight = div({ style: { display: 'inline' } }, ['ical Finding']);
+    const result = createHighlightSearchText('', 'Clin', afterHighlight);
     expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the middle of conceptName', () => {
     const searchFilter = 'cal';
     const columnItem = 'Clinical Finding';
-    const result = createHighlightSearchText('Clini', 'cal', ' Finding');
+    const afterHighlight = div({ style: { display: 'inline' } }, [' Finding']);
+    const result = createHighlightSearchText('Clini', 'cal', afterHighlight);
     expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the end of conceptName', () => {
     const searchFilter = 'Finding';
     const columnItem = 'Clinical Finding';
-    const result = createHighlightSearchText('Clinical ', 'Finding', '');
+    const afterHighlight = div({ style: { display: 'inline' } }, ['']);
+    const result = createHighlightSearchText('Clinical ', 'Finding', afterHighlight);
     expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
@@ -269,6 +273,17 @@ describe('test HighlightSearchText', () => {
     searchFilter = '   ';
     columnItem = 'Clinical Finding';
     result = div({ style: {} }, ['Clinical Finding']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+  });
+
+  test('multiple instances of searchedWord in columnItem', () => {
+    const searchFilter = '110';
+    const columnItem = '8598211000001100';
+    const afterHighlightSecondInstance = div({ style: { display: 'inline' } }, ['0']);
+    const afterHighlightFirstInstance = createHighlightSearchText('0000', '110', afterHighlightSecondInstance, {
+      display: 'inline',
+    });
+    const result = createHighlightSearchText('85982', '110', afterHighlightFirstInstance);
     expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 });

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -9,7 +9,7 @@ import {
   CriteriaGroup,
   debounceAsync,
   formatCount,
-  HighlightConceptName,
+  HighlightSearchText,
   OutputTable,
   ProgramDataListCriteria,
   ProgramDataRangeCriteria,
@@ -202,9 +202,9 @@ describe('test conversion of DatasetAccessRequest', () => {
   });
 });
 
-describe('test HighlightConceptName', () => {
-  const createHighlightConceptName = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
-    return div({ style: { display: 'pre-wrap' } }, [
+describe('test HighlightSearchText', () => {
+  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight: string) => {
+    return div({ style: {} }, [
       span([beforeHighlight]),
       span({ style: { fontWeight: 600 } }, [highlightWord]),
       span([afterHighlight]),
@@ -213,63 +213,63 @@ describe('test HighlightConceptName', () => {
 
   test('searching beginning of conceptName', () => {
     const searchFilter = 'Clinic';
-    const conceptName = 'Clinical Finding';
-    const result = createHighlightConceptName('', 'Clinic', 'al Finding');
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clinical Finding';
+    const result = createHighlightSearchText('', 'Clinic', 'al Finding');
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test("Testing to make sure capitalization doesn't change", () => {
     const searchFilter = 'clin';
-    const conceptName = 'Clinical Finding';
-    const result = createHighlightConceptName('', 'Clin', 'ical Finding');
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clinical Finding';
+    const result = createHighlightSearchText('', 'Clin', 'ical Finding');
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the middle of conceptName', () => {
     const searchFilter = 'cal';
-    const conceptName = 'Clinical Finding';
-    const result = createHighlightConceptName('Clini', 'cal', ' Finding');
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clinical Finding';
+    const result = createHighlightSearchText('Clini', 'cal', ' Finding');
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the end of conceptName', () => {
     const searchFilter = 'Finding';
-    const conceptName = 'Clinical Finding';
-    const result = createHighlightConceptName('Clinical ', 'Finding', '');
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clinical Finding';
+    const result = createHighlightSearchText('Clinical ', 'Finding', '');
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
     const searchFilter = 'XXX';
-    const conceptName = 'Clinical Finding';
-    const result = div(['Clinical Finding']);
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clinical Finding';
+    const result = div({ style: {} }, ['Clinical Finding']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord in the not in conceptName: "Clinical" in "Clin"', () => {
     const searchFilter = 'Clinical';
-    const conceptName = 'Clin';
-    const result = div(['Clin']);
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Clin';
+    const result = div({ style: {} }, ['Clin']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test('searchedWord is empty: "" ', () => {
     const searchFilter = '';
-    const conceptName = 'Condition';
-    const result = div(['Condition']);
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    const columnItem = 'Condition';
+    const result = div({ style: {} }, ['Condition']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 
   test("doesn't bold whitespace", () => {
     let searchFilter = ' ';
-    let conceptName = 'Clinical Finding';
-    let result = div(['Clinical Finding']);
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    let columnItem = 'Clinical Finding';
+    let result = div({ style: {} }, ['Clinical Finding']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
 
     searchFilter = '   ';
-    conceptName = 'Clinical Finding';
-    result = div(['Clinical Finding']);
-    expect(HighlightConceptName({ conceptName, searchFilter })).toStrictEqual(result);
+    columnItem = 'Clinical Finding';
+    result = div({ style: {} }, ['Clinical Finding']);
+    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
   });
 });
 

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -1,4 +1,5 @@
-import { div, span } from 'react-hyperscript-helpers';
+import { render, screen } from '@testing-library/react';
+import { div, h } from 'react-hyperscript-helpers';
 import {
   AnyCriteria,
   Cohort,
@@ -203,44 +204,40 @@ describe('test conversion of DatasetAccessRequest', () => {
 });
 
 describe('test HighlightSearchText', () => {
-  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight, style?) => {
-    return div({ style: { ...style } }, [
-      span([beforeHighlight]),
-      span({ style: { fontWeight: 600 } }, [highlightWord]),
-      span([afterHighlight]),
-    ]);
-  };
-
   test('searching beginning of conceptName', () => {
     const searchFilter = 'Clinic';
-    const columnItem = 'Clinical Finding';
-    const afterHighlight = div({ style: { display: 'inline' } }, ['al Finding']);
-    const result = createHighlightSearchText('', 'Clinic', afterHighlight);
-    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+    const unsearchedText = 'al Finding';
+    render(h(HighlightSearchText, { searchFilter, columnItem: searchFilter + unsearchedText }));
+    expect(screen.getByText(searchFilter)).toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedText)).not.toHaveStyle({ fontWeight: 600 });
   });
 
   test("Testing to make sure capitalization doesn't change", () => {
     const searchFilter = 'clin';
-    const columnItem = 'Clinical Finding';
-    const afterHighlight = div({ style: { display: 'inline' } }, ['ical Finding']);
-    const result = createHighlightSearchText('', 'Clin', afterHighlight);
-    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+    const unsearchedText = 'ical Finding';
+    render(h(HighlightSearchText, { searchFilter, columnItem: searchFilter + unsearchedText }));
+    expect(screen.getByText(searchFilter)).toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedText)).not.toHaveStyle({ fontWeight: 600 });
   });
 
   test('searchedWord in the middle of conceptName', () => {
     const searchFilter = 'cal';
-    const columnItem = 'Clinical Finding';
-    const afterHighlight = div({ style: { display: 'inline' } }, [' Finding']);
-    const result = createHighlightSearchText('Clini', 'cal', afterHighlight);
-    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+    const unsearchedTextStart = 'Clini';
+    const unsearchedTextEnd = 'Finding';
+    render(
+      h(HighlightSearchText, { searchFilter, columnItem: unsearchedTextStart + searchFilter + unsearchedTextEnd })
+    );
+    expect(screen.getByText(searchFilter)).toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedTextStart)).not.toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedTextEnd)).not.toHaveStyle({ fontWeight: 600 });
   });
 
   test('searchedWord in the end of conceptName', () => {
     const searchFilter = 'Finding';
-    const columnItem = 'Clinical Finding';
-    const afterHighlight = div({ style: { display: 'inline' } }, ['']);
-    const result = createHighlightSearchText('Clinical ', 'Finding', afterHighlight);
-    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+    const unsearchedText = 'Clinical';
+    render(h(HighlightSearchText, { searchFilter, columnItem: unsearchedText + searchFilter }));
+    expect(screen.getByText(searchFilter)).toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedText)).not.toHaveStyle({ fontWeight: 600 });
   });
 
   test('searchedWord in the not in conceptName: "XXX" in "Clinical Finding"', () => {
@@ -278,13 +275,22 @@ describe('test HighlightSearchText', () => {
 
   test('multiple instances of searchedWord in columnItem', () => {
     const searchFilter = '110';
-    const columnItem = '8598211000001100';
-    const afterHighlightSecondInstance = div({ style: { display: 'inline' } }, ['0']);
-    const afterHighlightFirstInstance = createHighlightSearchText('0000', '110', afterHighlightSecondInstance, {
-      display: 'inline',
+    const unsearchedTextStart = '85982';
+    const unsearchedTextMiddle = '0000';
+    const unsearchedTextEnd = '0';
+    render(
+      h(HighlightSearchText, {
+        searchFilter,
+        columnItem: unsearchedTextStart + searchFilter + unsearchedTextMiddle + searchFilter + unsearchedTextEnd,
+      })
+    );
+    const searchFilterInstances = screen.getAllByText(searchFilter);
+    searchFilterInstances.forEach((instance) => {
+      expect(instance).toHaveStyle({ fontWeight: 600 });
     });
-    const result = createHighlightSearchText('85982', '110', afterHighlightFirstInstance);
-    expect(HighlightSearchText({ columnItem, searchFilter })).toStrictEqual(result);
+    expect(screen.getByText(unsearchedTextStart)).not.toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedTextMiddle)).not.toHaveStyle({ fontWeight: 600 });
+    expect(screen.getByText(unsearchedTextEnd)).not.toHaveStyle({ fontWeight: 600 });
   });
 });
 

--- a/src/dataset-builder/DatasetBuilderUtils.test.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.test.ts
@@ -203,7 +203,7 @@ describe('test conversion of DatasetAccessRequest', () => {
 });
 
 describe('test HighlightSearchText', () => {
-  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight, style) => {
+  const createHighlightSearchText = (beforeHighlight: string, highlightWord: string, afterHighlight, style?) => {
     return div({ style: { ...style } }, [
       span([beforeHighlight]),
       span({ style: { fontWeight: 600 } }, [highlightWord]),

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -149,7 +149,7 @@ export const createSnapshotBuilderCountRequest = (cohort: Cohort[]): SnapshotBui
 type HighlightSearchTextProps = {
   readonly columnItem: string;
   readonly searchFilter: string;
-  readonly style: {};
+  readonly style?: {};
 };
 
 export const HighlightSearchText = (props: HighlightSearchTextProps): ReactElement => {

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -146,20 +146,20 @@ export const createSnapshotBuilderCountRequest = (cohort: Cohort[]): SnapshotBui
   return { cohorts: _.map(convertCohort, cohort) };
 };
 
-export const HighlightConceptName = ({ conceptName, searchFilter }): ReactElement => {
-  const startIndex = conceptName.toLowerCase().indexOf(searchFilter.toLowerCase());
+export const HighlightSearchText = ({ columnItem, searchFilter, style = {} }): ReactElement => {
+  const startIndex = columnItem.toLowerCase().indexOf(searchFilter.toLowerCase());
 
   // searchFilter is empty or does not exist in conceptName
   if (startIndex < 0 || searchFilter.trim() === '') {
-    return div([conceptName]);
+    return div({ style: { ...style } }, [columnItem]);
   }
 
   const endIndex = startIndex + searchFilter.length;
 
-  return div({ style: { display: 'pre-wrap' } }, [
-    span([conceptName.substring(0, startIndex)]),
-    span({ style: { fontWeight: 600 } }, [conceptName.substring(startIndex, endIndex)]),
-    span([conceptName.substring(endIndex)]),
+  return div({ style: { ...style } }, [
+    span([columnItem.substring(0, startIndex)]),
+    span({ style: { fontWeight: 600 } }, [columnItem.substring(startIndex, endIndex)]),
+    span([columnItem.substring(endIndex)]),
   ]);
 };
 

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -146,10 +146,17 @@ export const createSnapshotBuilderCountRequest = (cohort: Cohort[]): SnapshotBui
   return { cohorts: _.map(convertCohort, cohort) };
 };
 
-export const HighlightSearchText = ({ columnItem, searchFilter, style = {} }): ReactElement => {
+type HighlightSearchTextProps = {
+  readonly columnItem: string;
+  readonly searchFilter: string;
+  readonly style: {};
+};
+
+export const HighlightSearchText = (props: HighlightSearchTextProps): ReactElement => {
+  const { columnItem, searchFilter, style } = props;
   const startIndex = columnItem.toLowerCase().indexOf(searchFilter.toLowerCase());
 
-  // searchFilter is empty or does not exist in conceptName
+  // searchFilter is empty or does not exist in columnItem
   if (startIndex < 0 || searchFilter.trim() === '') {
     return div({ style: { ...style } }, [columnItem]);
   }
@@ -159,7 +166,13 @@ export const HighlightSearchText = ({ columnItem, searchFilter, style = {} }): R
   return div({ style: { ...style } }, [
     span([columnItem.substring(0, startIndex)]),
     span({ style: { fontWeight: 600 } }, [columnItem.substring(startIndex, endIndex)]),
-    span([columnItem.substring(endIndex)]),
+    span([
+      HighlightSearchText({
+        columnItem: columnItem.substring(endIndex),
+        searchFilter,
+        style: { display: 'inline' },
+      }),
+    ]),
   ]);
 };
 

--- a/src/dataset-builder/DatasetBuilderUtils.ts
+++ b/src/dataset-builder/DatasetBuilderUtils.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { ReactElement } from 'react';
-import { div, span } from 'react-hyperscript-helpers';
+import { div, h, span } from 'react-hyperscript-helpers';
 import { HeaderAndValues } from 'src/dataset-builder/DatasetBuilder';
 import {
   AnySnapshotBuilderCriteria,
@@ -167,7 +167,7 @@ export const HighlightSearchText = (props: HighlightSearchTextProps): ReactEleme
     span([columnItem.substring(0, startIndex)]),
     span({ style: { fontWeight: 600 } }, [columnItem.substring(startIndex, endIndex)]),
     span([
-      HighlightSearchText({
+      h(HighlightSearchText, {
         columnItem: columnItem.substring(endIndex),
         searchFilter,
         style: { display: 'inline' },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-1215

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Concept Name would already bold match when searched, but made it so that ID and Code did the same

### Why
- Makes it clearer which results matched the search

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
- There were already tests that tested this behavior for Concept Name, made sure they still passed with my changes
- Tested the UI locally for Concept ID and Code

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

https://github.com/user-attachments/assets/c06277b3-4464-416b-9129-b6fa9b090d2e

**EDIT**: Made it so that if there are multiple instances of the search term in an item (i.e., search term of 123 shows up twice in 12345123), all instances are bolded instead of just the first
- Added a test to test this change and edited existing tests to make sure they still pass

https://github.com/user-attachments/assets/8ae6aa27-a448-4c13-b866-145527220abe


