### PR TITLE
UIE-200 Ajax cleanup pt2

### DIFF
--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -2,7 +2,7 @@ import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { authOpts } from 'src/auth/auth-session';
-import { fetchAgora, fetchDrsHub, fetchGoogleForms, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
+import { fetchDrsHub, fetchGoogleForms, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { Billing } from 'src/libs/ajax/Billing';
 import { Catalog } from 'src/libs/ajax/Catalog';
@@ -15,6 +15,7 @@ import { Groups } from 'src/libs/ajax/Groups';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { Disks } from 'src/libs/ajax/leonardo/Disks';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
+import { Methods } from 'src/libs/ajax/methods/Methods';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { OAuth2 } from 'src/libs/ajax/OAuth2';
 import { SamResources } from 'src/libs/ajax/SamResources';
@@ -87,84 +88,6 @@ const FirecloudBucket = (signal?: AbortSignal) => ({
   getBadVersions: async () => {
     const res = await fetchOk(`${getConfig().firecloudBucketRoot}/bad-versions.txt`, { signal });
     return res.text();
-  },
-});
-
-const Methods = (signal?: AbortSignal) => ({
-  list: async (params) => {
-    const res = await fetchAgora(`methods?${qs.stringify(params)}`, _.merge(authOpts(), { signal }));
-    return res.json();
-  },
-
-  definitions: async () => {
-    const res = await fetchAgora('methods/definitions', _.merge(authOpts(), { signal }));
-    return res.json();
-  },
-
-  configInputsOutputs: async (loadedConfig) => {
-    const res = await fetchRawls(
-      'methodconfigs/inputsOutputs',
-      _.mergeAll([authOpts(), jsonBody(loadedConfig.methodRepoMethod), { signal, method: 'POST' }])
-    );
-    return res.json();
-  },
-
-  template: async (modifiedConfigMethod) => {
-    const res = await fetchRawls(
-      'methodconfigs/template',
-      _.mergeAll([authOpts(), jsonBody(modifiedConfigMethod), { signal, method: 'POST' }])
-    );
-    return res.json();
-  },
-
-  method: (namespace, name, snapshotId) => {
-    const root = `methods/${namespace}/${name}/${snapshotId}`;
-
-    return {
-      get: async () => {
-        const res = await fetchAgora(root, _.merge(authOpts(), { signal }));
-        return res.json();
-      },
-
-      configs: async () => {
-        const res = await fetchAgora(`${root}/configurations`, _.merge(authOpts(), { signal }));
-        return res.json();
-      },
-
-      allConfigs: async () => {
-        const res = await fetchAgora(`methods/${namespace}/${name}/configurations`, _.merge(authOpts(), { signal }));
-        return res.json();
-      },
-
-      toWorkspace: async (workspace, config: any = {}) => {
-        const res = await fetchRawls(
-          `workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
-          _.mergeAll([
-            authOpts(),
-            jsonBody(
-              _.merge(
-                {
-                  methodRepoMethod: {
-                    methodUri: `agora://${namespace}/${name}/${snapshotId}`,
-                  },
-                  name,
-                  namespace,
-                  rootEntityType: '',
-                  prerequisites: {},
-                  inputs: {},
-                  outputs: {},
-                  methodConfigVersion: 1,
-                  deleted: false,
-                },
-                config.payloadObject
-              )
-            ),
-            { signal, method: 'POST' },
-          ])
-        );
-        return res.json();
-      },
-    };
   },
 });
 

