### PR TITLE
UIE-200 Ajax cleanup pt1

### DIFF
--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -59,8 +59,8 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
       setTemplateWorkspaces(templates);
       const projects = await Ajax().Billing.listProjects();
       setUserHasBillingProjects(projects.length > 0);
-    });
-    loadTemplateWorkspaces();
+    }) as () => Promise<void>;
+    void loadTemplateWorkspaces();
   });
 
   const importPFB = async (importRequest: PFBImportRequest, workspace: WorkspaceInfo) => {
@@ -178,13 +178,13 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
     }
 
     const { namespace, name } = workspace;
-    Ajax().Metrics.captureEvent(Events.workspaceDataImport, {
+    void Ajax().Metrics.captureEvent(Events.workspaceDataImport, {
       format,
       ...extractWorkspaceDetails(workspace),
       importSource: getImportSource(importRequest),
     });
     Nav.goToPath('workspace-data', { namespace, name });
-  });
+  }) as () => Promise<void>;
 
   return h(Fragment, [
     h(ImportDataOverview, {

--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -1,0 +1,243 @@
+import { jsonBody } from '@terra-ui-packages/data-client-core';
+import _ from 'lodash/fp';
+import * as qs from 'qs';
+import { authOpts } from 'src/auth/auth-session';
+import { fetchAgora, fetchDrsHub, fetchGoogleForms, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
+import { AzureStorage } from 'src/libs/ajax/AzureStorage';
+import { Billing } from 'src/libs/ajax/Billing';
+import { Catalog } from 'src/libs/ajax/Catalog';
+import { DataRepo } from 'src/libs/ajax/DataRepo';
+import { Dockstore } from 'src/libs/ajax/Dockstore';
+import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
+import { appIdentifier, fetchOk } from 'src/libs/ajax/fetch/fetch-core';
+import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
+import { Groups } from 'src/libs/ajax/Groups';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
+import { Disks } from 'src/libs/ajax/leonardo/Disks';
+import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { OAuth2 } from 'src/libs/ajax/OAuth2';
+import { SamResources } from 'src/libs/ajax/SamResources';
+import { Support } from 'src/libs/ajax/Support';
+import { TermsOfService } from 'src/libs/ajax/TermsOfService';
+import { User } from 'src/libs/ajax/User';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
+import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
+import { WorkflowScript } from 'src/libs/ajax/workflows-app/WorkflowScript';
+import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
+import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
+import { getConfig } from 'src/libs/config';
+
+const CromIAM = (signal?: AbortSignal) => ({
+  callCacheDiff: async (thisWorkflow, thatWorkflow) => {
+    const { workflowId: thisWorkflowId, callFqn: thisCallFqn, index: thisIndex } = thisWorkflow;
+    const { workflowId: thatWorkflowId, callFqn: thatCallFqn, index: thatIndex } = thatWorkflow;
+
+    const params = {
+      workflowA: thisWorkflowId,
+      callA: thisCallFqn,
+      indexA: thisIndex !== -1 ? thisIndex : undefined,
+      workflowB: thatWorkflowId,
+      callB: thatCallFqn,
+      indexB: thatIndex !== -1 ? thatIndex : undefined,
+    };
+    const res = await fetchOrchestration(
+      `api/workflows/v1/callcaching/diff?${qs.stringify(params)}`,
+      _.merge(authOpts(), { signal })
+    );
+    return res.json();
+  },
+
+  workflowMetadata: async (workflowId, includeKey, excludeKey) => {
+    const res = await fetchOrchestration(
+      `api/workflows/v1/${workflowId}/metadata?${qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })}`,
+      _.merge(authOpts(), { signal })
+    );
+    return res.json();
+  },
+});
+
+const FirecloudBucket = (signal?: AbortSignal) => ({
+  getServiceAlerts: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal });
+    return res.json();
+  },
+
+  getFeaturedWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal });
+    return res.json();
+  },
+
+  getShowcaseWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/showcase.json`, { signal });
+    return res.json();
+  },
+
+  getFeaturedMethods: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal });
+    return res.json();
+  },
+
+  getTemplateWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/template-workspaces.json`, { signal });
+    return res.json();
+  },
+
+  getBadVersions: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/bad-versions.txt`, { signal });
+    return res.text();
+  },
+});
+
+const Methods = (signal?: AbortSignal) => ({
+  list: async (params) => {
+    const res = await fetchAgora(`methods?${qs.stringify(params)}`, _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
+  definitions: async () => {
+    const res = await fetchAgora('methods/definitions', _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
+  configInputsOutputs: async (loadedConfig) => {
+    const res = await fetchRawls(
+      'methodconfigs/inputsOutputs',
+      _.mergeAll([authOpts(), jsonBody(loadedConfig.methodRepoMethod), { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+
+  template: async (modifiedConfigMethod) => {
+    const res = await fetchRawls(
+      'methodconfigs/template',
+      _.mergeAll([authOpts(), jsonBody(modifiedConfigMethod), { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+
+  method: (namespace, name, snapshotId) => {
+    const root = `methods/${namespace}/${name}/${snapshotId}`;
+
+    return {
+      get: async () => {
+        const res = await fetchAgora(root, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      configs: async () => {
+        const res = await fetchAgora(`${root}/configurations`, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      allConfigs: async () => {
+        const res = await fetchAgora(`methods/${namespace}/${name}/configurations`, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      toWorkspace: async (workspace, config: any = {}) => {
+        const res = await fetchRawls(
+          `workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
+          _.mergeAll([
+            authOpts(),
+            jsonBody(
+              _.merge(
+                {
+                  methodRepoMethod: {
+                    methodUri: `agora://${namespace}/${name}/${snapshotId}`,
+                  },
+                  name,
+                  namespace,
+                  rootEntityType: '',
+                  prerequisites: {},
+                  inputs: {},
+                  outputs: {},
+                  methodConfigVersion: 1,
+                  deleted: false,
+                },
+                config.payloadObject
+              )
+            ),
+            { signal, method: 'POST' },
+          ])
+        );
+        return res.json();
+      },
+    };
+  },
+});
+
+const Submissions = (signal?: AbortSignal) => ({
+  queueStatus: async () => {
+    const res = await fetchRawls('submissions/queueStatus', _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+});
+
+const DrsUriResolver = (signal?: AbortSignal) => ({
+  // DRSHub now gets a signed URL instead of Martha
+  getSignedUrl: async ({ bucket, object, dataObjectUri, googleProject }) => {
+    const res = await fetchDrsHub(
+      '/api/v4/gcs/getSignedUrl',
+      _.mergeAll([
+        jsonBody({ bucket, object, dataObjectUri, googleProject }),
+        authOpts(),
+        appIdentifier,
+        { signal, method: 'POST' },
+      ])
+    );
+    return res.json();
+  },
+
+  getDataObjectMetadata: async (url, fields) => {
+    const res = await fetchDrsHub(
+      '/api/v4/drs/resolve',
+      _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+});
+
+const Surveys = (signal?: AbortSignal) => ({
+  submitForm: (formId, data) => fetchGoogleForms(`${formId}/formResponse?${qs.stringify(data)}`, { signal }),
+});
+
+export const Ajax = (signal?: AbortSignal) => {
+  return {
+    Apps: Apps(signal),
+    AzureStorage: AzureStorage(signal),
+    Billing: Billing(signal),
+    Buckets: GoogleStorage(signal),
+    Catalog: Catalog(signal),
+    Cbas: Cbas(signal),
+    CromIAM: CromIAM(signal),
+    CromwellApp: CromwellApp(signal),
+    DataRepo: DataRepo(signal),
+    Disks: Disks(signal),
+    Dockstore: Dockstore(signal),
+    DrsUriResolver: DrsUriResolver(signal),
+    ExternalCredentials: ExternalCredentials(signal),
+    FirecloudBucket: FirecloudBucket(signal),
+    Groups: Groups(signal),
+    Methods: Methods(signal),
+    Metrics: Metrics(signal),
+    OAuth2: OAuth2(signal),
+    Runtimes: Runtimes(signal),
+    SamResources: SamResources(signal),
+    Submissions: Submissions(signal),
+    Support: Support(signal),
+    Surveys: Surveys(signal),
+    TermsOfService: TermsOfService(signal),
+    User: User(signal),
+    WorkflowScript: WorkflowScript(signal),
+    WorkspaceData: WorkspaceData(signal),
+    WorkspaceManagerResources: WorkspaceManagerResources(signal),
+    Workspaces: Workspaces(signal),
+  };
+};
+
+export type AjaxContract = ReturnType<typeof Ajax>;
+
+// Exposing Ajax for use by integration tests (and debugging, or whatever)
+(window as any).Ajax = Ajax;

--- a/src/libs/ajax/leonardo/Apps.ts
+++ b/src/libs/ajax/leonardo/Apps.ts
@@ -8,7 +8,7 @@ import { fetchLeo } from 'src/libs/ajax/ajax-common';
 import { appIdentifier } from 'src/libs/ajax/fetch/fetch-core';
 import { CreateAppV1Request, GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 
-export const Apps = (signal: AbortSignal) => ({
+export const Apps = (signal?: AbortSignal) => ({
   list: async (project: string, labels: LeoResourceLabels = {}): Promise<ListAppItem[]> => {
     const res = await fetchLeo(
       `api/google/v1/apps/${project}?${qs.stringify({ saturnAutoCreated: true, ...labels })}`,

--- a/src/libs/ajax/leonardo/Runtimes.ts
+++ b/src/libs/ajax/leonardo/Runtimes.ts
@@ -63,7 +63,7 @@ const getNormalizedComputeRegion = (config: RawRuntimeConfig): NormalizedCompute
 export type RuntimesHelperDeps = {
   v1Api: LeoRuntimesV1DataClient;
 };
-export const makeRuntimesHelper = (deps: RuntimesHelperDeps) => (signal: AbortSignal) => {
+export const makeRuntimesHelper = (deps: RuntimesHelperDeps) => (signal?: AbortSignal) => {
   const { v1Api } = deps;
   const v1Func = (project: string, name: string) => {
     const root = `api/google/v1/runtimes/${project}/${name}`;

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -98,7 +98,10 @@ export const Workspaces = (signal) => ({
       },
 
       updateSettings: async (body) => {
-        const response = await fetchRawls(`${root}/settings`, _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }]));
+        const response = await fetchRawls(
+          `${root}/settings`,
+          _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }])
+        );
         return response.json();
       },
     };

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -5,9 +5,10 @@ import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 import { BillingProject, CloudPlatform } from 'src/billing-core/models';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { getRegionLabel } from 'src/libs/azure-utils';
 import Events from 'src/libs/events';
 import { goToPath } from 'src/libs/nav';
@@ -43,8 +44,6 @@ jest.mock(
   })
 );
 
-type AjaxContract = ReturnType<typeof Ajax>;
-
 interface SetupOptions {
   billingProjects?: BillingProject[];
   groups?: string[];
@@ -52,11 +51,11 @@ interface SetupOptions {
 
 interface SetupResult {
   captureEvent: jest.MockedFunction<AjaxContract['Metrics']['captureEvent']>;
-  checkBucketLocation: jest.MockedFunction<ReturnType<AjaxContract['Workspaces']['workspace']>['checkBucketLocation']>;
+  checkBucketLocation: jest.MockedFunction<ReturnType<WorkspacesAjaxContract['workspace']>['checkBucketLocation']>;
   containerInfo: jest.MockedFunction<AzureStorageContract['containerInfo']>;
-  cloneWorkspace: jest.MockedFunction<ReturnType<AjaxContract['Workspaces']['workspace']>['clone']>;
-  createWorkspace: jest.MockedFunction<AjaxContract['Workspaces']['create']>;
-  getWorkspaceDetails: jest.MockedFunction<ReturnType<AjaxContract['Workspaces']['workspace']>['details']>;
+  cloneWorkspace: jest.MockedFunction<ReturnType<WorkspacesAjaxContract['workspaceV2']>['clone']>;
+  createWorkspace: jest.MockedFunction<WorkspacesAjaxContract['create']>;
+  getWorkspaceDetails: jest.MockedFunction<ReturnType<WorkspacesAjaxContract['workspace']>['details']>;
   listApps: jest.MockedFunction<AjaxContract['Apps']['listAppsV2']>;
   listWdsCollections: jest.MockedFunction<AjaxContract['WorkspaceData']['listCollections']>;
 }

--- a/src/workspaces/dashboard/BucketLocation.test.ts
+++ b/src/workspaces/dashboard/BucketLocation.test.ts
@@ -4,7 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
+import { WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import {
@@ -15,8 +16,6 @@ import {
 } from 'src/testing/workspace-fixtures';
 import { BucketLocation } from 'src/workspaces/dashboard/BucketLocation';
 import { GoogleWorkspace } from 'src/workspaces/utils';
-
-type AjaxContract = ReturnType<typeof Ajax>;
 
 jest.mock('src/libs/ajax');
 
@@ -118,8 +117,8 @@ describe('BucketLocation', () => {
                   location: 'bermuda',
                   locationType: 'triangle',
                 }),
-              } as Partial<AjaxContract['Workspaces']['workspace']>),
-          } as Partial<AjaxContract['Workspaces']>,
+              } as Partial<ReturnType<WorkspacesAjaxContract['workspace']>>),
+          } as Partial<WorkspacesAjaxContract>,
         } as Partial<AjaxContract> as AjaxContract)
     );
 
@@ -151,8 +150,8 @@ describe('BucketLocation', () => {
             workspace: () =>
               ({
                 checkBucketLocation: () => Promise.reject(mockBucketRequesterPaysError),
-              } as Partial<AjaxContract['Workspaces']['workspace']>),
-          } as Partial<AjaxContract['Workspaces']>,
+              } as Partial<ReturnType<WorkspacesAjaxContract['workspace']>>),
+          } as Partial<WorkspacesAjaxContract>,
         } as Partial<AjaxContract> as AjaxContract)
     );
     // Act


### PR DESCRIPTION
 - moved Workspaces ajax subarea out of ajax.js and into a seperate ts module.
 - converted ajax.js to ts.
 - minimal Typescript conversion.  Added typed for data call returns, etc. will need to come from feature team folks.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- break out Workspaces Ajax submodule.

### Why
- a step to greatly improve code maintainability.
-  easier code owner fidelity on separate modules.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
