### PR TITLE
UIE-200 Ajax cleanup pt5

### DIFF
--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -1,15 +1,14 @@
-import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { authOpts } from 'src/auth/auth-session';
-import { fetchDrsHub, fetchGoogleForms, fetchRawls } from 'src/libs/ajax/ajax-common';
+import { fetchGoogleForms, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { Billing } from 'src/libs/ajax/Billing';
 import { Catalog } from 'src/libs/ajax/Catalog';
 import { DataRepo } from 'src/libs/ajax/DataRepo';
 import { Dockstore } from 'src/libs/ajax/Dockstore';
+import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
 import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
-import { appIdentifier } from 'src/libs/ajax/fetch/fetch-core';
 import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { Groups } from 'src/libs/ajax/Groups';
@@ -34,30 +33,6 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 const Submissions = (signal?: AbortSignal) => ({
   queueStatus: async () => {
     const res = await fetchRawls('submissions/queueStatus', _.merge(authOpts(), { signal }));
-    return res.json();
-  },
-});
-
-const DrsUriResolver = (signal?: AbortSignal) => ({
-  // DRSHub now gets a signed URL instead of Martha
-  getSignedUrl: async ({ bucket, object, dataObjectUri, googleProject }) => {
-    const res = await fetchDrsHub(
-      '/api/v4/gcs/getSignedUrl',
-      _.mergeAll([
-        jsonBody({ bucket, object, dataObjectUri, googleProject }),
-        authOpts(),
-        appIdentifier,
-        { signal, method: 'POST' },
-      ])
-    );
-    return res.json();
-  },
-
-  getDataObjectMetadata: async (url, fields) => {
-    const res = await fetchDrsHub(
-      '/api/v4/drs/resolve',
-      _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
-    );
     return res.json();
   },
 });

--- a/src/libs/ajax/drs/DrsUriResolver.ts
+++ b/src/libs/ajax/drs/DrsUriResolver.ts
@@ -1,0 +1,31 @@
+import { jsonBody } from '@terra-ui-packages/data-client-core';
+import _ from 'lodash/fp';
+import { authOpts } from 'src/auth/auth-session';
+import { fetchDrsHub } from 'src/libs/ajax/ajax-common';
+import { appIdentifier } from 'src/libs/ajax/fetch/fetch-core';
+
+export const DrsUriResolver = (signal?: AbortSignal) => ({
+  // DRSHub now gets a signed URL instead of Martha
+  getSignedUrl: async ({ bucket, object, dataObjectUri, googleProject }) => {
+    const res = await fetchDrsHub(
+      '/api/v4/gcs/getSignedUrl',
+      _.mergeAll([
+        jsonBody({ bucket, object, dataObjectUri, googleProject }),
+        authOpts(),
+        appIdentifier,
+        { signal, method: 'POST' },
+      ])
+    );
+    return res.json();
+  },
+
+  getDataObjectMetadata: async (url, fields) => {
+    const res = await fetchDrsHub(
+      '/api/v4/drs/resolve',
+      _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
+    );
+    return res.json();
+  },
+});
+
+export type DrsUriResolverAjaxContract = ReturnType<typeof DrsUriResolver>;


### PR DESCRIPTION
 - broke out DrsUriResolver sub area out of ajax.ts and into sub-module.
 - only minimal conversion to Typescript.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