--- a/src/libs/ajax/methods/Methods.ts
+++ b/src/libs/ajax/methods/Methods.ts
@@ -1,0 +1,83 @@
+import { jsonBody } from '@terra-ui-packages/data-client-core';
+import _ from 'lodash/fp';
+import * as qs from 'qs';
+import { authOpts } from 'src/auth/auth-session';
+import { fetchAgora, fetchRawls } from 'src/libs/ajax/ajax-common';
+
+export const Methods = (signal?: AbortSignal) => ({
+  list: async (params) => {
+    const res = await fetchAgora(`methods?${qs.stringify(params)}`, _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
+  definitions: async () => {
+    const res = await fetchAgora('methods/definitions', _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
+  configInputsOutputs: async (loadedConfig) => {
+    const res = await fetchRawls(
+      'methodconfigs/inputsOutputs',
+      _.mergeAll([authOpts(), jsonBody(loadedConfig.methodRepoMethod), { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+
+  template: async (modifiedConfigMethod) => {
+    const res = await fetchRawls(
+      'methodconfigs/template',
+      _.mergeAll([authOpts(), jsonBody(modifiedConfigMethod), { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+
+  method: (namespace, name, snapshotId) => {
+    const root = `methods/${namespace}/${name}/${snapshotId}`;
+
+    return {
+      get: async () => {
+        const res = await fetchAgora(root, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      configs: async () => {
+        const res = await fetchAgora(`${root}/configurations`, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      allConfigs: async () => {
+        const res = await fetchAgora(`methods/${namespace}/${name}/configurations`, _.merge(authOpts(), { signal }));
+        return res.json();
+      },
+
+      toWorkspace: async (workspace, config: any = {}) => {
+        const res = await fetchRawls(
+          `workspaces/${workspace.namespace}/${workspace.name}/methodconfigs`,
+          _.mergeAll([
+            authOpts(),
+            jsonBody(
+              _.merge(
+                {
+                  methodRepoMethod: {
+                    methodUri: `agora://${namespace}/${name}/${snapshotId}`,
+                  },
+                  name,
+                  namespace,
+                  rootEntityType: '',
+                  prerequisites: {},
+                  inputs: {},
+                  outputs: {},
+                  methodConfigVersion: 1,
+                  deleted: false,
+                },
+                config.payloadObject
+              )
+            ),
+            { signal, method: 'POST' },
+          ])
+        );
+        return res.json();
+      },
+    };
+  },
+});

--- a/src/libs/ajax/methods/Methods.ts
+++ b/src/libs/ajax/methods/Methods.ts
@@ -81,3 +81,5 @@ export const Methods = (signal?: AbortSignal) => ({
     };
   },
 });
+
+export type MethodsAjaxContract = ReturnType<typeof Methods>;

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -33,7 +33,7 @@ const attributesUpdateOps = _.flow(
       : [{ op: 'AddUpdateAttribute', attributeName: k, addUpdateAttribute: v }];
   })
 );
-export const Workspaces = (signal) => ({
+export const Workspaces = (signal?: AbortSignal) => ({
   list: async (fields, stringAttributeMaxLength) => {
     const lenParam = _.isNil(stringAttributeMaxLength) ? '' : `stringAttributeMaxLength=${stringAttributeMaxLength}&`;
     const res = await fetchRawls(

--- a/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/importDockstoreWorkflow.test.ts
@@ -1,13 +1,11 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
+import { WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { asMockedFn } from 'src/testing/test-utils';
 
 import { importDockstoreWorkflow } from './importDockstoreWorkflow';
 
 jest.mock('src/libs/ajax');
-
-type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 
 describe('importDockstoreWorkflow', () => {
   const testWorkspace = {
@@ -32,14 +30,13 @@ describe('importDockstoreWorkflow', () => {
     importMethodConfig = jest.fn().mockResolvedValue(undefined);
     deleteMethodConfig = jest.fn().mockResolvedValue(undefined);
 
-    const mockWorkspaceMethodConfigAjax: Partial<ReturnType<AjaxContract['Workspaces']['workspace']>['methodConfig']> =
-      {
-        delete: deleteMethodConfig,
-      };
+    const mockWorkspaceMethodConfigAjax: Partial<ReturnType<WorkspacesAjaxContract['workspace']>['methodConfig']> = {
+      delete: deleteMethodConfig,
+    };
 
     workspaceMethodConfigAjax = jest.fn().mockReturnValue(mockWorkspaceMethodConfigAjax);
 
-    const mockWorkspaceAjax: DeepPartial<ReturnType<AjaxContract['Workspaces']['workspace']>> = {
+    const mockWorkspaceAjax: DeepPartial<ReturnType<WorkspacesAjaxContract['workspace']>> = {
       entityMetadata: () =>
         Promise.resolve({
           participant: { count: 1, idName: 'participant_id', attributeNames: [] },

--- a/src/pages/workflows/WorkflowList.test.tsx
+++ b/src/pages/workflows/WorkflowList.test.tsx
@@ -3,7 +3,8 @@ import { act, fireEvent, screen, within } from '@testing-library/react';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import React from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
+import { MethodsAjaxContract } from 'src/libs/ajax/methods/Methods';
 import * as Nav from 'src/libs/nav';
 import { getLink } from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
@@ -40,15 +41,12 @@ jest.mock('react-virtualized', () => {
   };
 });
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxMethodsContract = AjaxContract['Methods'];
-
-const mockMethods = (methods: MethodDefinition[]): Partial<AjaxMethodsContract> => {
+const mockMethods = (methods: MethodDefinition[]): Partial<MethodsAjaxContract> => {
   return { definitions: jest.fn(() => Promise.resolve(methods)) };
 };
 
 const mockAjax = (methods: MethodDefinition[]): Partial<AjaxContract> => {
-  return { Methods: mockMethods(methods) as AjaxMethodsContract };
+  return { Methods: mockMethods(methods) as MethodsAjaxContract };
 };
 
 const mockUser = (email: string): Partial<TerraUser> => ({ email });
@@ -840,8 +838,8 @@ describe('workflows table', () => {
         Methods: {
           definitions: jest.fn(() => {
             throw new Error('BOOM');
-          }) as Partial<AjaxMethodsContract>,
-        } as AjaxMethodsContract,
+          }) as Partial<MethodsAjaxContract>,
+        } as MethodsAjaxContract,
       } as AjaxContract;
     });
 


### PR DESCRIPTION
 - moved Methods ajax sub-area to a Methods.ts sub-module.
 - minimal Typescript conversion.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- continued effort to split out remaining ajax sub-areas out of ajax.ts

### Why
- improve code maintainability and code ownership fidelity.
- enable follow-up Typecript improvements to add types to Methods data calls.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
