### PR TITLE
[WOR-1757] Add ability to set Bucket Lifecycle Rules on on GCP workspaces

### DIFF
--- a/packages/components/src/Select.tsx
+++ b/packages/components/src/Select.tsx
@@ -9,6 +9,7 @@ import RSelect, {
   SingleValue as RSelectSingleValue,
 } from 'react-select';
 import RAsyncCreatableSelect, { AsyncCreatableProps as RAsyncCreatableProps } from 'react-select/async-creatable';
+import RCreatableSelect from 'react-select/creatable';
 
 import { useUniqueId } from './hooks/useUniqueId';
 import { Icon } from './Icon';
@@ -272,4 +273,9 @@ export const AsyncCreatableSelect = <
       {...(_.merge(getCommonSelectProps(theme), props) as RAsyncCreatableProps<Option, IsMulti, Group>)}
     />
   );
+};
+
+export const CreatableSelect = (props: any) => {
+  const theme = useThemeFromContext();
+  return <RCreatableSelect {..._.merge(getCommonSelectProps(theme), props)} />;
 };

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -138,6 +138,16 @@ const Workspaces = (signal) => ({
         const response = await fetchRawls(`${root}/bucketMigration`, _.merge(authOpts(), { signal, method: 'POST' }));
         return response.json();
       },
+
+      getSettings: async () => {
+        const response = await fetchRawls(`${root}/settings`, _.merge(authOpts(), { signal }));
+        return response.json();
+      },
+
+      updateSettings: async (body) => {
+        const response = await fetchRawls(`${root}/settings`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }]));
+        return response.json();
+      },
     };
   },
 

--- a/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
+++ b/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
@@ -15,6 +15,7 @@ export interface WorkspaceDataProvider {
 export const workspaceProvider: WorkspaceDataProvider = {
   list: async (fieldsArgs: FieldsArg, options: WorkspaceListOptions): Promise<WorkspaceWrapper[]> => {
     const { signal, stringAttributeMaxLength } = options;
+
     const ws = await Ajax(signal).Workspaces.list(fieldsArgs, stringAttributeMaxLength);
     return ws;
   },

--- a/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
+++ b/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
@@ -15,7 +15,6 @@ export interface WorkspaceDataProvider {
 export const workspaceProvider: WorkspaceDataProvider = {
   list: async (fieldsArgs: FieldsArg, options: WorkspaceListOptions): Promise<WorkspaceWrapper[]> => {
     const { signal, stringAttributeMaxLength } = options;
-
     const ws = await Ajax(signal).Workspaces.list(fieldsArgs, stringAttributeMaxLength);
     return ws;
   },

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -170,6 +170,7 @@ const eventsList = {
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceOpenFromRecentlyViewed: 'workspace:open-from-recently-viewed',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
+  workspaceSettingsBucketLifecycle: 'workspace:settings:bucketLifecycle',
   workspaceShare: 'workspace:share',
   workspaceShareWithSupport: 'workspace:shareWithSupport',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -166,6 +166,7 @@ const eventsList = {
   workspaceDataRenameEntity: 'workspace:data:renameEntity',
   workspaceDataRenameTable: 'workspace:data:rename-table',
   workspaceDataDeleteTable: 'workspace:data:deleteTable',
+  workspaceMenu: 'workspace:menu:selected',
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceOpenFromRecentlyViewed: 'workspace:open-from-recently-viewed',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -5,6 +5,7 @@ export const ENABLE_AZURE_PFB_IMPORT = 'enableAzurePfbImport';
 export const ENABLE_AZURE_TDR_IMPORT = 'enableAzureTdrImport';
 export const FIRECLOUD_UI_MIGRATION = 'firecloudUiMigration';
 export const AXIN_DATASET_CARD = 'axinDatasetCard';
+export const GCP_BUCKET_LIFECYCLE_RULES = 'gcpBucketLifecycleRules';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -115,6 +116,15 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     description: 'Enabling this feature will show the card for AnalytiXIN in the Datasets tab in the Library.',
     feedbackUrl: `mailto:dsp-data-exploration@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Axin Dataset Card'
+    )}`,
+  },
+  {
+    id: GCP_BUCKET_LIFECYCLE_RULES,
+    title: 'GCP Workspace Bucket Lifecycle Rules',
+    description:
+      'Enabling this feature will allow GCP bucket lifecycle rules to be set via the Workspace Settings dialog.',
+    feedbackUrl: `mailto:dsp-workspaces@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on GCP Bucket Lifecycle Rules'
     )}`,
   },
 ];

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -1,0 +1,113 @@
+import { CreatableSelect, ExternalLink, Switch, useUniqueId } from '@terra-ui-packages/components';
+import _ from 'lodash/fp';
+import React, { ReactNode } from 'react';
+import { NumberInput } from 'src/components/input';
+import { FormLabel } from 'src/libs/forms';
+import { suggestedPrefixes } from 'src/workspaces/SettingsModal/utils';
+
+interface BucketLifecycleSettingsProps {
+  lifecycleRulesEnabled: boolean;
+  setLifecycleRulesEnabled: (enabled: boolean) => void;
+  lifecycleAge: number | null;
+  setLifecycleAge: (age: number | null) => void;
+  prefixes: string[];
+  setPrefixes: (prefixes: string[]) => void;
+}
+
+const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode => {
+  const { lifecycleRulesEnabled, setLifecycleRulesEnabled, lifecycleAge, setLifecycleAge, prefixes, setPrefixes } =
+    props;
+
+  const switchId = useUniqueId('switch');
+  const daysId = useUniqueId('days');
+  const descriptionId = useUniqueId('description');
+
+  const prefixOptions = () => {
+    // Append together suggested options any options the user has added or are already selected.
+    const allOptions = _.uniq(_.concat(_.values(suggestedPrefixes), prefixes));
+    return _.map((value) => ({ value, label: value }), allOptions);
+  };
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '.75rem' }}>
+        <FormLabel
+          htmlFor={switchId}
+          style={{ fontWeight: 600, whiteSpace: 'nowrap', marginRight: '.5rem', marginTop: '.5rem' }}
+        >
+          Lifecycle Rules:
+        </FormLabel>
+        <Switch
+          onLabel=''
+          offLabel=''
+          onChange={(checked: boolean) => {
+            setLifecycleRulesEnabled(checked);
+            if (!checked) {
+              // Clear out the values being display to reduce
+              setLifecycleAge(null);
+              setPrefixes([]);
+            }
+          }}
+          id={switchId}
+          checked={lifecycleRulesEnabled}
+          width={40}
+          height={20}
+          aria-describedby={descriptionId}
+        />
+      </div>
+      <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>
+        <div style={{ marginTop: '.75rem', marginBottom: '.5rem' }}>Delete objects in:</div>
+        <CreatableSelect
+          isClearable
+          isMulti
+          isSearchable
+          placeholder='Choose "All Objects" or specify prefixes'
+          aria-label='Specify if all objects should be deleted, or objects with specific prefixes'
+          value={_.map((value) => ({ value, label: value }), prefixes)}
+          onChange={(data) => {
+            const selectedPrefixes = _.map('value', data);
+            // If added "All Objects", clear the others.
+            if (
+              _.contains(suggestedPrefixes.allObjects, selectedPrefixes) &&
+              !_.contains(suggestedPrefixes.allObjects, prefixes)
+            ) {
+              setPrefixes([suggestedPrefixes.allObjects]);
+            } else if (selectedPrefixes.length > 1) {
+              setPrefixes(_.without([suggestedPrefixes.allObjects], selectedPrefixes));
+            } else {
+              setPrefixes(selectedPrefixes);
+            }
+          }}
+          options={prefixOptions()}
+          isDisabled={!lifecycleRulesEnabled}
+        />
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        {/* eslint-disable jsx-a11y/label-has-associated-control */}
+        <label style={{ marginRight: '.25rem' }} htmlFor={daysId}>
+          Days after upload:
+        </label>
+        <NumberInput
+          style={{ maxWidth: '100px' }}
+          id={daysId}
+          min={0}
+          isClearable
+          onlyInteger
+          value={lifecycleAge}
+          disabled={!lifecycleRulesEnabled}
+          onChange={(value: number) => {
+            setLifecycleAge(value);
+          }}
+        />
+      </div>
+      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
+        This{' '}
+        <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
+        automatically deletes objects a certain number of days after they are uploaded.{' '}
+        <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
+      </div>
+    </>
+  );
+};
+
+export default BucketLifecycleSettings;

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -12,6 +12,7 @@ interface BucketLifecycleSettingsProps {
   setLifecycleAge: (age: number | null) => void;
   prefixes: string[];
   setPrefixes: (prefixes: string[]) => void;
+  isOwner: boolean;
 }
 
 const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode => {
@@ -53,6 +54,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           width={40}
           height={20}
           aria-describedby={descriptionId}
+          disabled={!props.isOwner}
         />
       </div>
       <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -64,6 +64,12 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           disabled={!isOwner}
         />
       </div>
+      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
+        This{' '}
+        <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
+        automatically deletes objects a certain number of days after they are created.{' '}
+        <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
+      </div>
       <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>
         <div style={{ marginTop: '.75rem', marginBottom: '.5rem' }}>Delete objects in:</div>
         <CreatableSelect
@@ -108,12 +114,6 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
             setLifecycleAge(value);
           }}
         />
