### PR TITLE
[WX-1829] Improve workflow name validation

### DIFF
--- a/src/libs/workflow-utils.ts
+++ b/src/libs/workflow-utils.ts
@@ -5,6 +5,7 @@ import * as Utils from 'src/libs/utils';
 export const workflowNameValidation = () => {
   return {
     presence: { allowEmpty: false },
+    length: { maximum: 254 },
     format: {
       pattern: /^[A-Za-z0-9_\-.]*$/,
       message: 'can only contain letters, numbers, underscores, dashes, and periods',

--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -1,6 +1,7 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import _ from 'lodash';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
@@ -274,7 +275,7 @@ describe('ImportWorkflow', () => {
       expect(nameInput).toHaveValue('test-workflow');
     });
 
-    it('validates name', async () => {
+    it('validates name based on allowed symbols', async () => {
       // Arrange
       const user = userEvent.setup();
 
@@ -294,6 +295,28 @@ describe('ImportWorkflow', () => {
 
       // Assert
       screen.getByText('Workflow name can only contain letters, numbers, underscores, dashes, and periods');
+    });
+
+    it('validates name based on maximum length', async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      render(
+        h(ImportWorkflow, {
+          path: 'github.com/DataBiosphere/test-workflows/test-workflow',
+          version: 'v1.0.0',
+          source: 'dockstore',
+        })
+      );
+
+      const nameInput = screen.getByLabelText('Workflow Name');
+
+      // Act
+      await user.clear(nameInput);
+      await user.type(nameInput, _.repeat('a', 255));
+
+      // Assert
+      screen.getByText('Workflow name is too long (maximum is 254 characters)');
     });
   });
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1829

### Dependencies
- [WX-1733](https://broadworkbench.atlassian.net/browse/WX-1733) is dependent on this ticket to be able to implement correct workflow name validation in the modal for that ticket.

## Summary of changes:

### What
- Updated the client-side validation for workflow name inputs (used when importing a workflow from Dockstore or GitHub, copying a workflow from one workspace to another, or duplicating a workflow within a workspace) to show an error message and disable the user action when the input workflow name is greater than 254 characters long.

### Why
- To avoid nondescript `Internal server exception` messages when the user submits a workflow name that is too long.
- To make the error handling in this case consistent with when the workflow name is blank or contains invalid characters, and with other parts of Terra UI that honor Rawls's 254-character limit in their client-side validation.

Note: When importing a workflow from Dockstore or GitHub into an Azure workspace, this same new error message will appear under the same circumstances as for GCP, but CBAS's true upper limit for workflow name lengths is less than 254 characters. (If a workflow name's length is 254 characters or less but greater than CBAS's upper limit, the operation will fail as before.)

### Testing strategy
- [x] Manual testing
- [x] Ran existing unit tests
- [x] Added new unit test for `ImportWorkflow.js` for the new validation
Note: Unit tests for `ExportWorkflowModal.js`, the other consumer of the `workflowNameValidation` function that was updated in this PR, will be added in [WX-1733](https://broadworkbench.atlassian.net/browse/WX-1733). These tests will include a test verifying that this new validation works as intended in the component.

### Visual Aids
Before (after pressing button):
<img width="1512" alt="import workflow old error page image" src="https://github.com/user-attachments/assets/c04ec338-f67a-4404-8ec7-1d5539e8b72c">
<img width="883" alt="import workflow old error toast image" src="https://github.com/user-attachments/assets/b8fe8318-1fdf-4b02-a418-9819b8307f2a">

After:
<img width="1512" alt="import workflow new error image" src="https://github.com/user-attachments/assets/1ef94e7f-56a4-4549-98b8-1aac35aab721">

Before (after pressing button):
<img width="497" alt="copy workflow old error image" src="https://github.com/user-attachments/assets/c119fbfe-a635-41cd-9bac-ba1ad45993eb">

After:
<img width="661" alt="copy workflow new error image" src="https://github.com/user-attachments/assets/2c060b58-fecd-42ac-b8d8-a7fbb0e1bc36">

Before (after pressing button):
<img width="497" alt="duplicate workflow old error image" src="https://github.com/user-attachments/assets/edb2a265-8827-4eed-8c25-14b6b2bfc75f">

After:
<img width="660" alt="duplicate workflow new error image" src="https://github.com/user-attachments/assets/84c8705e-780c-48ed-9dc0-d92406e6b889">


[WX-1733]: https://broadworkbench.atlassian.net/browse/WX-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WX-1733]: https://broadworkbench.atlassian.net/browse/WX-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