### PR TITLE
AJ-1965 use cwds

### DIFF
--- a/src/workspace-data/useDataTableProvider.test.ts
+++ b/src/workspace-data/useDataTableProvider.test.ts
@@ -97,17 +97,16 @@ describe('useDataTableProvider', () => {
     expect(mockInnerFunction).toHaveBeenCalledWith(`collections/v1/${WDS_APP_WORKSPACE_ID}`, expect.anything());
   });
 
-  // This test is disabled until a later PR for AJ-1965 uses the useCwds variable to determine whether or not to call listAppsV2
-  //   it('should not call list apps if cwds is in use', async () => {
-  //     // Arrange
-  //     // Act
-  //     await act(() => {
-  //       renderHook(() => useDataTableProvider(CWDS_WORKSPACE_ID));
-  //     });
+  it('should not call list apps if cwds is in use', async () => {
+    // Arrange
+    // Act
+    await act(() => {
+      renderHook(() => useDataTableProvider(CWDS_WORKSPACE_ID));
+    });
 
-  //     // Assert
-  //     expect(mockListAppsV2).not.toHaveBeenCalled();
-  //   });
+    // Assert
+    expect(mockListAppsV2).not.toHaveBeenCalled();
+  });
 
   it('should call list apps if cwds is not in use', async () => {
     // Arrange


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1965

Following on https://github.com/DataBiosphere/terra-ui/pull/5065 and https://github.com/DataBiosphere/terra-ui/pull/5068, this PR relies on cWDS for data tables if the workspace in question has a collection in cWDS; otherwise it continues to use the workspaces' WDS app.

To test, I recommend using a locally running version of cWDS (the dev cWDS doesn't like communicating with a local terra-ui).  Just make sure you have `controlPlanePreview: "on"` set in your `application-local.yml` and `SPRING_PROFILES_ACTIVE=local,control-plane,local-cors` exported when running WDS.  Then use http://localhost:8080/swagger/swagger-ui.html#/Workspace/initWorkspaceV1 with an azure workspace id, and it should use your locally running cWDS instead of trying to contact the app.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
