### PR TITLE
[WX-1841] Fix ImportWorkflow unit test timeout

### DIFF
--- a/src/pages/ImportWorkflow/ImportWorkflow.test.ts
+++ b/src/pages/ImportWorkflow/ImportWorkflow.test.ts
@@ -1,5 +1,5 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash';
 import { h } from 'react-hyperscript-helpers';
@@ -276,9 +276,7 @@ describe('ImportWorkflow', () => {
     });
 
     it('validates name based on allowed symbols', async () => {
-      // Arrange
-      const user = userEvent.setup();
-
+      // Act
       render(
         h(ImportWorkflow, {
           path: 'github.com/DataBiosphere/test-workflows/test-workflow',
@@ -289,18 +287,14 @@ describe('ImportWorkflow', () => {
 
       const nameInput = screen.getByLabelText('Workflow Name');
 
-      // Act
-      await user.clear(nameInput);
-      await user.type(nameInput, 'a new workflow name');
+      fireEvent.change(nameInput, { target: { value: 'a new workflow name' } });
 
       // Assert
       screen.getByText('Workflow name can only contain letters, numbers, underscores, dashes, and periods');
     });
 
     it('validates name based on maximum length', async () => {
-      // Arrange
-      const user = userEvent.setup();
-
+      // Act
       render(
         h(ImportWorkflow, {
           path: 'github.com/DataBiosphere/test-workflows/test-workflow',
@@ -311,9 +305,7 @@ describe('ImportWorkflow', () => {
 
       const nameInput = screen.getByLabelText('Workflow Name');
 
-      // Act
-      await user.clear(nameInput);
-      await user.type(nameInput, _.repeat('a', 255));
+      fireEvent.change(nameInput, { target: { value: _.repeat('a', 255) } });
 
       // Assert
       screen.getByText('Workflow name is too long (maximum is 254 characters)');


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WX-1841

## Summary of changes:

### What
- Updated the unit tests in `ImportWorkflow.test.ts` to use `fireEvent` rather than `userEvent` for typing actions.

### Why
- As described in the [Terra UI TypeScript unit testing guide](https://docs.google.com/document/d/1bZ1uc6uSQ-CzydcVRDhcKpAqFIGh13yZNzu_lrSffqM/edit), the `type` function of `userEvent` does not have good performance, and `fireEvent.change` should be used instead. For one of the updated tests (`it validates name based on maximum length`), which has to type 255 characters into a text input field, the previous performance was slow enough that it was sometimes causing build failures due to Jest timeouts.

### Testing strategy
- [x] Ensured relevant unit tests still pass and are semantically equivalent to their previous versions.

### Learnings
I was aware of the recommendation given in the unit testing guide, and was using `fireEvent.change` for all typing actions in new test files. However, I used `userEvent.type` for the `it validates name based on maximum length` test that I added to `ImportWorkflow.test.ts`, simply because the preexisting test in this file that used type actions used this function for them. There is certainly value in consistency in many areas (e.g., UI design), but doing things a certain way just because "this is how it has been done before" is not always the best approach, especially when:
- It is trivial to update the existing approach to the more effective/performant one
- The new code may be impacted even more strongly by the shortcomings of the old approach than the existing code (e.g., in this case, because 255 characters have to be typed rather than 19)