-      </div>
-      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
-        This{' '}
-        <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
-        automatically deletes objects a certain number of days after they are created.{' '}
-        <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
       </div>
     </>
   );

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -16,15 +16,22 @@ interface BucketLifecycleSettingsProps {
 }
 
 const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode => {
-  const { lifecycleRulesEnabled, setLifecycleRulesEnabled, lifecycleAge, setLifecycleAge, prefixes, setPrefixes } =
-    props;
+  const {
+    lifecycleRulesEnabled,
+    setLifecycleRulesEnabled,
+    lifecycleAge,
+    setLifecycleAge,
+    prefixes,
+    setPrefixes,
+    isOwner,
+  } = props;
 
   const switchId = useUniqueId('switch');
   const daysId = useUniqueId('days');
   const descriptionId = useUniqueId('description');
 
   const prefixOptions = () => {
-    // Append together suggested options any options the user has added or are already selected.
+    // Append together suggested options and any options the user has already selected.
     const allOptions = _.uniq(_.concat(_.values(suggestedPrefixes), prefixes));
     return _.map((value) => ({ value, label: value }), allOptions);
   };
@@ -44,7 +51,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           onChange={(checked: boolean) => {
             setLifecycleRulesEnabled(checked);
             if (!checked) {
-              // Clear out the values being display to reduce
+              // Clear out the values being display to reduce confusion
               setLifecycleAge(null);
               setPrefixes([]);
             }
@@ -54,7 +61,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           width={40}
           height={20}
           aria-describedby={descriptionId}
-          disabled={!props.isOwner}
+          disabled={!isOwner}
         />
       </div>
       <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -112,7 +112,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
       <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
         This{' '}
         <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
-        automatically deletes objects a certain number of days after they are uploaded.{' '}
+        automatically deletes objects a certain number of days after they are created.{' '}
         <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
       </div>
     </>

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -85,7 +85,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {/* eslint-disable jsx-a11y/label-has-associated-control */}
         <label style={{ marginRight: '.25rem' }} htmlFor={daysId}>
-          Days after upload:
+          Days after creation:
         </label>
         <NumberInput
           style={{ maxWidth: '100px' }}

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -8,8 +8,8 @@ import React from 'react';
 import { Ajax } from 'src/libs/ajax';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
-import SettingsModal, { suggestedPrefixes } from 'src/workspaces/SettingsModal/SettingsModal';
-import { BucketLifecycleSetting, WorkspaceSetting } from 'src/workspaces/SettingsModal/utils';
+import SettingsModal from 'src/workspaces/SettingsModal/SettingsModal';
+import { BucketLifecycleSetting, suggestedPrefixes, WorkspaceSetting } from 'src/workspaces/SettingsModal/utils';
 
 jest.mock('src/libs/ajax');
 

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -1,0 +1,451 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { screen } from '@testing-library/react';
+import { act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import _ from 'lodash/fp';
+import React from 'react';
+import { Ajax } from 'src/libs/ajax';
+import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+import SettingsModal, { suggestedPrefixes } from 'src/workspaces/SettingsModal/SettingsModal';
+import { BucketLifecycleSetting } from 'src/workspaces/SettingsModal/utils';
+
+jest.mock('src/libs/ajax');
+
+type AjaxContract = ReturnType<typeof Ajax>;
+type AjaxWorkspacesContract = AjaxContract['Workspaces'];
+
+describe('SettingsModal', () => {
+  describe('Bucket Lifecycle Settings', () => {
+    const captureEvent = jest.fn();
+
+    const getToggle = () => screen.getByRole('switch');
+    const getPrefixInput = (user): SelectHelper =>
+      new SelectHelper(
+        screen.getByLabelText('Specify if all objects should be deleted, or objects with specific prefixes'),
+        user
+      );
+    const getDays = () => screen.getByLabelText('Days after upload:');
+
+    const fourDaysAllObjects = {
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 4,
+              matchesPrefix: [], // TODO, I have a bug here on setting
+            },
+          },
+        ],
+      },
+      settingType: 'GcpBucketLifecycle',
+    };
+
+    const zeroDaysTwoPrefixes = {
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 0,
+              matchesPrefix: ['a/', 'b/'],
+            },
+          },
+        ],
+      },
+      settingType: 'GcpBucketLifecycle',
+    };
+
+    const twoRules = {
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 1,
+              matchesPrefix: [],
+            },
+          },
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 2,
+              matchesPrefix: ['p/'],
+            },
+          },
+        ],
+      },
+      settingType: 'GcpBucketLifecycle',
+    };
+
+    const noLifecycleRules: BucketLifecycleSetting = { settingType: 'GcpBucketLifecycle', config: { rules: [] } };
+
+    const setup = (currentSetting: BucketLifecycleSetting[], updateSettingsMock: jest.Mock<any, any>) => {
+      jest.resetAllMocks();
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+      asMockedFn(Ajax).mockImplementation(
+        () =>
+          ({
+            Metrics: { captureEvent },
+            Workspaces: {
+              workspaceV2: () =>
+                ({
+                  getSettings: jest.fn().mockResolvedValue(currentSetting),
+                  updateSettings: updateSettingsMock,
+                } as DeepPartial<AjaxWorkspacesContract>),
+            },
+          } as DeepPartial<AjaxContract> as AjaxContract)
+      );
+    };
+
+    it('renders the option as disabled if no settings exist', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getToggle()).toHaveAttribute('aria-checked', 'false');
+
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([]);
+      expect(prefixInput.inputElement).toHaveAttribute('disabled');
+
+      const daysInput = getDays();
+      expect(daysInput).toHaveValue(null);
+      expect(daysInput).toHaveAttribute('disabled');
+    });
+
+    it('renders the option as enabled if all objects are being deleted', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([fourDaysAllObjects], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getToggle()).toHaveAttribute('aria-checked', 'true');
+
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([suggestedPrefixes.allObjects]);
+      expect(prefixInput.inputElement).not.toHaveAttribute('disabled');
+      const allOptions = await prefixInput.getOptions();
+      expect(allOptions).toEqual([suggestedPrefixes.submissions, suggestedPrefixes.submissionIntermediaries]);
+
+      const daysInput = getDays();
+      expect(daysInput).toHaveValue(4);
+      expect(daysInput).not.toHaveAttribute('disabled');
+    });
+
+    it('renders the option as enabled if certain prefixes are being disabled', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([zeroDaysTwoPrefixes], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getToggle()).toHaveAttribute('aria-checked', 'true');
+
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual(['a/', 'b/']);
+      expect(prefixInput.inputElement).not.toHaveAttribute('disabled');
+      const allOptions = await prefixInput.getOptions();
+      expect(allOptions).toEqual(_.values(suggestedPrefixes));
+
+      const daysInput = getDays();
+      expect(daysInput).toHaveValue(0);
+      expect(daysInput).not.toHaveAttribute('disabled');
+    });
+
+    it('uses the first GcpBucketLifecycle setting present', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const enabledForAllObjects: BucketLifecycleSetting[] = [fourDaysAllObjects, zeroDaysTwoPrefixes];
+      setup(enabledForAllObjects, jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getToggle()).toHaveAttribute('aria-checked', 'true');
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([suggestedPrefixes.allObjects]);
+      expect(getDays()).toHaveValue(4);
+    });
+
+    it('uses the first set of rules present', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([twoRules], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getToggle()).toHaveAttribute('aria-checked', 'true');
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([suggestedPrefixes.allObjects]);
+      expect(getDays()).toHaveValue(1);
+    });
+
+    it('persists disabling single lifecycle rule', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([fourDaysAllObjects], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const toggle = getToggle();
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+      // Options get cleared
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([]);
+      expect(getDays()).toHaveValue(null);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([noLifecycleRules]);
+    });
+
+    it('removes first lifecycle rule if user disables it', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([twoRules], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const toggle = getToggle();
+      expect(toggle).toHaveAttribute('aria-checked', 'true');
+      await user.click(toggle);
+      expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+      // Options get cleared
+      const prefixInput = getPrefixInput(user);
+      expect(prefixInput.getSelectedOptions()).toEqual([]);
+      expect(getDays()).toHaveValue(null);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        {
+          config: {
+            rules: [
+              {
+                action: {
+                  actionType: 'Delete',
+                },
+                conditions: {
+                  age: 2,
+                  matchesPrefix: ['p/'],
+                },
+              },
+            ],
+          },
+          settingType: 'GcpBucketLifecycle',
+        },
+      ]);
+    });
+
+    it('modifies only the first rule', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([twoRules], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const daysInput = getDays();
+      await user.clear(daysInput);
+      await user.type(daysInput, '7');
+      expect(daysInput).toHaveValue(7);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        {
+          config: {
+            rules: [
+              {
+                action: {
+                  actionType: 'Delete',
+                },
+                conditions: {
+                  age: 7,
+                  matchesPrefix: [],
+                },
+              },
+              {
+                action: {
+                  actionType: 'Delete',
+                },
+                conditions: {
+                  age: 2,
+                  matchesPrefix: ['p/'],
+                },
+              },
+            ],
+          },
+          settingType: 'GcpBucketLifecycle',
+        },
+      ]);
+    });
+
+    it('persists deleting all objects', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([zeroDaysTwoPrefixes], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const prefixInput = getPrefixInput(user);
+      await prefixInput.selectOption(suggestedPrefixes.allObjects);
+      expect(prefixInput.getSelectedOptions()).toEqual([suggestedPrefixes.allObjects]);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        {
+          config: {
+            rules: [
+              {
+                action: {
+                  actionType: 'Delete',
+                },
+                conditions: {
+                  age: 0,
+                  matchesPrefix: [],
+                },
+              },
+            ],
+          },
+          settingType: 'GcpBucketLifecycle',
+        },
+      ]);
+    });
+
+    it('persists changing prefixes and changing days', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([fourDaysAllObjects], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const prefixInput = getPrefixInput(user);
+      await prefixInput.selectOption(suggestedPrefixes.submissions);
+      await prefixInput.selectOption(suggestedPrefixes.submissionIntermediaries);
+      expect(prefixInput.getSelectedOptions()).toEqual([
+        suggestedPrefixes.submissions,
+        suggestedPrefixes.submissionIntermediaries,
+      ]);
+
+      const daysInput = getDays();
+      await user.clear(daysInput);
+      await user.type(daysInput, '14');
+      expect(daysInput).toHaveValue(14);
+
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      expect(saveButton).toHaveAttribute('aria-disabled', 'false');
+      await user.click(saveButton);
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        {
+          config: {
+            rules: [
+              {
+                action: {
+                  actionType: 'Delete',
+                },
+                conditions: {
+                  age: 14,
+                  matchesPrefix: [suggestedPrefixes.submissions, suggestedPrefixes.submissionIntermediaries],
+                },
+              },
+            ],
+          },
+          settingType: 'GcpBucketLifecycle',
+        },
+      ]);
+    });
+
+    it('disables Save if there is no date value specified', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([fourDaysAllObjects], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const daysInput = getDays();
+      await user.clear(daysInput);
+      expect(daysInput).toHaveValue(null);
+
+      // Assert
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('has no accessibility errors', async () => {
+      setup([twoRules], jest.fn());
+
+      // Act and Assert
+      await act(async () => {
+        const { container } = render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+        expect(await axe(container)).toHaveNoViolations();
+      });
+    });
+  });
+});

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -125,7 +125,7 @@ describe('SettingsModal', () => {
   it('does not show bucket lifecycle settings if the feature flag is disabled', async () => {
     // Arrange
     setup([], jest.fn());
-    asMockedFn(isFeaturePreviewEnabled).mockImplementation((_id) => false);
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
 
     // Act
     await act(async () => {

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -9,7 +9,7 @@ import { Ajax } from 'src/libs/ajax';
 import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import SettingsModal, { suggestedPrefixes } from 'src/workspaces/SettingsModal/SettingsModal';
-import { BucketLifecycleSetting } from 'src/workspaces/SettingsModal/utils';
+import { BucketLifecycleSetting, WorkspaceSetting } from 'src/workspaces/SettingsModal/utils';
 
 jest.mock('src/libs/ajax');
 
@@ -90,7 +90,7 @@ describe('SettingsModal', () => {
 
     const noLifecycleRules: BucketLifecycleSetting = { settingType: 'GcpBucketLifecycle', config: { rules: [] } };
 
-    const setup = (currentSetting: BucketLifecycleSetting[], updateSettingsMock: jest.Mock<any, any>) => {
+    const setup = (currentSetting: WorkspaceSetting[], updateSettingsMock: jest.Mock<any, any>) => {
       jest.resetAllMocks();
       jest.spyOn(console, 'log').mockImplementation(() => {});
       asMockedFn(Ajax).mockImplementation(
@@ -181,7 +181,7 @@ describe('SettingsModal', () => {
     it('uses the first GcpBucketLifecycle setting present', async () => {
       // Arrange
       const user = userEvent.setup();
-      const enabledForAllObjects: BucketLifecycleSetting[] = [fourDaysAllObjects, zeroDaysTwoPrefixes];
+      const enabledForAllObjects: WorkspaceSetting[] = [fourDaysAllObjects, zeroDaysTwoPrefixes];
       setup(enabledForAllObjects, jest.fn());
 
       // Act

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -178,7 +178,7 @@ describe('SettingsModal', () => {
         screen.getByLabelText('Specify if all objects should be deleted, or objects with specific prefixes'),
         user
       );
-    const getDays = () => screen.getByLabelText('Days after upload:');
+    const getDays = () => screen.getByLabelText('Days after creation:');
 
     it('renders the option as disabled if no settings exist', async () => {
       // Arrange
@@ -416,7 +416,7 @@ describe('SettingsModal', () => {
       ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBucketLifecycle, {
         enabled: true,
-        prefixes: ['AllObjects'],
+        prefixes: 'AllObjects',
         age: 7,
         ...extractWorkspaceDetails(defaultGoogleWorkspace),
       });
@@ -460,7 +460,7 @@ describe('SettingsModal', () => {
       ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBucketLifecycle, {
         enabled: true,
-        prefixes: ['AllObjects'],
+        prefixes: 'AllObjects',
         age: 0,
         ...extractWorkspaceDetails(defaultGoogleWorkspace),
       });
@@ -515,7 +515,7 @@ describe('SettingsModal', () => {
       ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBucketLifecycle, {
         enabled: true,
-        prefixes: ['Submissions', 'SubmissionsIntermediaries'],
+        prefixes: 'AllSubmissionsAndSubmissionsIntermediaries',
         age: 14,
         ...extractWorkspaceDetails(defaultGoogleWorkspace),
       });

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -128,16 +128,39 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     onDismiss();
   };
 
+  const getOkTooltip = () => {
+    if (lifecycleRulesEnabled) {
+      if (lifecycleAge === undefined) {
+        return 'Please specify a deletion age';
+      }
+      if (prefixes.length === 0) {
+        return 'Please choose "All Objects" or specify one or more prefixes';
+      }
+    }
+    return '';
+  };
+
   const loading = workspaceSettings === undefined;
   return (
     <Modal
       title='Configure Workspace Settings'
       onDismiss={onDismiss}
-      okButton={<ButtonPrimary onClick={persistSettings}>Ok</ButtonPrimary>}
+      okButton={
+        <ButtonPrimary
+          disabled={lifecycleRulesEnabled && (prefixes.length === 0 || lifecycleAge === undefined)}
+          onClick={persistSettings}
+          tooltip={getOkTooltip()}
+        >
+          Ok
+        </ButtonPrimary>
+      }
     >
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: 6 }}>
-        <FormLabel htmlFor={switchId} style={{ fontWeight: 'bold', whiteSpace: 'nowrap', marginRight: '5px' }}>
-          Lifecycle Rules:
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '6px' }}>
+        <FormLabel
+          htmlFor={switchId}
+          style={{ fontWeight: 'bold', whiteSpace: 'nowrap', marginRight: '5px', marginTop: '5px' }}
+        >
+          Bucket Lifecycle Rules:
         </FormLabel>
         <Switch
           onLabel=''
@@ -152,19 +175,20 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
         />
       </div>
       <div style={{ marginTop: '5px', fontSize: '12px' }}>
-        This setting allows you to automatically delete objects in the bucket a certain number of days after they are
-        uploaded to the bucket. You can limit the deletion to objects that start with one or more prefixes.
+        This setting allows you to automatically delete objects a certain number of days after they are uploaded to the
+        bucket. You can limit the deletion to objects that start with one or more prefixes.
       </div>
       <div style={{ marginTop: '10px', marginBottom: '10px' }}>
         <div style={{ display: 'flex', alignItems: 'center' }}>
-          <FormLabel style={{ marginRight: '5px' }} htmlFor={daysId}>
+          {/* eslint-disable jsx-a11y/label-has-associated-control */}
+          <label style={{ marginRight: '5px' }} htmlFor={daysId}>
             Deletion age (in days):
-          </FormLabel>
+          </label>
           <NumberInput
             style={{ maxWidth: '100px' }}
             id={daysId}
             min={0}
-            isClearable={false}
+            isClearable
             onlyInteger
             value={lifecycleAge}
             disabled={!lifecycleRulesEnabled}

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -1,0 +1,24 @@
+import { Modal } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+
+interface SettingsModalProps {
+  // workspace: WorkspaceWrapper;
+  onDismiss: () => void;
+}
+
+const SettingsModal = (props: SettingsModalProps): ReactNode => {
+  const { onDismiss } = props;
+  // const { namespace, name } = workspace.workspace;
+
+  return (
+    <Modal
+      title='Workspace Settings'
+      onDismiss={onDismiss}
+      // okButton={<ButtonPrimary onClick={toggleWorkspaceLock}>{helpText}</ButtonPrimary>}
+    >
+      <div>Set some settings</div>
+    </Modal>
+  );
+};
+
+export default SettingsModal;

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -1,22 +1,200 @@
-import { Modal } from '@terra-ui-packages/components';
-import React, { ReactNode } from 'react';
+import {
+  ButtonPrimary,
+  CreatableSelect,
+  Modal,
+  SpinnerOverlay,
+  Switch,
+  useUniqueId,
+} from '@terra-ui-packages/components';
+import _ from 'lodash/fp';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { NumberInput } from 'src/components/input';
+import { Ajax } from 'src/libs/ajax';
+import { withErrorReporting } from 'src/libs/error';
+import { FormLabel } from 'src/libs/forms';
+import { useCancellation } from 'src/libs/react-utils';
+import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
+
+interface BucketLifecycleRule {
+  action: {
+    actionType: 'Delete';
+  };
+  conditions: {
+    age: number;
+    matchesPrefix: string[];
+  };
+}
+
+interface BucketLifecycleSetting {
+  settingType: 'GcpBucketLifecycle';
+  config: { rules: BucketLifecycleRule[] };
+}
 
 interface SettingsModalProps {
-  // workspace: WorkspaceWrapper;
+  workspace: Workspace;
   onDismiss: () => void;
 }
 
+/**
+ * This modal is assumed to only be displayed for Google workspaces.
+ */
 const SettingsModal = (props: SettingsModalProps): ReactNode => {
-  const { onDismiss } = props;
-  // const { namespace, name } = workspace.workspace;
+  const { onDismiss, workspace } = props;
 
+  const allObjects = 'All Objects';
+  const [lifecycleRulesEnabled, setLifecycleRulesEnabled] = useState(false);
+  // In-progress lifecycle rules, will not be persisted (included in settings) unless lifecycleRulesEnabled is true
+  const [lifecycleRules, setLifecycleRules] = useState<BucketLifecycleSetting | undefined>(undefined);
+
+  const [workspaceSettings, setWorkspaceSettings] = useState<BucketLifecycleSetting[] | undefined>(undefined);
+  const [prefixes, setPrefixes] = useState<string[]>([]);
+  const [lifecycleAge, setLifecycleAge] = useState<number>();
+
+  const switchId = useUniqueId('switch');
+  const daysId = useUniqueId('days');
+  const signal = useCancellation();
+
+  useEffect(() => {
+    const { namespace, name } = workspace.workspace;
+    const loadSettings = withErrorReporting('Error loading Workspace Settings')(async () => {
+      const settings = await Ajax(signal).Workspaces.workspaceV2(namespace, name).getSettings();
+      setWorkspaceSettings(settings);
+      // TODO: change to filtering for GcpBucketLifecycle settings. We can assume that there will be at most 1.
+      if (settings.length > 0 && settings[0].settingType === 'GcpBucketLifecycle') {
+        const lifecycleSetting = settings[0] satisfies BucketLifecycleSetting;
+        setLifecycleRules(lifecycleSetting);
+        const rule = getBucketLifecycleRule(lifecycleSetting);
+        if (rule) {
+          setLifecycleRulesEnabled(true);
+          const prefixes = rule.conditions.matchesPrefix;
+          if (prefixes.length === 0) {
+            setPrefixes([allObjects]);
+          } else {
+            setPrefixes(prefixes);
+          }
+          setLifecycleAge(rule.conditions.age);
+        }
+      }
+    });
+
+    loadSettings();
+  }, [workspace, signal]);
+
+  const getBucketLifecycleRule = (
+    bucketLifecycleSetting: BucketLifecycleSetting | undefined
+  ): BucketLifecycleRule | undefined => {
+    const configRules = bucketLifecycleSetting?.config.rules;
+
+    return !!configRules && configRules.length >= 1 ? configRules[0] : undefined;
+  };
+
+  // TODOs: will need to disable controls if the feature as a whole is off.
+  // Although the API supports multiple rules, we only allow viewing and editing the first one.
+  // The others will be retained if they exist, but not displayed.
+
+  const prefixOptions = () => {
+    // Append together suggested options, any options that were already get in GCP, plus anything the user
+    // has added in the modal.
+    const currentLifecycleRule = getBucketLifecycleRule(lifecycleRules);
+    const gcpPrefixes = currentLifecycleRule ? currentLifecycleRule.conditions.matchesPrefix : [];
+    const allOptions = _.uniq([allObjects, 'submissions/intermediates/', ...prefixes, ...gcpPrefixes]);
+    return _.map((value) => ({ value, label: value }), allOptions);
+  };
+
+  const persistSettings = async () => {
+    const { namespace, name } = workspace.workspace;
+    // TODO: error handling, validing that the user entered values, and merge with existing settings.
+    if (lifecycleRulesEnabled) {
+      const newRules: BucketLifecycleRule = {
+        action: { actionType: 'Delete' },
+        conditions: { age: lifecycleAge!, matchesPrefix: prefixes },
+      };
+      const newSetting: BucketLifecycleSetting = {
+        settingType: 'GcpBucketLifecycle',
+        config: { rules: [newRules] },
+      };
+      await Ajax().Workspaces.workspaceV2(namespace, name).updateSettings([newSetting]);
+    } else {
+      // If we're disabling lifecycle rules, we should remove the setting.
+      await Ajax()
+        .Workspaces.workspaceV2(namespace, name)
+        .updateSettings([
+          {
+            settingType: 'GcpBucketLifecycle',
+            config: { rules: [] },
+          },
+        ]);
+    }
+    onDismiss();
+  };
+
+  const loading = workspaceSettings === undefined;
   return (
     <Modal
-      title='Workspace Settings'
+      title='Configure Workspace Settings'
       onDismiss={onDismiss}
-      // okButton={<ButtonPrimary onClick={toggleWorkspaceLock}>{helpText}</ButtonPrimary>}
+      okButton={<ButtonPrimary onClick={persistSettings}>Ok</ButtonPrimary>}
     >
-      <div>Set some settings</div>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: 6 }}>
+        <FormLabel htmlFor={switchId} style={{ fontWeight: 'bold', whiteSpace: 'nowrap', marginRight: '5px' }}>
+          Lifecycle Rules:
+        </FormLabel>
+        <Switch
+          onLabel=''
+          offLabel=''
+          onChange={(checked: boolean) => {
+            setLifecycleRulesEnabled(checked);
+          }}
+          id={switchId}
+          checked={lifecycleRulesEnabled}
+          width={40}
+          height={20}
+        />
+      </div>
+      <div style={{ marginTop: '5px', fontSize: '12px' }}>
+        This setting allows you to automatically delete objects in the bucket a certain number of days after they are
+        uploaded to the bucket. You can limit the deletion to objects that start with one or more prefixes.
+      </div>
+      <div style={{ marginTop: '10px', marginBottom: '10px' }}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <FormLabel style={{ marginRight: '5px' }} htmlFor={daysId}>
+            Deletion age (in days):
+          </FormLabel>
+          <NumberInput
+            style={{ maxWidth: '100px' }}
+            id={daysId}
+            min={0}
+            isClearable={false}
+            onlyInteger
+            value={lifecycleAge}
+            disabled={!lifecycleRulesEnabled}
+            onChange={(value: number) => setLifecycleAge(value)}
+          />
+        </div>
+        <div style={{ marginTop: '5px', marginBottom: '5px' }}>Prefix scoping rules:</div>
+        <CreatableSelect
+          isClearable
+          isMulti
+          isSearchable
+          placeholder='Choose "All Objects" or specify prefixes'
+          aria-label='Filter by access levels'
+          value={_.map((value) => ({ value, label: value }), prefixes)}
+          onChange={(data) => {
+            const selectedPrefixes = _.map('value', data);
+            // If added "All Objects", clear the others.
+            if (_.contains(allObjects, selectedPrefixes) && !_.contains(allObjects, prefixes)) {
+              setPrefixes([allObjects]);
+            } else if (selectedPrefixes.length > 1) {
+              setPrefixes(_.without([allObjects], selectedPrefixes));
+            } else {
+              setPrefixes(selectedPrefixes);
+            }
+          }}
+          options={prefixOptions()}
+          isDisabled={!lifecycleRulesEnabled}
+        />
+      </div>
+      {loading && <SpinnerOverlay />}
     </Modal>
   );
 };

--- a/src/workspaces/SettingsModal/utils.test.ts
+++ b/src/workspaces/SettingsModal/utils.test.ts
@@ -1,0 +1,382 @@
+import {
+  BucketLifecycleSetting,
+  modifyFirstBucketDeletionRule,
+  removeFirstBucketDeletionRule,
+  WorkspaceSetting,
+} from 'src/workspaces/SettingsModal/utils';
+
+describe('disableFirstBucketDeletionRule', () => {
+  it('returns an empty array', async () => {
+    // Assert
+    expect(removeFirstBucketDeletionRule([])).toEqual([]);
+  });
+
+  it('returns original settings if no bucket lifecyle setting', async () => {
+    // Act
+    const otherSetting: WorkspaceSetting = {
+      settingType: 'OtherSetting',
+    };
+    const result = removeFirstBucketDeletionRule([otherSetting]);
+
+    // Assert
+    expect(result).toEqual([otherSetting]);
+  });
+
+  it('removes the first delete rule (of multiple) in the first bucket lifecycle setting', async () => {
+    // Act
+    const otherSetting: WorkspaceSetting = {
+      settingType: 'OtherSetting',
+    };
+    const firstDeleteSetting: BucketLifecycleSetting = {
+      settingType: 'GcpBucketLifecycle',
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 1,
+              matchesPrefix: [],
+            },
+          },
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 2,
+              matchesPrefix: [],
+            },
+          },
+          {
+            action: {
+              actionType: 'OtherAction',
+            },
+          },
+        ],
+      },
+    };
+    const secondDeleteSetting: BucketLifecycleSetting = {
+      settingType: 'GcpBucketLifecycle',
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 0,
+              matchesPrefix: [],
+            },
+          },
+        ],
+      },
+    };
+    const result = removeFirstBucketDeletionRule([otherSetting, firstDeleteSetting, secondDeleteSetting]);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 2,
+                matchesPrefix: [],
+              },
+            },
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      secondDeleteSetting,
+      otherSetting, // The implementation puts other settings at the end
+    ]);
+  });
+
+  it('removes the first delete rule in the first bucket lifecycle setting', async () => {
+    // Act
+    const otherSetting: WorkspaceSetting = {
+      settingType: 'OtherSetting',
+    };
+    const firstDeleteSetting: BucketLifecycleSetting = {
+      settingType: 'GcpBucketLifecycle',
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'OtherAction',
+            },
+          },
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 1,
+              matchesPrefix: [],
+            },
+          },
+        ],
+      },
+    };
+    const secondDeleteSetting: BucketLifecycleSetting = {
+      settingType: 'GcpBucketLifecycle',
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 0,
+              matchesPrefix: [],
+            },
+          },
+        ],
+      },
+    };
+    const result = removeFirstBucketDeletionRule([otherSetting, firstDeleteSetting, secondDeleteSetting]);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      secondDeleteSetting,
+      otherSetting, // The implementation puts other settings at the end
+    ]);
+  });
+});
+
+describe('modifyFirstBucketDeletionRule', () => {
+  it('adds a new setting to an empty array', async () => {
+    // Arrange
+    const newSetting: BucketLifecycleSetting = {
+      settingType: 'GcpBucketLifecycle',
+      config: {
+        rules: [
+          {
+            action: {
+              actionType: 'Delete',
+            },
+            conditions: {
+              age: 1,
+              matchesPrefix: [],
+            },
+          },
+        ],
+      },
+    };
+    // Act
+    const result = modifyFirstBucketDeletionRule([], 1, []);
+
+    // Assert
+    expect(result).toEqual([newSetting]);
+  });
+
+  it('adds a new setting in the case of no existing delete bucket lifecycle', async () => {
+    // Arrange
+    const originalSettings = [
+      {
+        settingType: 'OtherSetting',
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'SecondOtherAction',
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    // Act
+    const result = modifyFirstBucketDeletionRule(originalSettings, 1, ['a/', 'b/']);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 1,
+                matchesPrefix: ['a/', 'b/'],
+              },
+            },
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'SecondOtherAction',
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'OtherSetting', // Algorithm concats other settings at the end
+      },
+    ]);
+  });
+
+  it('modifies the first delete rule found', async () => {
+    // Arrange
+    const originalSettings = [
+      {
+        settingType: 'OtherSetting',
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 0,
+                matchesPrefix: [],
+              },
+            },
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 1,
+                matchesPrefix: ['a/', 'b/'],
+              },
+            },
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 0,
+                matchesPrefix: [],
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    // Act
+    const result = modifyFirstBucketDeletionRule(originalSettings, 365, ['submissions/']);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 365,
+                matchesPrefix: ['submissions/'],
+              },
+            },
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 1,
+                matchesPrefix: ['a/', 'b/'],
+              },
+            },
+            {
+              action: {
+                actionType: 'OtherAction',
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'GcpBucketLifecycle',
+        config: {
+          rules: [
+            {
+              action: {
+                actionType: 'Delete',
+              },
+              conditions: {
+                age: 0,
+                matchesPrefix: [],
+              },
+            },
+          ],
+        },
+      },
+      {
+        settingType: 'OtherSetting', // Algorithm concats other settings at the end
+      },
+    ]);
+  });
+});

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -1,5 +1,11 @@
 import _ from 'lodash/fp';
 
