### PR TITLE
[NEEDS JIRA] Use the jupyterStartUserScriptUri field for runtimes instead of jupyterUserScriptUri

### DIFF
--- a/src/analysis/modal-utils.ts
+++ b/src/analysis/modal-utils.ts
@@ -53,9 +53,9 @@ export const buildExistingEnvironmentConfig = (
           cloudService,
           toolDockerImage: getImageUrlFromRuntime(currentRuntimeDetails),
           tool: toolLabel,
-          ...(currentRuntimeDetails?.jupyterUserScriptUri
+          ...(currentRuntimeDetails?.jupyterStartUserScriptUri
             ? {
-                jupyterUserScriptUri: currentRuntimeDetails?.jupyterUserScriptUri,
+                jupyterStartUserScriptUri: currentRuntimeDetails?.jupyterStartUserScriptUri,
               }
             : {}),
           ...(currentRuntimeDetails?.timeoutInMinutes

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -234,7 +234,7 @@ export const GcpComputeModalBase = ({
   const [isCustomSelectedImage, setIsCustomSelectedImage] = useState(false);
   const [customImageUrl, setCustomImageUrl] = useState('');
   const [timeoutInMinutes, setTimeoutInMinutes] = useState(null);
-  const [jupyterUserScriptUri, setJupyterUserScriptUri] = useState('');
+  const [jupyterStartUserScriptUri, setJupyterStartUserScriptUri] = useState('');
   const [runtimeType, setRuntimeType] = useState(runtimeTypes.gceVm);
   const [computeConfig, setComputeConfig] = useState({
     bootDiskSize: defaultGceBootDiskSize,
@@ -403,7 +403,7 @@ export const GcpComputeModalBase = ({
               saturnWorkspaceName: name,
             },
             customEnvironmentVariables: customEnvVars,
-            ...(desiredRuntime.jupyterUserScriptUri ? { jupyterUserScriptUri: desiredRuntime.jupyterUserScriptUri } : {}),
+            ...(desiredRuntime.jupyterStartUserScriptUri ? { jupyterStartUserScriptUri: desiredRuntime.jupyterStartUserScriptUri } : {}),
           });
       }
     }
@@ -443,7 +443,7 @@ export const GcpComputeModalBase = ({
       !desiredRuntime ||
       desiredRuntime.cloudService !== existingRuntime.cloudService ||
       desiredRuntime.toolDockerImage !== existingRuntime.toolDockerImage ||
-      desiredRuntime.jupyterUserScriptUri !== existingRuntime.jupyterUserScriptUri ||
+      desiredRuntime.jupyterStartUserScriptUri !== existingRuntime.jupyterStartUserScriptUri ||
       (desiredRuntime.cloudService === cloudServices.GCE
         ? desiredRuntime.persistentDiskAttached !== existingRuntime.persistentDiskAttached ||
           desiredAutopauseThreshold !== existingAutopauseThreshold ||
@@ -487,7 +487,7 @@ export const GcpComputeModalBase = ({
               cloudService,
               toolDockerImage: isCustomSelectedImage ? customImageUrl : selectedImage?.url,
               tool: selectedImage?.toolLabel ?? getToolLabelFromCloudEnv(existingRuntime),
-              ...(jupyterUserScriptUri ? { jupyterUserScriptUri } : {}),
+              ...(jupyterStartUserScriptUri ? { jupyterStartUserScriptUri } : {}),
               ...(timeoutInMinutes ? { timeoutInMinutes } : {}),
               ...(cloudService === cloudServices.GCE
                 ? {
@@ -792,7 +792,7 @@ export const GcpComputeModalBase = ({
             }
           : null
       );
-      setJupyterUserScriptUri(runtimeDetails?.jupyterUserScriptUri ?? '');
+      setJupyterStartUserScriptUri(runtimeDetails?.jupyterStartUserScriptUri ?? '');
 
       const runtimeImageUrl = getImageUrlFromRuntime(runtimeDetails);
       const locationType = getLocationType(location);
@@ -1020,8 +1020,8 @@ export const GcpComputeModalBase = ({
               h(TextInput, {
                 id,
                 placeholder: 'URI',
-                value: jupyterUserScriptUri,
-                onChange: setJupyterUserScriptUri,
+                value: jupyterStartUserScriptUri,
+                onChange: setJupyterStartUserScriptUri,
               }),
             ]),
           ]),


### PR DESCRIPTION
### Jira Ticket: needs JIRA

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Pass the runtime creation field `jupyterStartUserScriptUri` to Leo instead of `jupyterUserScriptUri`.

### Why
- The behavior of `jupyterUserScriptUri` is that the script only runs on runtime creation, not on runtime resume. This is problematic if the script makes changes outside of the PD mount (which many users do), because all changes are wiped upon container restart. Many users have bumped up against this behavior where their script changes disappear after a pause/resume cycle.
- `jupyterStartUserScriptUri` was introduced long ago to solve this issue. AoU RWB has been successfully using `jupyterStartUserScriptUri` for years, but we never updated Terra UI.
- Note users will need to recreate their runtimes to take advantage of this behavior.


### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- Tested on a BEE with the `gs://rtitle_test/install_vips.sh` user script. I verified that the `libvips` package disappeared after pause/resume before this PR, and it persists after this PR.
- TODO: I would like to add a unit test to `GcpComputeModal.test.js` (looks like it doesn't currently have any tests around user scripts).

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
