### PR TITLE
UIE-204 Narrow Ajax Usage pt1

### DIFF
--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -50,8 +50,9 @@ import galaxyLogo from 'src/images/galaxy-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo.svg';
 import rstudioBioLogo from 'src/images/r-bio-logo.svg';
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png';
-import { Ajax } from 'src/libs/ajax';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
@@ -514,8 +515,8 @@ export const BaseAnalyses = (
       setCurrentUserHash(currentUserHash);
       setPotentialLockers(potentialLockers);
 
-      const fileTransfers: any[] = await Ajax(signal)
-        .Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name)
+      const fileTransfers: any[] = await Workspaces(signal)
+        .workspace(workspaceInfo.namespace, workspaceInfo.name)
         .listActiveFileTransfers();
       setActiveFileTransfers(!_.isEmpty(fileTransfers));
     });
@@ -574,7 +575,7 @@ export const BaseAnalyses = (
                     onChange: (value) => {
                       setEnableJupyterLabGCP(value);
                       setLocalPref(enableJupyterLabPersistenceId, value);
-                      Ajax().Metrics.captureEvent(Events.analysisToggleJupyterLabGCP, {
+                      Metrics().captureEvent(Events.analysisToggleJupyterLabGCP, {
                         ...extractWorkspaceDetails(workspaceInfo),
                         enabled: value,
                       });

--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -40,10 +40,11 @@ import galaxyLogo from 'src/images/galaxy-project-logo-square.png';
 import hailLogo from 'src/images/hail-logo.svg';
 import jupyterLogo from 'src/images/jupyter-logo.svg';
 import rstudioSquareLogo from 'src/images/rstudio-logo-square.png';
-import { Ajax } from 'src/libs/ajax';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { Runtime } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { PersistentDisk } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import Events from 'src/libs/events';
@@ -353,14 +354,14 @@ export const ContextBar = ({
               tooltipSide: 'left',
               href: terminalLaunchLink,
               onClick: withErrorReporting('Error starting runtime')(async () => {
-                await Ajax().Metrics.captureEvent(Events.analysisLaunch, {
+                await Metrics().captureEvent(Events.analysisLaunch, {
                   origin: 'contextBar',
                   application: 'terminal',
                   workspaceName: name,
                   namespace,
                 });
                 if (currentRuntime?.status === 'Stopped') {
-                  await Ajax().Runtimes.runtimeWrapper(currentRuntime).start();
+                  await Runtimes().runtimeWrapper(currentRuntime).start();
                 }
               }),
               tooltip: 'Terminal',

--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -34,10 +34,10 @@ const Surveys = (signal?: AbortSignal) => ({
 
 export const Ajax = (signal?: AbortSignal) => {
   return {
-    Apps: Apps(signal),
-    AzureStorage: AzureStorage(signal),
+    Apps: Apps(signal), // used for e2e testing
+    AzureStorage: AzureStorage(signal), // target 1 for removal
     Billing: Billing(signal),
-    Buckets: GoogleStorage(signal),
+    Buckets: GoogleStorage(signal), // used for e2e testing
     Catalog: Catalog(signal),
     Cbas: Cbas(signal),
     CromIAM: CromIAM(signal),
@@ -52,7 +52,7 @@ export const Ajax = (signal?: AbortSignal) => {
     Methods: Methods(signal),
     Metrics: Metrics(signal),
     OAuth2: OAuth2(signal),
-    Runtimes: Runtimes(signal),
+    Runtimes: Runtimes(signal), // used for e2e testing
     SamResources: SamResources(signal),
     Support: Support(signal),
     Surveys: Surveys(signal),
@@ -61,7 +61,7 @@ export const Ajax = (signal?: AbortSignal) => {
     WorkflowScript: WorkflowScript(signal),
     WorkspaceData: WorkspaceData(signal),
     WorkspaceManagerResources: WorkspaceManagerResources(signal),
-    Workspaces: Workspaces(signal),
+    Workspaces: Workspaces(signal), // used for e2e testing
   };
 };
 


### PR DESCRIPTION
 - switch portion of src/analysis area to not call Ajax() directly.
 - fix related test mocks.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/UEI-204

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- switch to use Ajax sub-contracts directly.  Mostly one-liner fixes.

### Why
- reduce reliance on centralized Ajax.ts super-object.
- reduce friction for future code maintainability and potential code sharing.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