+export const suggestedPrefixes = {
+  allObjects: 'All Objects',
+  submissions: 'submissions/',
+  submissionIntermediaries: 'submissions/intermediates/',
+};
+
 interface BucketLifecycleRule {
   action: {
     actionType: string;

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -1,0 +1,113 @@
+import _ from 'lodash/fp';
+
+interface BucketLifecycleRule {
+  action: {
+    actionType: string;
+  };
+  conditions?: any;
+}
+
+export interface DeleteBucketLifecycleRule extends BucketLifecycleRule {
+  action: {
+    actionType: 'Delete';
+  };
+  conditions: {
+    age: number;
+    matchesPrefix: string[];
+  };
+}
+
+export interface WorkspaceSetting {
+  settingType: string;
+}
+
+export interface BucketLifecycleSetting extends WorkspaceSetting {
+  settingType: 'GcpBucketLifecycle';
+  config: { rules: BucketLifecycleRule[] };
+}
+
+export const isBucketLifecycleSetting = (setting: WorkspaceSetting): setting is BucketLifecycleSetting =>
+  setting.settingType === 'GcpBucketLifecycle';
+
+export const isDeleteBucketLifecycleRule = (rule: BucketLifecycleRule): rule is DeleteBucketLifecycleRule =>
+  rule.action.actionType === 'Delete';
+
+/**
+ * Removes the first delete rule from the first bucketLifecycleSetting in the workspace settings.
+ * Pulled out for unit tests.
+ */
+export const removeFirstBucketDeletionRule = (originalSettings: WorkspaceSetting[]): WorkspaceSetting[] => {
+  const workspaceSettings = _.cloneDeep(originalSettings); // cloning mostly for testing purposes
+
+  const bucketLifecycleSettings: BucketLifecycleSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
+    isBucketLifecycleSetting(setting)
+  ) as BucketLifecycleSetting[];
+  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isBucketLifecycleSetting(setting));
+
+  // If no bucketLifecycleSettings existed, nothing to delete
+  if (bucketLifecycleSettings.length === 0) {
+    return otherSettings;
+  }
+
+  // If multiple bucketLifecycleSettings, we will modify only the first one.
+  const existingSetting = bucketLifecycleSettings[0];
+  // Remove the first delete rule in this setting and leave the rest.
+  const deleteRules = existingSetting.config.rules.filter((rule) => rule.action.actionType === 'Delete');
+  const otherRules = existingSetting.config.rules.filter((rule) => rule.action.actionType !== 'Delete');
+  bucketLifecycleSettings[0].config.rules = _.concat(deleteRules.slice(1), otherRules);
+
+  return _.concat(bucketLifecycleSettings, otherSettings);
+};
+
+export const modifyFirstBucketDeletionRule = (
+  originalSettings: WorkspaceSetting[],
+  days: number,
+  prefixes: string[]
+): WorkspaceSetting[] => {
+  const workspaceSettings = _.cloneDeep(originalSettings); // cloning mostly for testing purposes
+
+  const bucketLifecycleSettings: BucketLifecycleSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
+    isBucketLifecycleSetting(setting)
+  ) as BucketLifecycleSetting[];
+  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isBucketLifecycleSetting(setting));
+
+  // If no bucketLifecycleSettings existed, create a new one.
+  if (bucketLifecycleSettings.length === 0) {
+    // @ts-ignore
+    return _.concat(
+      [
+        {
+          settingType: 'GcpBucketLifecycle',
+          config: {
+            rules: [
+              {
+                action: { actionType: 'Delete' },
+                conditions: { age: days, matchesPrefix: prefixes },
+              },
+            ],
+          },
+        } as BucketLifecycleSetting,
+      ],
+      otherSettings
+    );
+  }
+  // If multiple bucketLifecycleSettings, we will modify only the first one.
+  const existingSetting = bucketLifecycleSettings[0];
+  // Modify the first delete rule in this setting and leave the rest.
+  const deleteRules: DeleteBucketLifecycleRule[] = existingSetting.config.rules.filter((rule) =>
+    isDeleteBucketLifecycleRule(rule)
+  ) as DeleteBucketLifecycleRule[];
+  const otherRules = existingSetting.config.rules.filter((rule) => !isDeleteBucketLifecycleRule(rule));
+
+  if (deleteRules.length === 0) {
+    deleteRules.push({
+      action: { actionType: 'Delete' },
+      conditions: { age: days, matchesPrefix: prefixes },
+    });
+  } else {
+    deleteRules[0].conditions.age = days;
+    deleteRules[0].conditions.matchesPrefix = prefixes;
+  }
+  bucketLifecycleSettings[0].config.rules = _.concat(deleteRules, otherRules);
+  return _.concat(bucketLifecycleSettings, otherSettings);
+};

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -43,7 +43,8 @@ export const isDeleteBucketLifecycleRule = (rule: BucketLifecycleRule): rule is 
  * Pulled out for unit tests.
  */
 export const removeFirstBucketDeletionRule = (originalSettings: WorkspaceSetting[]): WorkspaceSetting[] => {
-  const workspaceSettings = _.cloneDeep(originalSettings); // cloning mostly for testing purposes
+  // Clone original for testing purposes and to allow eventing only if there was a change.
+  const workspaceSettings = _.cloneDeep(originalSettings);
 
   const bucketLifecycleSettings: BucketLifecycleSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
     isBucketLifecycleSetting(setting)
@@ -70,7 +71,8 @@ export const modifyFirstBucketDeletionRule = (
   days: number,
   prefixes: string[]
 ): WorkspaceSetting[] => {
-  const workspaceSettings = _.cloneDeep(originalSettings); // cloning mostly for testing purposes
+  // Clone original for testing purposes and to allow eventing only if there was a change.
+  const workspaceSettings = _.cloneDeep(originalSettings);
 
   const bucketLifecycleSettings: BucketLifecycleSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
     isBucketLifecycleSetting(setting)

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -414,7 +414,7 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
         expect(screen.queryByRole('tooltip', { name: tooltipText.deleteNoPermission })).not.toBeNull();
       }
     }
