### PR TITLE
[WOR-1600] Workspace Settings Soft Delete functionality

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -171,6 +171,7 @@ const eventsList = {
   workspaceOpenFromRecentlyViewed: 'workspace:open-from-recently-viewed',
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceSettingsBucketLifecycle: 'workspace:settings:bucketLifecycle',
+  workspaceSettingsSoftDelete: 'workspace:settings:softDelete',
   workspaceShare: 'workspace:share',
   workspaceShareWithSupport: 'workspace:shareWithSupport',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -94,7 +94,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
             }
           }}
           options={prefixOptions()}
-          isDisabled={!lifecycleRulesEnabled}
+          isDisabled={!lifecycleRulesEnabled || !isOwner}
         />
       </div>
       <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -109,7 +109,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           isClearable
           onlyInteger
           value={lifecycleAge}
-          disabled={!lifecycleRulesEnabled}
+          disabled={!lifecycleRulesEnabled || !isOwner}
           onChange={(value: number) => {
             setLifecycleAge(value);
           }}

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -1,8 +1,8 @@
-import { CreatableSelect, ExternalLink, Switch, useUniqueId } from '@terra-ui-packages/components';
+import { CreatableSelect, ExternalLink, useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { ReactNode } from 'react';
 import { NumberInput } from 'src/components/input';
-import { FormLabel } from 'src/libs/forms';
+import Setting from 'src/workspaces/SettingsModal/Setting';
 import { suggestedPrefixes } from 'src/workspaces/SettingsModal/utils';
 
 interface BucketLifecycleSettingsProps {
@@ -26,9 +26,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
     isOwner,
   } = props;
 
-  const switchId = useUniqueId('switch');
   const daysId = useUniqueId('days');
-  const descriptionId = useUniqueId('description');
 
   const prefixOptions = () => {
     // Append together suggested options and any options the user has already selected.
@@ -36,40 +34,30 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
     return _.map((value) => ({ value, label: value }), allOptions);
   };
 
+  const settingToggled = (checked: boolean) => {
+    setLifecycleRulesEnabled(checked);
+    if (!checked) {
+      // Clear out the values being display to reduce confusion
+      setLifecycleAge(null);
+      setPrefixes([]);
+    }
+  };
+
   return (
-    <>
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '.75rem' }}>
-        <FormLabel
-          htmlFor={switchId}
-          style={{ fontWeight: 600, whiteSpace: 'nowrap', marginRight: '.5rem', marginTop: '.5rem' }}
-        >
-          Lifecycle Rules:
-        </FormLabel>
-        <Switch
-          onLabel=''
-          offLabel=''
-          onChange={(checked: boolean) => {
-            setLifecycleRulesEnabled(checked);
-            if (!checked) {
-              // Clear out the values being display to reduce confusion
-              setLifecycleAge(null);
-              setPrefixes([]);
-            }
-          }}
-          id={switchId}
-          checked={lifecycleRulesEnabled}
-          width={40}
-          height={20}
-          aria-describedby={descriptionId}
-          disabled={!isOwner}
-        />
-      </div>
-      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
-        This{' '}
-        <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
-        automatically deletes objects a certain number of days after they are created.{' '}
-        <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
-      </div>
+    <Setting
+      settingEnabled={lifecycleRulesEnabled}
+      setSettingEnabled={settingToggled}
+      label='Lifecycle Rules:'
+      isOwner={isOwner}
+      description={
+        <>
+          This{' '}
+          <ExternalLink href='https://cloud.google.com/storage/docs/lifecycle'>bucket lifecycle setting</ExternalLink>{' '}
+          automatically deletes objects a certain number of days after they are created.{' '}
+          <span style={{ fontWeight: 'bold' }}>Changes can take up to 24 hours to take effect.</span>
+        </>
+      }
+    >
       <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>
         <div style={{ marginTop: '.75rem', marginBottom: '.5rem' }}>Delete objects in:</div>
         <CreatableSelect
@@ -115,7 +103,7 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
           }}
         />
       </div>
-    </>
+    </Setting>
   );
 };
 

