### PR TITLE
AJ-1950: mixpanel event for create-collection in data uploader

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -88,6 +88,7 @@ const eventsList = {
   pageView: 'page:view',
   permissionsSynchronizationDelay: 'permissions:propagationDelay',
   resourceLeave: 'resource:leave',
+  uploaderCreateCollection: 'uploader:collection:create',
   user: {
     authToken: {
       load: {

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -14,6 +14,7 @@ import { TopBar } from 'src/components/TopBar';
 import { Ajax } from 'src/libs/ajax';
 import colors from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
+import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { forwardRefWithName, useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as StateHistory from 'src/libs/state-history';
@@ -390,7 +391,7 @@ const WorkspaceSelectorPanel = ({ workspaces, selectedWorkspaceId, setWorkspaceI
 
 const CollectionSelectorPanel = ({
   workspace: {
-    workspace: { googleProject, bucketName },
+    workspace: { namespace: workspaceNamespace, name: workspaceName, googleProject, bucketName },
   },
   selectedCollection,
   setCollection,
@@ -495,7 +496,10 @@ const CollectionSelectorPanel = ({
         validator: /^[^\s/#*?\[\]]+$/, // eslint-disable-line no-useless-escape
         validationMessage: 'Collection name may not contain spaces, forward slashes, or any of the following characters: # * ? [ ]',
         onDismiss: () => setCreating(false),
-        onSuccess: ({ name }) => setCollection(name),
+        onSuccess: ({ name }) => {
+          Ajax().Metrics.captureEvent(Events.uploaderCreateCollection, { collectionName: name, workspaceNamespace, workspaceName });
+          setCollection(name);
+        },
       }),
     isLoading && topSpinnerOverlay,
   ]);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1950

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Adds a `uploader:collection:create` mixpanel event, sent when a user successfully creates a new collection in the data uploader.

### Why
By request from Product, to better understand actual usage of the data uploader. There will be more events; I'm starting with one.

### Testing strategy
Tested manually by looking at requests in dev tools and by seeing the event arrive in mixpanel.


<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
