### PR TITLE
[WOR-1818] Add to Workspace ajax types.

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -5,7 +5,7 @@ import { authOpts } from 'src/auth/auth-session';
 import { fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
-import { CloneRequestBody, WorkspaceInfo, WorkspaceSetting } from 'src/libs/ajax/workspaces/workspace-models';
+import { CreationRequestBody, WorkspaceInfo, WorkspaceSetting } from 'src/libs/ajax/workspaces/workspace-models';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
@@ -44,7 +44,7 @@ export const Workspaces = (signal?: AbortSignal) => ({
     return res.json();
   },
 
-  create: async (body) => {
+  create: async (body: CreationRequestBody): Promise<WorkspaceInfo> => {
     const res = await fetchRawls('workspaces', _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }]));
     return res.json();
   },
@@ -76,7 +76,7 @@ export const Workspaces = (signal?: AbortSignal) => ({
     const root = `workspaces/v2/${namespace}/${name}`;
 
     return {
-      clone: async (body: CloneRequestBody): Promise<WorkspaceInfo> => {
+      clone: async (body: CreationRequestBody): Promise<WorkspaceInfo> => {
         const res = await fetchRawls(
           `${root}/clone`,
           _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }])

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -5,6 +5,7 @@ import { authOpts } from 'src/auth/auth-session';
 import { fetchOrchestration, fetchRawls } from 'src/libs/ajax/ajax-common';
 import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
+import { CloneRequestBody, WorkspaceInfo, WorkspaceSetting } from 'src/libs/ajax/workspaces/workspace-models';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
@@ -75,7 +76,7 @@ export const Workspaces = (signal?: AbortSignal) => ({
     const root = `workspaces/v2/${namespace}/${name}`;
 
     return {
-      clone: async (body) => {
+      clone: async (body: CloneRequestBody): Promise<WorkspaceInfo> => {
         const res = await fetchRawls(
           `${root}/clone`,
           _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'POST' }])
@@ -92,12 +93,12 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return response.json();
       },
 
-      getSettings: async () => {
+      getSettings: async (): Promise<WorkspaceSetting[]> => {
         const response = await fetchRawls(`${root}/settings`, _.merge(authOpts(), { signal }));
         return response.json();
       },
 
-      updateSettings: async (body) => {
+      updateSettings: async (body: WorkspaceSetting[]) => {
         const response = await fetchRawls(
           `${root}/settings`,
           _.mergeAll([authOpts(), jsonBody(body), { signal, method: 'PUT' }])

--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -30,3 +30,102 @@ export interface MethodConfiguration {
   deleted?: boolean;
   dataReferenceName?: string;
 }
+
+// TYPES RELATED TO WORKSPACE SETTINGS
+export type WorkspaceSetting = BucketLifecycleSetting | SoftDeleteSetting;
+
+export interface BucketLifecycleSetting {
+  settingType: 'GcpBucketLifecycle';
+  config: { rules: BucketLifecycleRule[] };
+}
+
+export interface SoftDeleteSetting {
+  settingType: 'GcpBucketSoftDelete';
+  config: { retentionDurationInSeconds: number };
+}
+
+export interface BucketLifecycleRule {
+  action: {
+    actionType: string;
+  };
+  conditions?: any;
+}
+
+export interface DeleteBucketLifecycleRule extends BucketLifecycleRule {
+  action: {
+    actionType: 'Delete';
+  };
+  conditions: {
+    age: number;
+    matchesPrefix: string[];
+  };
+}
+
+// TYPES RELATED TO WORKSPACE INFO
+export interface WorkspacePolicy {
+  name: string;
+  namespace: string;
+  additionalData: { [key: string]: string }[];
+}
+
+export type AuthorizationDomain = {
+  membersGroupName: string;
+};
+
+export type WorkspaceState =
+  | 'Creating'
+  | 'CreateFailed'
+  | 'Cloning'
+  | 'CloningContainer'
+  | 'CloningFailed'
+  | 'Ready'
+  | 'Updating'
+  | 'UpdateFailed'
+  | 'Deleting'
+  | 'DeleteFailed'
+  | 'Deleted'; // For UI only - not a state in rawls
+
+// TODO: Clean up all the optional types when we fix return types of all the places we retrieve workspaces
+export interface BaseWorkspaceInfo {
+  namespace: string;
+  name: string;
+  workspaceId: string;
+  authorizationDomain: AuthorizationDomain[];
+  createdDate: string;
+  createdBy: string;
+  lastModified: string;
+  attributes?: Record<string, unknown>;
+  isLocked?: boolean;
+  state?: WorkspaceState;
+  errorMessage?: string;
+  completedCloneWorkspaceFileTransfer?: string;
+  workspaceType?: 'mc' | 'rawls';
+  workspaceVersion?: string;
+}
+
+export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {
+  cloudPlatform: 'Azure';
+  bucketName?: '';
+  googleProject?: '';
+}
+
+export interface GoogleWorkspaceInfo extends BaseWorkspaceInfo {
+  cloudPlatform: 'Gcp';
+  googleProject: string;
+  billingAccount: string;
+  bucketName: string;
+}
+
+export type WorkspaceInfo = AzureWorkspaceInfo | GoogleWorkspaceInfo;
+
+// BODY FOR V2 CLONE REQUEST
+export interface CloneRequestBody {
+  namespace: string;
+  name: string;
+  authorizationDomain: AuthorizationDomain[];
+  attributes?: Record<string, unknown>;
+  copyFilesWithPrefix?: string;
+  bucketLocation?: string;
+  enhancedBucketLogging?: boolean;
+  policies?: WorkspacePolicy[];
+}

--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -118,8 +118,8 @@ export interface GoogleWorkspaceInfo extends BaseWorkspaceInfo {
 
 export type WorkspaceInfo = AzureWorkspaceInfo | GoogleWorkspaceInfo;
 
-// BODY FOR V2 CLONE REQUEST
-export interface CloneRequestBody {
+// BODY FOR WORKSPACE CREATE AND CLONE REQUEST
+export interface CreationRequestBody {
   namespace: string;
   name: string;
   authorizationDomain: AuthorizationDomain[];

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -1116,8 +1116,7 @@ describe('NewWorkspaceModal', () => {
         // Arrange
         const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-        // Create workspace endpoint response does not include cloudPlatform.
-        const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
+        const newWorkspace: AzureWorkspaceInfo = {
           namespace: azureBillingProject.projectName,
           name: 'test-workspace',
           workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
@@ -1125,6 +1124,7 @@ describe('NewWorkspaceModal', () => {
           createdDate: '2023-11-13T18:39:32.267Z',
           lastModified: '2023-11-13T18:39:32.267Z',
           authorizationDomain: [],
+          cloudPlatform: 'Azure',
         };
 
         const { createWorkspace, listApps, listWdsCollections } = setup({ billingProjects: [azureBillingProject] });
@@ -1234,8 +1234,7 @@ describe('NewWorkspaceModal', () => {
         // Arrange
         const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-        // Create workspace endpoint response does not include cloudPlatform.
-        const newWorkspace: Omit<AzureWorkspaceInfo, 'cloudPlatform'> = {
+        const newWorkspace: AzureWorkspaceInfo = {
           namespace: azureBillingProject.projectName,
           name: 'test-workspace',
           workspaceId: 'aaaabbbb-cccc-dddd-0000-111122223333',
@@ -1243,6 +1242,7 @@ describe('NewWorkspaceModal', () => {
           createdDate: '2023-11-13T18:39:32.267Z',
           lastModified: '2023-11-13T18:39:32.267Z',
           authorizationDomain: [],
+          cloudPlatform: 'Azure',
         };
 
         const { createWorkspace, listApps } = setup({ billingProjects: [azureBillingProject] });

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -142,7 +142,7 @@ export const NewWorkspaceModal = withDisplayName(
         setCreating(true);
 
         const body = {
-          namespace,
+          namespace: namespace!,
           name,
           authorizationDomain: _.map((v) => ({ membersGroupName: v }), [...getRequiredGroups(), ...groups]),
           attributes: { description },
@@ -156,7 +156,7 @@ export const NewWorkspaceModal = withDisplayName(
           [
             !!cloneWorkspace,
             async () => {
-              const workspace = await Ajax()
+              const workspace: WorkspaceInfo = await Ajax()
                 .Workspaces.workspaceV2(cloneWorkspace!.workspace.namespace, cloneWorkspace!.workspace.name)
                 .clone(body);
               const featuredList = await Ajax().FirecloudBucket.getFeaturedWorkspaces();

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -37,7 +37,7 @@ jest.mock('src/libs/feature-previews', (): FeaturePreviewsExports => {
 describe('SettingsModal', () => {
   const captureEvent = jest.fn();
 
-  const fourDaysAllObjects = {
+  const fourDaysAllObjects: BucketLifecycleSetting = {
     config: {
       rules: [
         {
@@ -54,7 +54,7 @@ describe('SettingsModal', () => {
     settingType: 'GcpBucketLifecycle',
   };
 
-  const zeroDaysTwoPrefixes = {
+  const zeroDaysTwoPrefixes: BucketLifecycleSetting = {
     config: {
       rules: [
         {
@@ -71,7 +71,7 @@ describe('SettingsModal', () => {
     settingType: 'GcpBucketLifecycle',
   };
 
-  const twoRules = {
+  const twoRules: BucketLifecycleSetting = {
     config: {
       rules: [
         {

--- a/src/workspaces/SettingsModal/utils.test.ts
+++ b/src/workspaces/SettingsModal/utils.test.ts
@@ -8,6 +8,12 @@ import {
   WorkspaceSetting,
 } from 'src/workspaces/SettingsModal/utils';
 
+// There may be other setting types in the future-- this test data is used to ensure they are preserved.
+const otherSetting: WorkspaceSetting = {
+  // @ts-ignore
+  settingType: 'OtherSetting',
+};
+
 describe('disableFirstBucketDeletionRule', () => {
   it('returns an empty array', async () => {
     // Assert
@@ -16,9 +22,6 @@ describe('disableFirstBucketDeletionRule', () => {
 
   it('returns original settings if no bucket lifecyle setting', async () => {
     // Act
-    const otherSetting: WorkspaceSetting = {
-      settingType: 'OtherSetting',
-    };
     const result = removeFirstBucketDeletionRule([otherSetting]);
 
     // Assert
@@ -27,9 +30,6 @@ describe('disableFirstBucketDeletionRule', () => {
 
   it('removes the first delete rule (of multiple) in the first bucket lifecycle setting', async () => {
     // Act
-    const otherSetting: WorkspaceSetting = {
-      settingType: 'OtherSetting',
-    };
     const firstDeleteSetting: BucketLifecycleSetting = {
       settingType: 'GcpBucketLifecycle',
       config: {
@@ -108,9 +108,6 @@ describe('disableFirstBucketDeletionRule', () => {
 
   it('removes the first delete rule in the first bucket lifecycle setting', async () => {
     // Act
-    const otherSetting: WorkspaceSetting = {
-      settingType: 'OtherSetting',
-    };
     const firstDeleteSetting: BucketLifecycleSetting = {
       settingType: 'GcpBucketLifecycle',
       config: {
@@ -198,10 +195,8 @@ describe('modifyFirstBucketDeletionRule', () => {
 
   it('adds a new setting in the case of no existing delete bucket lifecycle', async () => {
     // Arrange
-    const originalSettings = [
-      {
-        settingType: 'OtherSetting',
-      },
+    const originalSettings: WorkspaceSetting[] = [
+      otherSetting,
       {
         settingType: 'GcpBucketLifecycle',
         config: {
@@ -274,10 +269,8 @@ describe('modifyFirstBucketDeletionRule', () => {
 
   it('modifies the first delete rule found', async () => {
     // Arrange
-    const originalSettings = [
-      {
-        settingType: 'OtherSetting',
-      },
+    const originalSettings: WorkspaceSetting[] = [
+      otherSetting,
       {
         settingType: 'GcpBucketLifecycle',
         config: {
@@ -402,10 +395,8 @@ describe('modifyFirstSoftDeleteSetting', () => {
 
   it('adds a new setting in the case of no existing soft delete lifecycle', async () => {
     // Arrange
-    const originalSettings = [
-      {
-        settingType: 'OtherSetting',
-      },
+    const originalSettings: WorkspaceSetting[] = [
+      otherSetting,
       {
         settingType: 'GcpBucketLifecycle',
         config: {
@@ -451,10 +442,8 @@ describe('modifyFirstSoftDeleteSetting', () => {
 
   it('modifies the first soft delete setting found', async () => {
     // Arrange
-    const originalSettings = [
-      {
-        settingType: 'OtherSetting',
-      },
+    const originalSettings: WorkspaceSetting[] = [
+      otherSetting,
       {
         settingType: 'GcpBucketSoftDelete',
         config: {

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -1,4 +1,18 @@
 import _ from 'lodash/fp';
+import {
+  BucketLifecycleRule,
+  BucketLifecycleSetting,
+  DeleteBucketLifecycleRule,
+  SoftDeleteSetting,
+  WorkspaceSetting,
+} from 'src/libs/ajax/workspaces/workspace-models';
+
+export type {
+  BucketLifecycleSetting,
+  SoftDeleteSetting,
+  WorkspaceSetting,
+  DeleteBucketLifecycleRule,
+} from 'src/libs/ajax/workspaces/workspace-models';
 
 export const suggestedPrefixes = {
   allObjects: 'All Objects',
@@ -8,37 +22,6 @@ export const suggestedPrefixes = {
 
 export const secondsInADay = 86400;
 export const softDeleteDefaultRetention = 7 * secondsInADay;
-
-interface BucketLifecycleRule {
-  action: {
-    actionType: string;
-  };
-  conditions?: any;
-}
-
-export interface DeleteBucketLifecycleRule extends BucketLifecycleRule {
-  action: {
-    actionType: 'Delete';
-  };
-  conditions: {
-    age: number;
-    matchesPrefix: string[];
-  };
-}
-
-export interface WorkspaceSetting {
-  settingType: string;
-}
-
-export interface BucketLifecycleSetting extends WorkspaceSetting {
-  settingType: 'GcpBucketLifecycle';
-  config: { rules: BucketLifecycleRule[] };
-}
-
-export interface SoftDeleteSetting extends WorkspaceSetting {
-  settingType: 'GcpBucketSoftDelete';
-  config: { retentionDurationInSeconds: number };
-}
 
 export const isBucketLifecycleSetting = (setting: WorkspaceSetting): setting is BucketLifecycleSetting =>
   setting.settingType === 'GcpBucketLifecycle';

--- a/src/workspaces/utils.ts
+++ b/src/workspaces/utils.ts
@@ -2,7 +2,17 @@ import { cond, safeCurry } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import pluralize from 'pluralize';
 import { AzureBillingProject, BillingProject } from 'src/billing-core/models';
+import { GoogleWorkspaceInfo, WorkspaceInfo, WorkspacePolicy } from 'src/libs/ajax/workspaces/workspace-models';
 import { azureRegions } from 'src/libs/azure-regions';
+
+export type {
+  AzureWorkspaceInfo,
+  BaseWorkspaceInfo,
+  GoogleWorkspaceInfo,
+  WorkspaceInfo,
+  WorkspacePolicy,
+  WorkspaceState,
+} from 'src/libs/ajax/workspaces/workspace-models';
 
 export type CloudProvider = 'AZURE' | 'GCP';
 export const cloudProviderTypes: Record<CloudProvider, CloudProvider> = {
@@ -18,43 +28,6 @@ export const cloudProviderLabels: Record<CloudProvider, string> = {
 export const isKnownCloudProvider = (x: unknown): x is CloudProvider => {
   return (x as string) in cloudProviderTypes;
 };
-
-export type AuthorizationDomain = {
-  membersGroupName: string;
-};
-
-// TODO: Clean up all the optional types when we fix return types of all the places we retrieve workspaces
-export interface BaseWorkspaceInfo {
-  namespace: string;
-  name: string;
-  workspaceId: string;
-  authorizationDomain: AuthorizationDomain[];
-  createdDate: string;
-  createdBy: string;
-  lastModified: string;
-  attributes?: Record<string, unknown>;
-  isLocked?: boolean;
-  state?: WorkspaceState;
-  errorMessage?: string;
-  completedCloneWorkspaceFileTransfer?: string;
-  workspaceType?: 'mc' | 'rawls';
-  workspaceVersion?: string;
-}
-
-export interface AzureWorkspaceInfo extends BaseWorkspaceInfo {
-  cloudPlatform: 'Azure';
-  bucketName?: '';
-  googleProject?: '';
-}
-
-export interface GoogleWorkspaceInfo extends BaseWorkspaceInfo {
-  cloudPlatform: 'Gcp';
-  googleProject: string;
-  billingAccount: string;
-  bucketName: string;
-}
-
-export type WorkspaceInfo = AzureWorkspaceInfo | GoogleWorkspaceInfo;
 
 export const isGoogleWorkspaceInfo = (workspace: WorkspaceInfo | undefined): workspace is GoogleWorkspaceInfo => {
   return workspace ? workspace.cloudPlatform === 'Gcp' : false;
@@ -80,19 +53,6 @@ export interface WorkspaceSubmissionStats {
   runningSubmissionsCount: number;
 }
 
-export type WorkspaceState =
-  | 'Creating'
-  | 'CreateFailed'
-  | 'Cloning'
-  | 'CloningContainer'
-  | 'CloningFailed'
-  | 'Ready'
-  | 'Updating'
-  | 'UpdateFailed'
-  | 'Deleting'
-  | 'DeleteFailed'
-  | 'Deleted'; // For UI only - not a state in rawls
-
 export interface BaseWorkspace {
   owners?: string[];
   accessLevel: WorkspaceAccessLevel;
@@ -108,12 +68,6 @@ export interface AzureContext {
   managedResourceGroupId: string;
   subscriptionId: string;
   tenantId: string;
-}
-
-export interface WorkspacePolicy {
-  name: string;
-  namespace: string;
-  additionalData: { [key: string]: string }[];
 }
 
 export interface PolicyDescription {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1818

Adding some types to the Rawls Workspaces API (more to follow).

This mostly just moves already existing types to the new location adjacent to the Workflows Ajax file, and references them from the relevant methods. I chose then the re-export the definitions from their original locations to minimize changes and dependencies on the ajax package.