### PR TITLE
ID-1387 Fix Terra Synchronization Banner Grammar

### DIFF
--- a/src/workspaces/container/WorkspaceContainer.test.ts
+++ b/src/workspaces/container/WorkspaceContainer.test.ts
@@ -92,7 +92,7 @@ describe('WorkspaceContainer', () => {
     render(h(WorkspaceContainer, props));
     // Assert
     const alert = screen.getByRole('alert');
-    expect(within(alert).getByText(/Terra synchronizing permissions with Google/)).not.toBeNull();
+    expect(within(alert).getByText(/Terra is synchronizing permissions with Google/)).not.toBeNull();
   });
 
   it('shows no alerts for initialized Gcp workspaces', async () => {

--- a/src/workspaces/container/WorkspaceContainer.ts
+++ b/src/workspaces/container/WorkspaceContainer.ts
@@ -47,7 +47,7 @@ const TitleBarSpinner = (props: PropsWithChildren): ReactNode => {
 };
 
 const GooglePermissionsSpinner = (): ReactNode => {
-  const warningMessage = ['Terra synchronizing permissions with Google. This may take a couple moments.'];
+  const warningMessage = ['Terra is synchronizing permissions with Google. This may take a couple moments.'];
 
   return h(TitleBarSpinner, warningMessage);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1387 

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Include "is" in the `Terra is synchronizing permissions with Google. This may take a couple moments.` banner.

### What
- Does what it says on the tin.

### Why
- Grammar important

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