-  });
+  );
 
   it.each([
     { menuText: 'Share' },
@@ -466,7 +466,6 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
 describe('Settings menu item (GCP or Azure workspace)', () => {
   it('does not show the settings menu item if the feature flag is disabled', () => {
     asMockedFn(useWorkspaceDetails).mockReturnValue({
-      // @ts-expect-error - the type checker thinks workspace is only of type undefined
       workspace: googleWorkspace,
       refresh: jest.fn(),
       loading: false,
@@ -482,7 +481,6 @@ describe('Settings menu item (GCP or Azure workspace)', () => {
 
   it('Shows an enabled settings menu item for GCP workspaces if the feature flag is enabled', () => {
     asMockedFn(useWorkspaceDetails).mockReturnValue({
-      // @ts-expect-error - the type checker thinks workspace is only of type undefined
       workspace: googleWorkspace,
       refresh: jest.fn(),
       loading: false,
@@ -499,7 +497,6 @@ describe('Settings menu item (GCP or Azure workspace)', () => {
 
   it('shows a disabled settings menu item with a tooltip for Azure workspaces if feature flag is enabled', () => {
     asMockedFn(useWorkspaceDetails).mockReturnValue({
-      // @ts-expect-error - the type checker thinks workspace is only of type undefined
       workspace: azureWorkspace,
       refresh: jest.fn(),
       loading: false,

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { div, h } from 'react-hyperscript-helpers';
 import { MenuTrigger } from 'src/components/PopupTrigger';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { GCP_BUCKET_LIFECYCLE_RULES } from 'src/libs/feature-previews-config';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, protectedDataPolicy } from 'src/testing/workspace-fixtures';
 import { useWorkspaceDetails } from 'src/workspaces/common/state/useWorkspaceDetails';
@@ -29,6 +31,14 @@ jest.mock('src/components/PopupTrigger', () => {
   };
 });
 
+type FeaturePreviewsExports = typeof import('src/libs/feature-previews');
+jest.mock('src/libs/feature-previews', (): FeaturePreviewsExports => {
+  return {
+    ...jest.requireActual<FeaturePreviewsExports>('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn(),
+  };
+});
+
 const workspaceMenuProps = {
   iconSize: 20,
   popupLocation: 'left',
@@ -38,8 +48,43 @@ const workspaceMenuProps = {
     onLock: () => {},
     onDelete: () => {},
     onLeave: () => {},
+    onShowSettings: () => {},
   },
   workspaceInfo: { name: 'example1', namespace: 'example-billing-project' },
+};
+
+const descriptionText =
+  'This description is longer then two hundred and fifty five characters, to ensure we can test that all two hundred and fifty five characters actually get copied over during a cloning event. If they are not copied over then it is indeed a bug that needs to fail the test. (280chars)';
+const googleWorkspace: GoogleWorkspace = {
+  // @ts-expect-error - Limit return values based on what is requested
+  workspace: {
+    cloudPlatform: 'Gcp',
+    googleProject: 'googleProjectName',
+    bucketName: 'fc-bucketname',
+    isLocked: false,
+    state: 'Ready',
+    attributes: {
+      description: descriptionText,
+    },
+  },
+  accessLevel: 'OWNER',
+  canShare: true,
+  policies: [],
+};
+
+const azureWorkspace: AzureWorkspace = {
+  // @ts-expect-error - Limit return values based on what is requested
+  workspace: {
+    cloudPlatform: 'Azure',
+    isLocked: false,
+    state: 'Ready',
+    attributes: {
+      description: descriptionText,
+    },
+  },
+  accessLevel: 'OWNER',
+  canShare: true,
+  policies: [protectedDataPolicy],
 };
 
 beforeEach(() => {
@@ -52,6 +97,8 @@ describe('WorkspaceMenu - undefined workspace', () => {
   beforeEach(() => {
     // Arrange
     asMockedFn(useWorkspaceDetails).mockReturnValue({ workspace: undefined, loading: false, refresh: jest.fn() });
+    // Enable feature flag for Settings menu (check to be removed when soft delete option is added).
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
   });
 
   it('should not fail any accessibility tests', async () => {
@@ -61,7 +108,7 @@ describe('WorkspaceMenu - undefined workspace', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it.each(['Clone', 'Share', 'Lock', 'Leave', 'Delete'])('renders menu item %s as disabled', (menuText) => {
+  it.each(['Clone', 'Share', 'Lock', 'Leave', 'Delete', 'Settings'])('renders menu item %s as disabled', (menuText) => {
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));
     const menuItem = screen.getByText(menuText);
@@ -74,6 +121,7 @@ describe('WorkspaceMenu - undefined workspace', () => {
     { menuText: 'Delete', tooltipText: tooltipText.deleteLocked },
     { menuText: 'Delete', tooltipText: tooltipText.deleteNoPermission },
     { menuText: 'Lock', tooltipText: tooltipText.lockNoPermission },
+    { menuText: 'Settings', tooltipText: tooltipText.azureWorkspaceNoSettings },
   ])('does not render tooltip text "$tooltipText" for menu item $menuText', ({ menuText, tooltipText }) => {
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));
@@ -84,6 +132,11 @@ describe('WorkspaceMenu - undefined workspace', () => {
 });
 
 describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
+  beforeEach(() => {
+    // Enable feature flag for Settings menu (check to be removed when soft delete option is added).
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
+  });
+
   it('should not fail any accessibility tests', async () => {
     // Arrange
     asMockedFn(useWorkspaceDetails).mockReturnValue({
@@ -172,6 +225,9 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
 
     const deleteItem = screen.getByText('Delete');
     expect(deleteItem).toHaveAttribute('disabled');
+
+    const settingsItem = screen.getByText('Settings');
+    expect(settingsItem).toHaveAttribute('disabled');
   });
 
   it('disables all items except Share and Delete for a workspace in state DeleteFailed', () => {
@@ -205,6 +261,9 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
 
     const leave = screen.getByText('Leave');
     expect(leave).toHaveAttribute('disabled');
+
+    const settingsItem = screen.getByText('Settings');
+    expect(settingsItem).toHaveAttribute('disabled');
   });
 
   it.each([true, false])('renders Share tooltip based on canShare: %s', (canShare) => {
@@ -352,41 +411,61 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
   );
 });
 
+describe('Settings menu item (GCP or Azure workspace)', () => {
+  it('does not show the settings menu item if the feature flag is disabled', () => {
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
+      // @ts-expect-error - the type checker thinks workspace is only of type undefined
+      workspace: googleWorkspace,
+      refresh: jest.fn(),
+      loading: false,
+    });
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+
+    // Act
+    render(h(WorkspaceMenu, workspaceMenuProps));
+
+    // Assert
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  it('Shows an enabled settings menu item for GCP workspaces if the feature flag is enabled', () => {
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
+      // @ts-expect-error - the type checker thinks workspace is only of type undefined
+      workspace: googleWorkspace,
+      refresh: jest.fn(),
+      loading: false,
+    });
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
+
+    // Act
+    render(h(WorkspaceMenu, workspaceMenuProps));
+
+    // Assert
+    const menuItem = screen.getByText('Settings');
+    expect(menuItem).not.toHaveAttribute('disabled');
+  });
+
+  it('shows a disabled settings menu item with a tooltip for Azure workspaces if feature flag is enabled', () => {
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
+      // @ts-expect-error - the type checker thinks workspace is only of type undefined
+      workspace: azureWorkspace,
+      refresh: jest.fn(),
+      loading: false,
+    });
+    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
+
+    // Act
+    render(h(WorkspaceMenu, workspaceMenuProps));
+
+    // Assert
+    const menuItem = screen.getByText('Settings');
+    expect(menuItem).toHaveAttribute('disabled');
+    // Verify tooltip text
+    screen.getByText(tooltipText.azureWorkspaceNoSettings);
+  });
+});
+
 describe('DynamicWorkspaceMenuContent fetches specific workspace details', () => {
-  const descriptionText =
-    'This description is longer then two hundred and fifty five characters, to ensure we can test that all two hundred and fifty five characters actually get copied over during a cloning event. If they are not copied over then it is indeed a bug that needs to fail the test. (280chars)';
-  const googleWorkspace: GoogleWorkspace = {
-    // @ts-expect-error - Limit return values based on what is requested
-    workspace: {
-      cloudPlatform: 'Gcp',
-      googleProject: 'googleProjectName',
-      bucketName: 'fc-bucketname',
-      isLocked: false,
-      state: 'Ready',
-      attributes: {
-        description: descriptionText,
-      },
-    },
-    accessLevel: 'OWNER',
-    canShare: true,
-    policies: [],
-  };
-
-  const azureWorkspace: AzureWorkspace = {
-    // @ts-expect-error - Limit return values based on what is requested
-    workspace: {
-      cloudPlatform: 'Azure',
-      isLocked: false,
-      state: 'Ready',
-      attributes: {
-        description: descriptionText,
-      },
-    },
-    accessLevel: 'OWNER',
-    canShare: true,
-    policies: [protectedDataPolicy],
-  };
-
   const onClone = jest.fn((_policies, _bucketName, _description, _googleProject) => {});
   const onShare = jest.fn((_policies, _bucketName) => {});
   const namespace = 'test-namespace';
@@ -395,7 +474,14 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
   const workspaceMenuProps = {
     iconSize: 20,
     popupLocation: 'left',
-    callbacks: { onClone, onShare, onLock: jest.fn(), onDelete: jest.fn(), onLeave: jest.fn() },
+    callbacks: {
+      onClone,
+      onShare,
+      onLock: jest.fn(),
+      onDelete: jest.fn(),
+      onLeave: jest.fn(),
+      onShowSettings: jest.fn(),
+    },
     workspaceInfo: { namespace, name },
   };
 

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -245,7 +245,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
           !isOwner && [isLocked ? tooltipText.unlockNoPermission : tooltipText.lockNoPermission],
         tooltipSide: 'left',
         onClick: () => {
-          menuClicked('Lock');
+          menuClicked(isLocked ? 'Unlock' : 'Lock');
           onLock();
         },
       },

--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -88,6 +88,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
   const [sharingWorkspace, setSharingWorkspace] = useState(false);
   const [showLockWorkspaceModal, setShowLockWorkspaceModal] = useState(false);
   const [leavingWorkspace, setLeavingWorkspace] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
   const isGoogleWorkspaceSyncing = isGoogleWorkspace(workspace) && workspace.workspaceInitialized === false;
 
   useCloningWorkspaceNotifications();
@@ -113,6 +114,7 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
       setLeavingWorkspace,
       setSharingWorkspace,
       setShowLockWorkspaceModal,
+      setShowSettingsModal,
     }),
     h(WorkspaceDeletingBanner, { workspace }),
     isGoogleWorkspaceSyncing && h(GooglePermissionsSpinner),
@@ -147,6 +149,8 @@ export const WorkspaceContainer = (props: WorkspaceContainerProps) => {
       setSharingWorkspace,
       showLockWorkspaceModal,
       setShowLockWorkspaceModal,
+      showSettingsModal,
+      setShowSettingsModal,
     }),
   ]);
 };

--- a/src/workspaces/container/WorkspaceContainerModals.tsx
+++ b/src/workspaces/container/WorkspaceContainerModals.tsx
@@ -83,7 +83,7 @@ export const WorkspaceContainerModals = (props: WorkspaceContainerModalsProps): 
         />
       )}
       {sharingWorkspace && <ShareWorkspaceModal workspace={workspace} onDismiss={() => setSharingWorkspace(false)} />}
-      {showSettingsModal && <SettingsModal workspace={workspace} onDismiss={() => setShowSettingsModal(false)} />}
+      {showSettingsModal && <SettingsModal onDismiss={() => setShowSettingsModal(false)} />}
     </>
   );
 };

--- a/src/workspaces/container/WorkspaceContainerModals.tsx
+++ b/src/workspaces/container/WorkspaceContainerModals.tsx
@@ -83,7 +83,7 @@ export const WorkspaceContainerModals = (props: WorkspaceContainerModalsProps): 
         />
       )}
       {sharingWorkspace && <ShareWorkspaceModal workspace={workspace} onDismiss={() => setSharingWorkspace(false)} />}
-      {showSettingsModal && <SettingsModal onDismiss={() => setShowSettingsModal(false)} />}
+      {showSettingsModal && <SettingsModal workspace={workspace} onDismiss={() => setShowSettingsModal(false)} />}
     </>
   );
 };

--- a/src/workspaces/container/WorkspaceContainerModals.tsx
+++ b/src/workspaces/container/WorkspaceContainerModals.tsx
@@ -6,6 +6,7 @@ import { InitializedWorkspaceWrapper } from 'src/workspaces/common/state/useWork
 import DeleteWorkspaceModal from 'src/workspaces/DeleteWorkspaceModal/DeleteWorkspaceModal';
 import LockWorkspaceModal from 'src/workspaces/LockWorkspaceModal/LockWorkspaceModal';
 import { NewWorkspaceModal } from 'src/workspaces/NewWorkspaceModal/NewWorkspaceModal';
+import SettingsModal from 'src/workspaces/SettingsModal/SettingsModal';
 import ShareWorkspaceModal from 'src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal';
 import { isGoogleWorkspace } from 'src/workspaces/utils';
 
@@ -22,6 +23,8 @@ export interface WorkspaceContainerModalsProps {
   setSharingWorkspace: (value: boolean) => void;
   showLockWorkspaceModal: boolean;
   setShowLockWorkspaceModal: (value: boolean) => void;
+  showSettingsModal: boolean;
+  setShowSettingsModal: (value: boolean) => void;
 }
 export const WorkspaceContainerModals = (props: WorkspaceContainerModalsProps): ReactNode => {
   const {
@@ -37,6 +40,8 @@ export const WorkspaceContainerModals = (props: WorkspaceContainerModalsProps): 
     setSharingWorkspace,
     showLockWorkspaceModal,
     setShowLockWorkspaceModal,
+    showSettingsModal,
+    setShowSettingsModal,
   } = props;
   return (
     <>
@@ -78,6 +83,7 @@ export const WorkspaceContainerModals = (props: WorkspaceContainerModalsProps): 
         />
       )}
       {sharingWorkspace && <ShareWorkspaceModal workspace={workspace} onDismiss={() => setSharingWorkspace(false)} />}
+      {showSettingsModal && <SettingsModal workspace={workspace} onDismiss={() => setShowSettingsModal(false)} />}
     </>
   );
 };

--- a/src/workspaces/container/WorkspaceTabs.test.ts
+++ b/src/workspaces/container/WorkspaceTabs.test.ts
@@ -145,6 +145,8 @@ describe('WorkspaceTabs', () => {
           isOwner: true,
           workspaceLoaded: true,
           cloudProvider: cloudProviderTypes.GCP,
+          namespace: props.namespace,
+          name: props.name,
         },
       })
     );
@@ -176,6 +178,8 @@ describe('WorkspaceTabs', () => {
           isOwner: false,
           workspaceLoaded: false,
           cloudProvider: undefined,
+          namespace: props.namespace,
+          name: props.name,
         },
       })
     );

--- a/src/workspaces/container/WorkspaceTabs.test.ts
+++ b/src/workspaces/container/WorkspaceTabs.test.ts
@@ -5,7 +5,7 @@ import { h } from 'react-hyperscript-helpers';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { WorkspaceTabs } from 'src/workspaces/container/WorkspaceTabs';
-import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
+import { cloudProviderTypes, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 // Mocking for Nav.getLink
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
@@ -50,6 +50,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
 
     // Act
@@ -76,6 +77,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
     // Act
     const { container } = render(h(WorkspaceTabs, props));
@@ -101,6 +103,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
     // Act
     const { container } = render(h(WorkspaceTabs, props));
@@ -127,6 +130,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
 
     // Act
@@ -135,7 +139,13 @@ describe('WorkspaceTabs', () => {
     // Assert
     expect(mockWorkspaceMenu).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspaceInfo: { canShare: true, isLocked: false, isOwner: true, workspaceLoaded: true },
+        workspaceInfo: {
+          canShare: true,
+          isLocked: false,
+          isOwner: true,
+          workspaceLoaded: true,
+          cloudProvider: cloudProviderTypes.GCP,
+        },
       })
     );
   });
@@ -152,6 +162,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
 
     // Act
@@ -159,7 +170,13 @@ describe('WorkspaceTabs', () => {
     // Assert
     expect(mockWorkspaceMenu).toHaveBeenCalledWith(
       expect.objectContaining({
-        workspaceInfo: { canShare: false, isLocked: false, isOwner: false, workspaceLoaded: false },
+        workspaceInfo: {
+          canShare: false,
+          isLocked: false,
+          isOwner: false,
+          workspaceLoaded: false,
+          cloudProvider: undefined,
+        },
       })
     );
   });
@@ -180,6 +197,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
     // Act
     render(h(WorkspaceTabs, props));
@@ -206,6 +224,7 @@ describe('WorkspaceTabs', () => {
       setShowLockWorkspaceModal: () => {},
       setLeavingWorkspace: () => {},
       refresh: () => {},
+      setShowSettingsModal: () => {},
     };
     // Act
     render(h(WorkspaceTabs, props));

--- a/src/workspaces/container/WorkspaceTabs.ts
+++ b/src/workspaces/container/WorkspaceTabs.ts
@@ -7,6 +7,7 @@ import * as Nav from 'src/libs/nav';
 import { WorkspaceMenu } from 'src/workspaces/common/WorkspaceMenu';
 import { WorkspaceAttributeNotice } from 'src/workspaces/container/WorkspaceAttributeNotice';
 import {
+  getCloudProviderFromWorkspace,
   isAzureWorkspace,
   isGoogleWorkspace,
   isOwner,
@@ -27,6 +28,7 @@ export interface WorkspaceTabsProps {
   setSharingWorkspace: Dispatch<boolean>;
   setShowLockWorkspaceModal: Dispatch<boolean>;
   setLeavingWorkspace: Dispatch<boolean>;
+  setShowSettingsModal: Dispatch<boolean>;
 }
 
 export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
@@ -39,6 +41,7 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
     setSharingWorkspace,
     setShowLockWorkspaceModal,
     setLeavingWorkspace,
+    setShowSettingsModal,
   } = props;
   const { namespace, name } = props;
   const wsOwner = !!workspace && isOwner(workspace.accessLevel);
@@ -51,6 +54,9 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
   const onLock = () => setShowLockWorkspaceModal(true);
   const onShare = () => setSharingWorkspace(true);
   const onLeave = () => setLeavingWorkspace(true);
+  const onShowSettings = () => {
+    setShowSettingsModal(true);
+  };
 
   const tabs = getTabs(workspace);
 
@@ -74,13 +80,14 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
       h(WorkspaceMenu, {
         iconSize: 27,
         popupLocation: 'bottom',
-        callbacks: { onClone, onShare, onLock, onDelete, onLeave },
+        callbacks: { onClone, onShare, onLock, onDelete, onLeave, onShowSettings },
         workspaceInfo: {
           state: workspace?.workspace?.state,
           canShare: !!canShare,
           isLocked,
           isOwner: wsOwner,
           workspaceLoaded,
+          cloudProvider: !workspace ? undefined : getCloudProviderFromWorkspace(workspace),
         },
       }),
     ]

--- a/src/workspaces/container/WorkspaceTabs.ts
+++ b/src/workspaces/container/WorkspaceTabs.ts
@@ -54,9 +54,7 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
   const onLock = () => setShowLockWorkspaceModal(true);
   const onShare = () => setSharingWorkspace(true);
   const onLeave = () => setLeavingWorkspace(true);
-  const onShowSettings = () => {
-    setShowSettingsModal(true);
-  };
+  const onShowSettings = () => setShowSettingsModal(true);
 
   const tabs = getTabs(workspace);
 

--- a/src/workspaces/container/WorkspaceTabs.ts
+++ b/src/workspaces/container/WorkspaceTabs.ts
@@ -88,6 +88,8 @@ export const WorkspaceTabs = (props: WorkspaceTabsProps): ReactNode => {
           isOwner: wsOwner,
           workspaceLoaded,
           cloudProvider: !workspace ? undefined : getCloudProviderFromWorkspace(workspace),
+          namespace,
+          name,
         },
       }),
     ]

--- a/src/workspaces/list/RenderedWorkspaces.tsx
+++ b/src/workspaces/list/RenderedWorkspaces.tsx
@@ -290,6 +290,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
   const onShare = (policies, bucketName) =>
     setUserActions({ sharingWorkspace: extendWorkspace(workspaceId, policies, bucketName) });
   const onLeave = () => setUserActions({ leavingWorkspaceId: workspaceId });
+  const onShowSettings = () => setUserActions({ showSettingsWorkspaceId: workspaceId });
 
   return (
     <div style={{ ...styles.tableCellContainer, paddingRight: 0 }}>
@@ -297,7 +298,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
         <WorkspaceMenu
           iconSize={20}
           popupLocation='left'
-          callbacks={{ onClone, onShare, onLock, onDelete, onLeave }}
+          callbacks={{ onClone, onShare, onLock, onDelete, onLeave, onShowSettings }}
           workspaceInfo={{ namespace, name }}
         />
       </div>

--- a/src/workspaces/list/WorkspaceUserActions.ts
+++ b/src/workspaces/list/WorkspaceUserActions.ts
@@ -19,6 +19,7 @@ export interface WorkspaceUserActions {
   deletingWorkspaceId?: string;
   lockingWorkspaceId?: string;
   leavingWorkspaceId?: string;
+  showSettingsWorkspaceId?: string;
   requestingAccessWorkspaceId?: string;
   sharingWorkspace?: WorkspaceWrapper;
   cloningWorkspace?: WorkspaceWrapper;

--- a/src/workspaces/list/WorkspacesListModals.ts
+++ b/src/workspaces/list/WorkspacesListModals.ts
@@ -8,6 +8,7 @@ import { WorkspaceUserActionsContext } from 'src/workspaces/list/WorkspaceUserAc
 import LockWorkspaceModal from 'src/workspaces/LockWorkspaceModal/LockWorkspaceModal';
 import { NewWorkspaceModal } from 'src/workspaces/NewWorkspaceModal/NewWorkspaceModal';
 import { RequestAccessModal } from 'src/workspaces/RequestAccessModal/RequestAccessModal';
+import SettingsModal from 'src/workspaces/SettingsModal/SettingsModal';
 import ShareWorkspaceModal from 'src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal';
 import { isGoogleWorkspace, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
@@ -69,6 +70,11 @@ export const WorkspacesListModals = (props: WorkspacesListModalsProps): ReactNod
       h(RequestAccessModal, {
         workspace: getWorkspace(userActions.requestingAccessWorkspaceId),
         onDismiss: () => setUserActions({ requestingAccessWorkspaceId: undefined }),
+      }),
+    !!userActions.showSettingsWorkspaceId &&
+      h(SettingsModal, {
+        workspace: getWorkspace(userActions.showSettingsWorkspaceId),
+        onDismiss: () => setUserActions({ showSettingsWorkspaceId: undefined }),
       }),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1757

To use this, you must enable the [feature flag](https://pr-9-dot-bvdp-saturn-dev.appspot.com/#feature-preview):
![image](https://github.com/user-attachments/assets/32e3cc80-13dd-4991-b820-7d20bc9fc300)

This adds a Workspace Settings dialog which currently has the following properties:
1) It is not shown at all in the workspace menu (list or dashboard) if the feature flag is not enabled.
2) The menu item is always disabled for Azure workspaces.
3) For GCP workspaces, users with owner access and above can change bucket lifecycle settings; readers and writers can view the current settings but cannot change them.

Bucket Lifecycle Settings behavior:
1) By default it is disabled.
2) When enabled, the user must choose an "age" and which objects in the bucket to delete after that "age".
3) The objects to delete can either be "All Objects", or 1 or more prefixes. We offer 3 common options, but the user can type anything they want and we will persist it. There is no validation of anything that they type.

This PR also adds eventing for when workspace menu items are clicked, as well as eventing when the user persists a bucket lifecycle change.

Screenshots:

Owner access:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/d66c2c3b-08e2-4cd5-8c46-cd85e76ae242">

Reader access on same workspace:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/65173956-f3c5-4e2a-a1a1-259723482145">

Lifecycle rules off:
<img width="490" alt="image" src="https://github.com/user-attachments/assets/27a850f4-eff9-4d63-85b9-48653e9025d6">

