### PR TITLE
UIE-200 Ajax cleanup pt3

### DIFF
--- a/src/alerts/service-alerts.test.ts
+++ b/src/alerts/service-alerts.test.ts
@@ -1,6 +1,6 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn } from '@terra-ui-packages/test-utils';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 
 import { getServiceAlerts } from './service-alerts';
 
@@ -21,8 +21,6 @@ jest.mock('src/libs/utils', (): UtilsExports => {
 afterEach(() => {
   jest.restoreAllMocks();
 });
-
-type AjaxContract = ReturnType<typeof Ajax>;
 
 describe('getServiceAlerts', () => {
   it('fetches service alerts from GCS', async () => {

--- a/src/alerts/version-alerts.test.ts
+++ b/src/alerts/version-alerts.test.ts
@@ -1,14 +1,11 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { asMockedFn, withFakeTimers } from '@terra-ui-packages/test-utils';
 import { act, renderHook } from '@testing-library/react';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 
 import { getBadVersions, useTimeUntilRequiredUpdate, useVersionAlerts, versionStore } from './version-alerts';
 
-type AjaxExports = typeof import('src/libs/ajax');
 jest.mock('src/libs/ajax');
-
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 
 describe('useVersionAlerts', () => {
   it('returns an empty list if current version and latest version match', () => {

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -3,7 +3,7 @@ import { partial } from '@terra-ui-packages/test-utils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 import { DataRepo, DataRepoContract, Snapshot } from 'src/libs/ajax/DataRepo';
 import { SamResources, SamResourcesContract } from 'src/libs/ajax/SamResources';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
@@ -26,8 +26,6 @@ jest.mock('src/workspaces/common/state/useWorkspaces', (): UseWorkspacesExports 
   };
 });
 
-type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 jest.mock('src/libs/ajax');
 
 type DataRepoExports = typeof import('src/libs/ajax/DataRepo');

--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -9,7 +9,8 @@ import { Catalog } from 'src/libs/ajax/Catalog';
 import { DataRepo } from 'src/libs/ajax/DataRepo';
 import { Dockstore } from 'src/libs/ajax/Dockstore';
 import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
-import { appIdentifier, fetchOk } from 'src/libs/ajax/fetch/fetch-core';
+import { appIdentifier } from 'src/libs/ajax/fetch/fetch-core';
+import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { Groups } from 'src/libs/ajax/Groups';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
@@ -28,7 +29,6 @@ import { WorkflowScript } from 'src/libs/ajax/workflows-app/WorkflowScript';
 import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
-import { getConfig } from 'src/libs/config';
 
 const CromIAM = (signal?: AbortSignal) => ({
   callCacheDiff: async (thisWorkflow, thatWorkflow) => {
@@ -56,38 +56,6 @@ const CromIAM = (signal?: AbortSignal) => ({
       _.merge(authOpts(), { signal })
     );
     return res.json();
-  },
-});
-
-const FirecloudBucket = (signal?: AbortSignal) => ({
-  getServiceAlerts: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal });
-    return res.json();
-  },
-
-  getFeaturedWorkspaces: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal });
-    return res.json();
-  },
-
-  getShowcaseWorkspaces: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/showcase.json`, { signal });
-    return res.json();
-  },
-
-  getFeaturedMethods: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal });
-    return res.json();
-  },
-
-  getTemplateWorkspaces: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/template-workspaces.json`, { signal });
-    return res.json();
-  },
-
-  getBadVersions: async () => {
-    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/bad-versions.txt`, { signal });
-    return res.text();
   },
 });
 

--- a/src/libs/ajax/firecloud/FirecloudBucket.ts
+++ b/src/libs/ajax/firecloud/FirecloudBucket.ts
@@ -1,0 +1,36 @@
+import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';
+import { getConfig } from 'src/libs/config';
+
+export const FirecloudBucket = (signal?: AbortSignal) => ({
+  getServiceAlerts: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/alerts.json`, { signal });
+    return res.json();
+  },
+
+  getFeaturedWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal });
+    return res.json();
+  },
+
+  getShowcaseWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/showcase.json`, { signal });
+    return res.json();
+  },
+
+  getFeaturedMethods: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-methods.json`, { signal });
+    return res.json();
+  },
+
+  getTemplateWorkspaces: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/template-workspaces.json`, { signal });
+    return res.json();
+  },
+
+  getBadVersions: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/bad-versions.txt`, { signal });
+    return res.text();
+  },
+});
+
+export type FirecloudBucketAjaxContract = ReturnType<typeof FirecloudBucket>;

--- a/src/pages/workspaces/DashboardAuthContainer.test.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.test.tsx
@@ -2,13 +2,11 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 import { AuthState, authStore } from 'src/libs/state';
 import { DashboardAuthContainer } from 'src/pages/workspaces/DashboardAuthContainer';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { WorkspaceDashboardPage, WorkspaceDashboardPageProps } from 'src/workspaces/dashboard/WorkspaceDashboardPage';
-
-type AjaxContract = ReturnType<typeof Ajax>;
 
 jest.mock('src/libs/ajax', () => ({
   Ajax: jest.fn(),

--- a/src/workspaces/list/WorkspacesList.test.ts
+++ b/src/workspaces/list/WorkspacesList.test.ts
@@ -1,7 +1,7 @@
 import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, waitFor } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { useWorkspaces } from 'src/workspaces/common/state/useWorkspaces';
@@ -38,7 +38,6 @@ jest.mock('src/libs/notifications', (): NotificationExports => {
 });
 
 type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
 
 jest.mock('src/libs/ajax', (): AjaxExports => {
   return {


### PR DESCRIPTION
 - broke out FirecloudBucket sub area out of ajax.js and into sub-module.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- ajax.ts sub-area breakout

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
