### PR TITLE
[WX-1733] Rename `importMethodConfigFromDocker` to `importMethodConfig`

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -203,8 +203,8 @@ const Workspaces = (signal) => ({
         return res.json();
       },
 
-      importMethodConfigFromDocker: (payload) => {
-        return fetchRawls(mcPath, _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]));
+      importMethodConfig: (config) => {
+        return fetchRawls(mcPath, _.mergeAll([authOpts(), jsonBody(config), { signal, method: 'POST' }]));
       },
 
       methodConfig: (configNamespace, configName) => {

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
@@ -24,12 +24,12 @@ describe('importDockstoreWorkflow', () => {
   let workspaceAjax;
   let workspaceMethodConfigAjax;
   let methodConfigInputsOutputs;
-  let importMethodConfigFromDocker;
+  let importMethodConfig;
   let deleteMethodConfig;
 
   beforeEach(() => {
     // Arrange
-    importMethodConfigFromDocker = jest.fn().mockResolvedValue(undefined);
+    importMethodConfig = jest.fn().mockResolvedValue(undefined);
     deleteMethodConfig = jest.fn().mockResolvedValue(undefined);
 
     const mockWorkspaceMethodConfigAjax: Partial<ReturnType<AjaxContract['Workspaces']['workspace']>['methodConfig']> =
@@ -45,7 +45,7 @@ describe('importDockstoreWorkflow', () => {
           participant: { count: 1, idName: 'participant_id', attributeNames: [] },
           sample: { count: 1, idName: 'sample_id', attributeNames: [] },
         }),
-      importMethodConfigFromDocker,
+      importMethodConfig,
       methodConfig: workspaceMethodConfigAjax,
     };
 
@@ -71,7 +71,7 @@ describe('importDockstoreWorkflow', () => {
     await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' });
 
     // Assert
-    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
+    expect(importMethodConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         namespace: testWorkspace.namespace,
         name: 'test-workflow',
@@ -91,9 +91,7 @@ describe('importDockstoreWorkflow', () => {
     await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' });
 
     // Assert
-    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
-      expect.objectContaining({ rootEntityType: 'participant' })
-    );
+    expect(importMethodConfig).toHaveBeenCalledWith(expect.objectContaining({ rootEntityType: 'participant' }));
   });
 
   it('configures default outputs', async () => {
@@ -101,7 +99,7 @@ describe('importDockstoreWorkflow', () => {
     await importDockstoreWorkflow({ workspace: testWorkspace, workflow: testWorkflow, workflowName: 'test-workflow' });
 
     // Assert
-    expect(importMethodConfigFromDocker).toHaveBeenCalledWith(
+    expect(importMethodConfig).toHaveBeenCalledWith(
       expect.objectContaining({
         outputs: {
           'taskA.output1': 'this.output1',

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.ts
@@ -58,7 +58,7 @@ export const importDockstoreWorkflow = async (
     _.fromPairs
   )(workflowOutputs);
 
-  await workspaceApi.importMethodConfigFromDocker({
+  await workspaceApi.importMethodConfig({
     namespace,
     name: workflowName,
     rootEntityType: _.head(_.keys(entityMetadata)),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1733

## Summary of changes:

### What
- Renamed the Ajax function `importMethodConfigFromDocker` (likely intended to be `importMethodConfigFromDockstore`) and its references to `importMethodConfig`.

### Why
- The API call performed by this function is able to import a method configuration into a workspace regardless of its source. A future PR for this ticket will use this function to import a method configuration that ultimately comes from Agora (not Dockstore).

### Testing strategy

- [x] Manual smoke testing
- [x] Ran existing unit tests