### PR TITLE
UIE-200 Ajax cleanup pt4

### DIFF
--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -2,7 +2,7 @@ import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { authOpts } from 'src/auth/auth-session';
-import { fetchDrsHub, fetchGoogleForms, fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
+import { fetchDrsHub, fetchGoogleForms, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { Billing } from 'src/libs/ajax/Billing';
 import { Catalog } from 'src/libs/ajax/Catalog';
@@ -24,40 +24,12 @@ import { Support } from 'src/libs/ajax/Support';
 import { TermsOfService } from 'src/libs/ajax/TermsOfService';
 import { User } from 'src/libs/ajax/User';
 import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
+import { CromIAM } from 'src/libs/ajax/workflows-app/CromIAM';
 import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
 import { WorkflowScript } from 'src/libs/ajax/workflows-app/WorkflowScript';
 import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
-
-const CromIAM = (signal?: AbortSignal) => ({
-  callCacheDiff: async (thisWorkflow, thatWorkflow) => {
-    const { workflowId: thisWorkflowId, callFqn: thisCallFqn, index: thisIndex } = thisWorkflow;
-    const { workflowId: thatWorkflowId, callFqn: thatCallFqn, index: thatIndex } = thatWorkflow;
-
-    const params = {
-      workflowA: thisWorkflowId,
-      callA: thisCallFqn,
-      indexA: thisIndex !== -1 ? thisIndex : undefined,
-      workflowB: thatWorkflowId,
-      callB: thatCallFqn,
-      indexB: thatIndex !== -1 ? thatIndex : undefined,
-    };
-    const res = await fetchOrchestration(
-      `api/workflows/v1/callcaching/diff?${qs.stringify(params)}`,
-      _.merge(authOpts(), { signal })
-    );
-    return res.json();
-  },
-
-  workflowMetadata: async (workflowId, includeKey, excludeKey) => {
-    const res = await fetchOrchestration(
-      `api/workflows/v1/${workflowId}/metadata?${qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })}`,
-      _.merge(authOpts(), { signal })
-    );
-    return res.json();
-  },
-});
 
 const Submissions = (signal?: AbortSignal) => ({
   queueStatus: async () => {

--- a/src/libs/ajax/workflows-app/CromIAM.ts
+++ b/src/libs/ajax/workflows-app/CromIAM.ts
@@ -1,0 +1,35 @@
+import _ from 'lodash/fp';
+import * as qs from 'qs';
+import { authOpts } from 'src/auth/auth-session';
+import { fetchOrchestration } from 'src/libs/ajax/ajax-common';
+
+export const CromIAM = (signal?: AbortSignal) => ({
+  callCacheDiff: async (thisWorkflow, thatWorkflow) => {
+    const { workflowId: thisWorkflowId, callFqn: thisCallFqn, index: thisIndex } = thisWorkflow;
+    const { workflowId: thatWorkflowId, callFqn: thatCallFqn, index: thatIndex } = thatWorkflow;
+
+    const params = {
+      workflowA: thisWorkflowId,
+      callA: thisCallFqn,
+      indexA: thisIndex !== -1 ? thisIndex : undefined,
+      workflowB: thatWorkflowId,
+      callB: thatCallFqn,
+      indexB: thatIndex !== -1 ? thatIndex : undefined,
+    };
+    const res = await fetchOrchestration(
+      `api/workflows/v1/callcaching/diff?${qs.stringify(params)}`,
+      _.merge(authOpts(), { signal })
+    );
+    return res.json();
+  },
+
+  workflowMetadata: async (workflowId, includeKey, excludeKey) => {
+    const res = await fetchOrchestration(
+      `api/workflows/v1/${workflowId}/metadata?${qs.stringify({ includeKey, excludeKey }, { arrayFormat: 'repeat' })}`,
+      _.merge(authOpts(), { signal })
+    );
+    return res.json();
+  },
+});
+
+export type CromIamAjaxContract = ReturnType<typeof CromIAM>;


### PR DESCRIPTION
 - broke out CromIAM sub area out of ajax.ts and into sub-module.
 - only minimal conversion to Typescript.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
