### PR TITLE
WOR-1810: Hide azure apps from Cloud Environments page

### DIFF
--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -96,9 +96,6 @@ export const Apps = (signal: AbortSignal) => ({
     const body = {
       appType,
       accessScope,
-      labels: {
-        saturnAutoCreated: 'true',
-      },
     };
     const res = fetchLeo(
       `api/apps/v2/${workspaceId}/${appName}`,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1810

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Remove `saturnAutoCreated` label for newly created v2 (azure) apps.
- This PR will be followed by a migration (https://github.com/DataBiosphere/leonardo/pull/4772) to remove this label for existing apps.

### Why
- Users are seeing public CBAS and CROMWELL_RUNNER apps they did not create in the Cloud Environments screen, which is confusing. This is because the UI lists all apps the user has access to with the `saturnAutoCreated` label. For WOR-1810 we decided to just hide these app types from the Cloud Environments screen. Removing the label accomplishes that. No other Azure workspace functionality depends on this label.
- Note this mirrors the behavior for WDS: WDS apps do not use the `saturnAutoCreated` label and thus they are hidden from the Cloud Environments screen.

### Testing strategy
Tested in a BEE via the following steps:
1. Created Azure workspace (WDS, CBAS, and Cromwell apps) using dev code
2. Verified I see CBAS and Cromwell in the Cloud Envs screen
3. Created Azure workspace using PR code
4. Verified workspace functionality still works
5. Verified I do _not_ see Azure apps from (3) in Cloud Envs screen
6. Deployed Leo migration PR
7. Verified I no longer see any Azure apps in the Cloud Envs screen

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
