### PR TITLE
[IA-5055] Fix Cloud Environments state logic

### DIFF
--- a/src/analysis/Environments/Environments.test.ts
+++ b/src/analysis/Environments/Environments.test.ts
@@ -114,10 +114,11 @@ describe('Environments Component', () => {
       // Arrange
       const props = getEnvironmentsProps();
       const runtime1 = generateTestListGoogleRuntime();
+      const otherGoogleWorkspace = generateGoogleWorkspace();
       asMockedFn(props.leoRuntimeData.list).mockResolvedValue([runtime1]);
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [],
+        workspaces: [otherGoogleWorkspace],
       });
 
       // Act
@@ -922,7 +923,6 @@ describe('Environments Component', () => {
       const refreshWorkspaces = jest.fn();
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [],
         refresh: refreshWorkspaces,
       });
 
@@ -951,7 +951,6 @@ describe('Environments Component', () => {
       const refreshWorkspaces = jest.fn();
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [],
         refresh: refreshWorkspaces,
       });
 
@@ -982,7 +981,6 @@ describe('Environments Component', () => {
       const refreshWorkspaces = jest.fn();
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [defaultGoogleWorkspace],
         refresh: refreshWorkspaces,
       });
 
@@ -1011,7 +1009,6 @@ describe('Environments Component', () => {
       const refreshWorkspaces = jest.fn();
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [],
         refresh: refreshWorkspaces,
       });
 
@@ -1038,7 +1035,6 @@ describe('Environments Component', () => {
       const refreshWorkspaces = jest.fn();
       asMockedFn(props.useWorkspaces).mockReturnValue({
         ...defaultUseWorkspacesProps,
-        workspaces: [],
         refresh: refreshWorkspaces,
       });
 

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -247,12 +247,11 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
     loadData();
   }, [shouldFilterByCreator, workspacesLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Set the workspacesLoaded state to true as soon as the useWorkspaces hook loads to trigger fetch of Leo data.
+  // Set the workspacesLoaded state to true when workspaces are loaded to trigger a fetch of Leo data.
   useEffect(() => {
-    if (Object.keys(workspaces).length > 0) {
-      setWorkspacesLoaded(true);
-    }
-  }, [workspaces]); // eslint-disable-line react-hooks/exhaustive-deps
+    const isLoaded = Object.keys(workspaces).length > 0;
+    setWorkspacesLoaded(isLoaded);
+  }, [workspaces]);
 
   const getCloudProvider = (cloudEnvironment) =>
     cond<string | undefined>(

--- a/src/analysis/Environments/Environments.ts
+++ b/src/analysis/Environments/Environments.ts
@@ -136,13 +136,13 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
   const [shouldFilterByCreator, setShouldFilterByCreator] = useState(true);
   const [initialWorkspacesLoaded, setInitialWorkspacesLoaded] = useState(false);
 
-  const workspacesLoaded = (workspaces: WorkspaceWrapperLookup) => Object.keys(workspaces).length > 0;
+  const isWorkspacesLoaded = (workspaces: WorkspaceWrapperLookup) => Object.keys(workspaces).length > 0;
 
   // TODO: this function is a great candidate for breaking out into a separate hook.
   const refreshData = withLoading(async () => {
     // Only refresh workspaces if we have pre-existing runtime/disk/app state.
-    // This prevents a double-call to Rawls upon component load, but causes a refresh
-    // upon subsequent effects.
+    // This prevents a double-call to Rawls upon component load, but still triggers
+    // a refresh upon subsequent effects (like users changing filtering).
     if (runtimes || disks || apps) {
       await refreshWorkspaces();
     }
@@ -150,7 +150,7 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
     const workspaces = getWorkspaces();
 
     // Short circuit if the workspaces haven't loaded yet.
-    if (!workspacesLoaded(workspaces)) {
+    if (!isWorkspacesLoaded(workspaces)) {
       return;
     }
 
@@ -251,7 +251,7 @@ export const Environments = (props: EnvironmentsProps): ReactNode => {
 
   // Set the initialWorkspacesLoaded state to true as soon as workspaces load to trigger fetch of Leo data.
   useEffect(() => {
-    if (workspacesLoaded(workspaces)) {
+    if (isWorkspacesLoaded(workspaces)) {
       setInitialWorkspacesLoaded(true);
     }
   }, [workspaces]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-5055

Note: the IA ticket number matches the PR number! 🤯 

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
My [last PR](https://github.com/DataBiosphere/terra-ui/pull/5045) didn't actually fix the issue -- it was still subject to a race condition where the cloud environments page could load before the workspace fetch finished. This PR should fix it.

### What
- Set a boolean `workspacesLoaded` state to true when the `useWorkspaces` hook loads workspaces. Only render the component when workspaces are loaded.

### Why
- It was tricky (for me) to figure out how to sequence the dependencies between async data fetches/hooks. Especially when these hooks themselves are refreshing data from other hooks, it was easy to get into an infinite loop. Talking with @msilva-broad I think there is an opportunity to factor some of the data fetch logic in `Environments.ts` to dedicated hooks with clear contracts.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] Unit tests pass
- [x] Verified the fix locally and on PR site

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