--- a/src/workspaces/SettingsModal/Setting.tsx
+++ b/src/workspaces/SettingsModal/Setting.tsx
@@ -1,0 +1,50 @@
+import { Switch, useUniqueId } from '@terra-ui-packages/components';
+import React, { PropsWithChildren, ReactNode } from 'react';
+import { FormLabel } from 'src/libs/forms';
+
+type SettingsProps = PropsWithChildren<{
+  settingEnabled: boolean;
+  setSettingEnabled: (enabled: boolean) => void;
+  label: string;
+  isOwner: boolean;
+  description: ReactNode;
+}>;
+
+const Setting = (props: SettingsProps): ReactNode => {
+  const { settingEnabled, setSettingEnabled, label, isOwner, description, children } = props;
+
+  const switchId = useUniqueId('switch');
+  const descriptionId = useUniqueId('description');
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '.75rem' }}>
+        <FormLabel
+          htmlFor={switchId}
+          style={{ fontWeight: 600, whiteSpace: 'nowrap', marginRight: '.5rem', marginTop: '.5rem' }}
+        >
+          {label}
+        </FormLabel>
+        <Switch
+          onLabel=''
+          offLabel=''
+          onChange={(checked: boolean) => {
+            setSettingEnabled(checked);
+          }}
+          id={switchId}
+          checked={settingEnabled}
+          width={40}
+          height={20}
+          aria-describedby={descriptionId}
+          disabled={!isOwner}
+        />
+      </div>
+      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
+        {description}
+      </div>
+      {children}
+    </>
+  );
+};
+
+export default Setting;

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -623,7 +623,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(getSoftDeleteToggle()).toBeChecked();
-      expect(getRetention()).toHaveValue(softDeleteDefaultRetention);
+      expect(getRetention()).toHaveValue(softDeleteDefaultRetention / secondsInADay);
     });
 
     it('disables Save if there is no retention value specified', async () => {

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -612,7 +612,7 @@ describe('SettingsModal', () => {
       expect(getRetention()).toHaveAttribute('disabled');
     });
 
-    it('renders the option as on with 7 day retention if no setting exists', async () => {
+    it('renders the option as "on" with default retention if no setting exists', async () => {
       // Arrange
       setup([], jest.fn());
 
@@ -623,7 +623,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(getSoftDeleteToggle()).toBeChecked();
-      expect(getRetention()).toHaveValue(7);
+      expect(getRetention()).toHaveValue(softDeleteDefaultRetention);
     });
 
     it('disables Save if there is no retention value specified', async () => {
@@ -723,7 +723,7 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([defaultSoftDeleteSetting]);
       // An above case captures testing that there is no event if Save is pressed and the user initially
-      // had no soft delete setting.
+      // had no soft delete setting (although the default setting is then persisted).
       expect(captureEvent).not.toHaveBeenCalledWith();
     });
   });

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -207,9 +207,10 @@ describe('SettingsModal', () => {
       );
     const getDays = () => screen.getByLabelText('Days after creation:');
 
-    it('renders the option as disabled if the user is not an owner', async () => {
+    it('renders all options as disabled if the user is not an owner', async () => {
       // Arrange
-      setup([], jest.fn());
+      const user = userEvent.setup();
+      setup([twoRules], jest.fn());
 
       // Act
       await act(async () => {
@@ -218,6 +219,8 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(getToggle()).toBeDisabled();
+      expect(getDays()).toHaveAttribute('disabled');
+      expect(getPrefixInput(user).inputElement).toHaveAttribute('disabled');
     });
 
     it('renders the option as off if no settings exist', async () => {
@@ -591,7 +594,7 @@ describe('SettingsModal', () => {
     const getSoftDeleteToggle = () => screen.getByLabelText('Soft Delete:');
     const getRetention = () => screen.getByLabelText('Days to retain:');
 
-    it('renders the option as disabled if the user is not an owner', async () => {
+    it('renders all options as disabled if the user is not an owner', async () => {
       // Arrange
       setup([], jest.fn());
 
@@ -602,6 +605,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(getSoftDeleteToggle()).toBeDisabled();
+      expect(getRetention()).toHaveAttribute('disabled');
     });
 
     it('renders the option as on with 7 day retention if no setting exists', async () => {
@@ -616,6 +620,26 @@ describe('SettingsModal', () => {
       // Assert
       expect(getSoftDeleteToggle()).toBeChecked();
       expect(getRetention()).toHaveValue(7);
+    });
+
+    it('disables Save if there is no retention value specified', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      setup([], jest.fn());
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      const daysInput = getRetention();
+      await user.clear(daysInput);
+      expect(daysInput).toHaveValue(null);
+
+      // Assert
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+      screen.getByText('Please specify a soft delete retention value');
     });
   });
 });

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -18,6 +18,7 @@ import {
   modifyFirstBucketDeletionRule,
   modifyFirstSoftDeleteSetting,
   removeFirstBucketDeletionRule,
+  secondsInADay,
   SoftDeleteSetting,
   suggestedPrefixes,
   WorkspaceSetting,
@@ -118,7 +119,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
         }
       }
       const softDelete = getFirstSoftDeleteSetting(settings, true);
-      const retentionDays = softDelete === undefined ? 7 : softDelete.config.retentionDurationInSeconds / 86400;
+      const retentionDays = softDelete === undefined ? 7 : softDelete.config.retentionDurationInSeconds / secondsInADay;
       setSoftDeleteEnabled(retentionDays !== 0);
       setSoftDeleteRetention(retentionDays);
     });

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -186,7 +186,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     ) {
       // If the bucket had no soft delete setting before, and the current one is the default retention, don't event.
     } else if (!_.isEqual(originalSoftDeleteSetting, newSoftDeleteSetting)) {
-      // If the soft delete setting previously existed and didn't actually change, don't event.
+      // Event if an explicit setting existed before and it changed.
       Ajax().Metrics.captureEvent(Events.workspaceSettingsSoftDelete, {
         enabled: softDeleteEnabled,
         retention: softDeleteRetention, // will be null if soft delete is disabled

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -120,8 +120,13 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
       }
       const softDelete = getFirstSoftDeleteSetting(settings, true);
       const retentionDays = softDelete === undefined ? 7 : softDelete.config.retentionDurationInSeconds / secondsInADay;
-      setSoftDeleteEnabled(retentionDays !== 0);
-      setSoftDeleteRetention(retentionDays);
+      const settingEnabled = retentionDays !== 0;
+      setSoftDeleteEnabled(settingEnabled);
+      if (settingEnabled) {
+        // If soft delete is not enabled, a retention of 0 is returned. However, the UI should not display the value
+        // because it is confusing with the switch being disabled.
+        setSoftDeleteRetention(retentionDays);
+      }
     });
 
     loadSettings();
@@ -175,6 +180,9 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     }
     if (lifecycleRulesEnabled && (prefixes.length === 0 || lifecycleAge === null)) {
       return 'Please specify all lifecycle rule options';
+    }
+    if (softDeleteEnabled && softDeleteRetention === null) {
+      return 'Please specify a soft delete retention value';
     }
   };
 

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -184,8 +184,9 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
       originalSoftDeleteSetting === undefined &&
       newSoftDeleteSetting?.config.retentionDurationInSeconds === softDeleteDefaultRetention
     ) {
-      // If the bucket had no soft delete setting before, and the current one is the default retention, don't log the event.
+      // If the bucket had no soft delete setting before, and the current one is the default retention, don't event.
     } else if (!_.isEqual(originalSoftDeleteSetting, newSoftDeleteSetting)) {
+      // If the soft delete setting previously existed and didn't actually change, don't event.
       Ajax().Metrics.captureEvent(Events.workspaceSettingsSoftDelete, {
         enabled: softDeleteEnabled,
         retention: softDeleteRetention, // will be null if soft delete is disabled

--- a/src/workspaces/SettingsModal/SoftDelete.tsx
+++ b/src/workspaces/SettingsModal/SoftDelete.tsx
@@ -63,7 +63,7 @@ const SoftDelete = (props: SoftDeleteProps): ReactNode => {
           isClearable
           onlyInteger
           value={softDeleteRetention}
-          disabled={!softDeleteEnabled}
+          disabled={!softDeleteEnabled || !isOwner}
           onChange={(value: number) => {
             setSoftDeleteRetention(value);
           }}

--- a/src/workspaces/SettingsModal/SoftDelete.tsx
+++ b/src/workspaces/SettingsModal/SoftDelete.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink, Switch, useUniqueId } from '@terra-ui-packages/components';
+import { ExternalLink, useUniqueId } from '@terra-ui-packages/components';
 import React, { ReactNode } from 'react';
 import { NumberInput } from 'src/components/input';
-import { FormLabel } from 'src/libs/forms';
+import Setting from 'src/workspaces/SettingsModal/Setting';
 
 interface SoftDeleteProps {
   softDeleteEnabled: boolean;
@@ -14,42 +14,29 @@ interface SoftDeleteProps {
 const SoftDelete = (props: SoftDeleteProps): ReactNode => {
   const { softDeleteEnabled, setSoftDeleteEnabled, softDeleteRetention, setSoftDeleteRetention, isOwner } = props;
 
-  const switchId = useUniqueId('switch');
   const daysId = useUniqueId('days');
-  const descriptionId = useUniqueId('description');
+  const settingToggled = (checked: boolean) => {
+    setSoftDeleteEnabled(checked);
+    if (!checked) {
+      setSoftDeleteRetention(null);
+    }
+  };
 
   return (
-    <>
-      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '.75rem' }}>
-        <FormLabel
-          htmlFor={switchId}
-          style={{ fontWeight: 600, whiteSpace: 'nowrap', marginRight: '.5rem', marginTop: '.5rem' }}
-        >
-          Soft Delete:
-        </FormLabel>
-        <Switch
-          onLabel=''
-          offLabel=''
-          onChange={(checked: boolean) => {
-            setSoftDeleteEnabled(checked);
-            if (!checked) {
-              setSoftDeleteRetention(null);
-            }
-          }}
-          id={switchId}
-          checked={softDeleteEnabled}
-          width={40}
-          height={20}
-          aria-describedby={descriptionId}
-          disabled={!isOwner}
-        />
-      </div>
-      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
-        This <ExternalLink href='https://cloud.google.com/storage/docs/soft-delete'>storage setting</ExternalLink>{' '}
-        specifies a retention period during which a deleted object can be restored. Soft delete can be disabled, or set
-        between 7 and 90 days.{' '}
-        <span style={{ fontWeight: 'bold' }}>Data storage fees apply to objects during their retention period.</span>
-      </div>
+    <Setting
+      settingEnabled={softDeleteEnabled}
+      setSettingEnabled={settingToggled}
+      label='Soft Delete:'
+      isOwner={isOwner}
+      description={
+        <>
+          This <ExternalLink href='https://cloud.google.com/storage/docs/soft-delete'>storage setting</ExternalLink>{' '}
+          specifies a retention period during which a deleted object can be restored. Soft delete can be disabled, or
+          set between 7 and 90 days.{' '}
+          <span style={{ fontWeight: 'bold' }}>Data storage fees apply to objects during their retention period.</span>
+        </>
+      }
+    >
       <div style={{ marginTop: '.5rem', display: 'flex', alignItems: 'center' }}>
         {/* eslint-disable jsx-a11y/label-has-associated-control */}
         <label style={{ marginRight: '.25rem' }} htmlFor={daysId}>
@@ -69,7 +56,7 @@ const SoftDelete = (props: SoftDeleteProps): ReactNode => {
           }}
         />
       </div>
-    </>
+    </Setting>
   );
 };
 

--- a/src/workspaces/SettingsModal/SoftDelete.tsx
+++ b/src/workspaces/SettingsModal/SoftDelete.tsx
@@ -1,0 +1,76 @@
+import { ExternalLink, Switch, useUniqueId } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+import { NumberInput } from 'src/components/input';
+import { FormLabel } from 'src/libs/forms';
+
+interface SoftDeleteProps {
+  softDeleteEnabled: boolean;
+  setSoftDeleteEnabled: (enabled: boolean) => void;
+  softDeleteRetention: number | null;
+  setSoftDeleteRetention: (age: number | null) => void;
+  isOwner: boolean;
+}
+
+const SoftDelete = (props: SoftDeleteProps): ReactNode => {
+  const { softDeleteEnabled, setSoftDeleteEnabled, softDeleteRetention, setSoftDeleteRetention, isOwner } = props;
+
+  const switchId = useUniqueId('switch');
+  const daysId = useUniqueId('days');
+  const descriptionId = useUniqueId('description');
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '.75rem' }}>
+        <FormLabel
+          htmlFor={switchId}
+          style={{ fontWeight: 600, whiteSpace: 'nowrap', marginRight: '.5rem', marginTop: '.5rem' }}
+        >
+          Soft Delete:
+        </FormLabel>
+        <Switch
+          onLabel=''
+          offLabel=''
+          onChange={(checked: boolean) => {
+            setSoftDeleteEnabled(checked);
+            if (!checked) {
+              setSoftDeleteRetention(null);
+            }
+          }}
+          id={switchId}
+          checked={softDeleteEnabled}
+          width={40}
+          height={20}
+          aria-describedby={descriptionId}
+          disabled={!isOwner}
+        />
+      </div>
+      <div id={descriptionId} style={{ marginTop: '.5rem', fontSize: '12px' }}>
+        This <ExternalLink href='https://cloud.google.com/storage/docs/soft-delete'>storage setting</ExternalLink>{' '}
+        specifies a retention period during which a deleted object can be restored. Soft delete can be disabled, or set
+        between 7 and 90 days.{' '}
+        <span style={{ fontWeight: 'bold' }}>Data storage fees apply to objects during their retention period.</span>
+      </div>
+      <div style={{ marginTop: '.5rem', display: 'flex', alignItems: 'center' }}>
+        {/* eslint-disable jsx-a11y/label-has-associated-control */}
+        <label style={{ marginRight: '.25rem' }} htmlFor={daysId}>
+          Days to retain:
+        </label>
+        <NumberInput
+          style={{ minWidth: '100px' }}
+          id={daysId}
+          min={7}
+          max={90}
+          isClearable
+          onlyInteger
+          value={softDeleteRetention}
+          disabled={!softDeleteEnabled}
+          onChange={(value: number) => {
+            setSoftDeleteRetention(value);
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default SoftDelete;

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -7,6 +7,7 @@ export const suggestedPrefixes = {
 };
 
 export const secondsInADay = 86400;
+export const softDeleteDefaultRetention = 7 * secondsInADay;
 
 interface BucketLifecycleRule {
   action: {

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -6,6 +6,8 @@ export const suggestedPrefixes = {
   submissionIntermediaries: 'submissions/intermediates/',
 };
 
+export const secondsInADay = 86400;
+
 interface BucketLifecycleRule {
   action: {
     actionType: string;
@@ -151,7 +153,7 @@ export const modifyFirstSoftDeleteSetting = (
   const softDeleteSettings: SoftDeleteSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
     isSoftDeleteSetting(setting)
   ) as SoftDeleteSetting[];
-  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isBucketLifecycleSetting(setting));
+  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isSoftDeleteSetting(setting));
 
   // If no bucketLifecycleSettings existed, create a new one.
   if (softDeleteSettings.length === 0) {
@@ -161,7 +163,7 @@ export const modifyFirstSoftDeleteSetting = (
         {
           settingType: 'GcpBucketSoftDelete',
           config: {
-            retentionDurationInSeconds: 86400 * days,
+            retentionDurationInSeconds: secondsInADay * days,
           },
         } as SoftDeleteSetting,
       ],
@@ -170,7 +172,7 @@ export const modifyFirstSoftDeleteSetting = (
   }
   // If multiple soft delete settings, we will modify only the first one.
   const existingSetting = softDeleteSettings[0];
-  existingSetting.config.retentionDurationInSeconds = 86400 * days;
+  existingSetting.config.retentionDurationInSeconds = secondsInADay * days;
 
   return _.concat(softDeleteSettings, otherSettings);
 };

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -32,11 +32,19 @@ export interface BucketLifecycleSetting extends WorkspaceSetting {
   config: { rules: BucketLifecycleRule[] };
 }
 
+export interface SoftDeleteSetting extends WorkspaceSetting {
+  settingType: 'GcpBucketSoftDelete';
+  config: { retentionDurationInSeconds: number };
+}
+
 export const isBucketLifecycleSetting = (setting: WorkspaceSetting): setting is BucketLifecycleSetting =>
   setting.settingType === 'GcpBucketLifecycle';
 
 export const isDeleteBucketLifecycleRule = (rule: BucketLifecycleRule): rule is DeleteBucketLifecycleRule =>
   rule.action.actionType === 'Delete';
+
+export const isSoftDeleteSetting = (setting: WorkspaceSetting): setting is BucketLifecycleSetting =>
+  setting.settingType === 'GcpBucketSoftDelete';
 
 /**
  * Removes the first delete rule from the first bucketLifecycleSetting in the workspace settings.
@@ -125,4 +133,44 @@ export const modifyFirstBucketDeletionRule = (
   }
   bucketLifecycleSettings[0].config.rules = _.concat(deleteRules, otherRules);
   return _.concat(bucketLifecycleSettings, otherSettings);
+};
+
+/**
+ * Modifies the first soft delete setting in the workspace settings.
+ * If no such setting exists, it will be created.
+ *
+ * Note that any other settings will be preserved but moved to the end of the array.
+ */
+export const modifyFirstSoftDeleteSetting = (
+  originalSettings: WorkspaceSetting[],
+  days: number
+): WorkspaceSetting[] => {
+  // Clone original for testing purposes and to allow eventing only if there was a change.
+  const workspaceSettings = _.cloneDeep(originalSettings);
+
+  const softDeleteSettings: SoftDeleteSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
+    isSoftDeleteSetting(setting)
+  ) as SoftDeleteSetting[];
+  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isBucketLifecycleSetting(setting));
+
+  // If no bucketLifecycleSettings existed, create a new one.
+  if (softDeleteSettings.length === 0) {
+    // @ts-ignore
+    return _.concat(
+      [
+        {
+          settingType: 'GcpBucketSoftDelete',
+          config: {
+            retentionDurationInSeconds: 86400 * days,
+          },
+        } as SoftDeleteSetting,
+      ],
+      otherSettings
+    );
+  }
+  // If multiple soft delete settings, we will modify only the first one.
+  const existingSetting = softDeleteSettings[0];
+  existingSetting.config.retentionDurationInSeconds = 86400 * days;
+
+  return _.concat(softDeleteSettings, otherSettings);
 };

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -99,7 +99,6 @@ export const modifyFirstBucketDeletionRule = (
 
   // If no bucketLifecycleSettings existed, create a new one.
   if (bucketLifecycleSettings.length === 0) {
-    // @ts-ignore
     return _.concat(
       [
         {
@@ -156,9 +155,8 @@ export const modifyFirstSoftDeleteSetting = (
   ) as SoftDeleteSetting[];
   const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isSoftDeleteSetting(setting));
 
-  // If no bucketLifecycleSettings existed, create a new one.
+  // If no SoftDeleteSetting existed, create a new one.
   if (softDeleteSettings.length === 0) {
-    // @ts-ignore
     return _.concat(
       [
         {

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -6,8 +6,6 @@ import { div, h } from 'react-hyperscript-helpers';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { GCP_BUCKET_LIFECYCLE_RULES } from 'src/libs/feature-previews-config';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, protectedDataPolicy } from 'src/testing/workspace-fixtures';
 import { useWorkspaceDetails } from 'src/workspaces/common/state/useWorkspaceDetails';
@@ -34,14 +32,6 @@ jest.mock('src/components/PopupTrigger', () => {
   return {
     ...originalModule,
     MenuTrigger: jest.fn(),
-  };
-});
-
-type FeaturePreviewsExports = typeof import('src/libs/feature-previews');
-jest.mock('src/libs/feature-previews', (): FeaturePreviewsExports => {
-  return {
-    ...jest.requireActual<FeaturePreviewsExports>('src/libs/feature-previews'),
-    isFeaturePreviewEnabled: jest.fn(),
   };
 });
 
@@ -103,8 +93,6 @@ describe('WorkspaceMenu - undefined workspace', () => {
   beforeEach(() => {
     // Arrange
     asMockedFn(useWorkspaceDetails).mockReturnValue({ workspace: undefined, loading: false, refresh: jest.fn() });
-    // Enable feature flag for Settings menu (check to be removed when soft delete option is added).
-    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
   });
 
   it('should not fail any accessibility tests', async () => {
@@ -138,11 +126,6 @@ describe('WorkspaceMenu - undefined workspace', () => {
 });
 
 describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
-  beforeEach(() => {
-    // Enable feature flag for Settings menu (check to be removed when soft delete option is added).
-    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
-  });
-
   it('should not fail any accessibility tests', async () => {
     // Arrange
     asMockedFn(useWorkspaceDetails).mockReturnValue({
@@ -464,28 +447,12 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
 });
 
 describe('Settings menu item (GCP or Azure workspace)', () => {
-  it('does not show the settings menu item if the feature flag is disabled', () => {
+  it('Shows an enabled settings menu item for GCP workspaces', () => {
     asMockedFn(useWorkspaceDetails).mockReturnValue({
       workspace: googleWorkspace,
       refresh: jest.fn(),
       loading: false,
     });
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
-
-    // Act
-    render(h(WorkspaceMenu, workspaceMenuProps));
-
-    // Assert
-    expect(screen.queryByText('Settings')).toBeNull();
-  });
-
-  it('Shows an enabled settings menu item for GCP workspaces if the feature flag is enabled', () => {
-    asMockedFn(useWorkspaceDetails).mockReturnValue({
-      workspace: googleWorkspace,
-      refresh: jest.fn(),
-      loading: false,
-    });
-    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
 
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));
@@ -495,13 +462,12 @@ describe('Settings menu item (GCP or Azure workspace)', () => {
     expect(menuItem).not.toHaveAttribute('disabled');
   });
 
-  it('shows a disabled settings menu item with a tooltip for Azure workspaces if feature flag is enabled', () => {
+  it('shows a disabled settings menu item with a tooltip for Azure workspaces', () => {
     asMockedFn(useWorkspaceDetails).mockReturnValue({
       workspace: azureWorkspace,
       refresh: jest.fn(),
       loading: false,
     });
-    asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === GCP_BUCKET_LIFECYCLE_RULES);
 
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -7,8 +7,6 @@ import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import { Ajax } from 'src/libs/ajax';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { GCP_BUCKET_LIFECYCLE_RULES } from 'src/libs/feature-previews-config';
 import { useWorkspaceDetails } from 'src/workspaces/common/state/useWorkspaceDetails';
 import {
   CloudProvider,
@@ -193,26 +191,23 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   };
 
   return h(Fragment, [
-    // Only thing currently in the settings dialog is GCP bucket lifecycle rules. When
-    // soft delete is added, remove this check.
-    isFeaturePreviewEnabled(GCP_BUCKET_LIFECYCLE_RULES) &&
-      h(
-        MenuButton,
-        {
-          disabled:
-            cloudProvider !== cloudProviderTypes.GCP ||
-            !workspaceLoaded ||
-            state === 'Deleting' ||
-            state === 'DeleteFailed',
-          onClick: () => {
-            menuClicked('Settings');
-            onShowSettings();
-          },
-          tooltipSide: 'left',
-          tooltip: cloudProvider === cloudProviderTypes.AZURE ? tooltipText.azureWorkspaceNoSettings : '',
+    h(
+      MenuButton,
+      {
+        disabled:
+          cloudProvider !== cloudProviderTypes.GCP ||
+          !workspaceLoaded ||
+          state === 'Deleting' ||
+          state === 'DeleteFailed',
+        onClick: () => {
+          menuClicked('Settings');
+          onShowSettings();
         },
-        [makeMenuIcon('cog'), 'Settings']
-      ),
+        tooltipSide: 'left',
+        tooltip: cloudProvider === cloudProviderTypes.AZURE ? tooltipText.azureWorkspaceNoSettings : '',
+      },
+      [makeMenuIcon('cog'), 'Settings']
+    ),
     h(
       MenuButton,
       {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1600

This ticket does the following:
1. Changes the Settings menu item/modal so that it is always displayed for GCP workspaces. Now just the Bucket Lifecycle Setting will be behind the feature flag.
2. Adds ability to control the GCP storage Soft Delete setting. This setting can only be changed by Owners+.
3. Adds eventing when the soft delete setting is changed (does not event when the implicit default value of 7 is made explicit without changing the retention time).

Screenshots:

Both settings (default options):

![image](https://github.com/user-attachments/assets/1063249e-9ee3-406b-bda7-a5c6196ce4df)

Feature flag disabled:

![image](https://github.com/user-attachments/assets/0e9127c7-4bd0-42e3-a2d9-2b7e6ce8dd5a)

User is reader on the workspace:

![image](https://github.com/user-attachments/assets/1e98d274-91fc-4f43-9283-6fe8b47dea7d)

