### PR TITLE
Fix type check so we don't always turn isNameType (WOR-1814).

### DIFF
--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -20,7 +20,11 @@ import {
 } from 'src/workspaces/utils';
 
 const isNameType = (o: WorkspaceInfo): o is DynamicWorkspaceInfo =>
-  'name' in o && typeof o.name === 'string' && 'namespace' in o && typeof o.namespace === 'string';
+  'name' in o &&
+  typeof o.name === 'string' &&
+  'namespace' in o &&
+  typeof o.namespace === 'string' &&
+  Object.keys(o).length === 2;
 
 type LoadedWorkspaceInfo = {
   state?: WorkspaceState;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1814

I noticed this while looking at the new events for menu item triggers… they always had origin "list", even when triggered from the dashboard view.

Now from the list view (you can see the menu items start disabled and then enable):
![image](https://github.com/user-attachments/assets/fc794f3a-d6c5-4789-87c6-0be18a365dcf)

From the dashboard (menu items should immediately be enabled):
![image](https://github.com/user-attachments/assets/497ef516-58ec-4599-ad4e-4b278856fd66)
