### PR TITLE
AJ-1950: mixpanel events for uploader

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -73,6 +73,7 @@ const eventsList = {
   catalogWorkspaceLinkFromDetailsView: 'catalog:workspaceLink:detailsView',
   catalogWorkspaceLinkExportFinished: 'catalog:workspaceLink:completed',
   datasetLibraryBrowseData: 'library:browseData',
+  dataTableOpenUploader: 'dataTable:openUploader',
   dataTableSaveColumnSettings: 'dataTable:saveColumnSettings',
   dataTableLoadColumnSettings: 'dataTable:loadColumnSettings',
   dataTableVersioningViewVersionHistory: 'dataTable:versioning:viewVersionHistory',

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -89,6 +89,9 @@ const eventsList = {
   permissionsSynchronizationDelay: 'permissions:propagationDelay',
   resourceLeave: 'resource:leave',
   uploaderCreateCollection: 'uploader:collection:create',
+  uploaderUploadMetadata: 'uploader:metadata:upload',
+  uploaderCreateTable: 'uploader:table:create',
+  uploaderUpdateTable: 'uploader:table:update',
   user: {
     authToken: {
       load: {

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -759,6 +759,11 @@ export const WorkspaceData = _.flow(
                               MenuButton,
                               {
                                 href: `${Nav.getLink('upload')}?${qs.stringify({ workspace: workspaceId })}`,
+                                onClick: () =>
+                                  Ajax().Metrics.captureEvent(Events.dataTableOpenUploader, {
+                                    workspaceNamespace: namespace,
+                                    workspaceName: name,
+                                  }),
                               },
                               ['Open data uploader']
                             ),

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -631,6 +631,11 @@ const MetadataUploadPanel = ({
       if (!idColumn || _.indexOf('', headerRow) > -1) {
         errors.push(['This does not look like a valid .tsv file.']);
         // Return right away
+        Ajax().Metrics.captureEvent(Events.uploaderUploadMetadata, {
+          workspaceNamespace: namespace,
+          workspaceName: name,
+          success: false,
+        });
         setErrors(errors);
         return;
       }
@@ -691,10 +696,23 @@ const MetadataUploadPanel = ({
           otherRows
         );
 
+        Ajax().Metrics.captureEvent(Events.uploaderUploadMetadata, {
+          workspaceNamespace: namespace,
+          workspaceName: name,
+          success: true,
+        });
+
         setMetadataTable({ errors, entityClass, entityType, idName, idColumn, columns: headerRow, rows: otherRows });
       }
     } catch (e) {
       console.error('Failed to parse metadata file', e);
+
+      Ajax().Metrics.captureEvent(Events.uploaderUploadMetadata, {
+        workspaceNamespace: namespace,
+        workspaceName: name,
+        success: false,
+      });
+
       setErrors(['We were unable to process the metadata file. Are you sure it is in the proper format?']);
     }
   };
@@ -729,14 +747,14 @@ const MetadataUploadPanel = ({
       Ajax().Metrics.captureEvent(metadata?.isUpdate ? Events.uploaderUpdateTable : Events.uploaderCreateTable, {
         workspaceNamespace: namespace,
         workspaceName: name,
-        successful: true,
+        success: true,
       });
       onSuccess && onSuccess({ file, metadata });
     } catch (error) {
       Ajax().Metrics.captureEvent(metadata?.isUpdate ? Events.uploaderUpdateTable : Events.uploaderCreateTable, {
         workspaceNamespace: namespace,
         workspaceName: name,
-        successful: false,
+        success: false,
       });
       await reportError('Failed to upload entity metadata', error);
     }

--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -726,8 +726,18 @@ const MetadataUploadPanel = ({
       const file = Utils.makeTSV([metadata.table.columns, ...metadata.table.rows]);
       const workspace = Ajax().Workspaces.workspace(namespace, name);
       await workspace.importFlexibleEntitiesFileSynchronous(file);
+      Ajax().Metrics.captureEvent(metadata?.isUpdate ? Events.uploaderUpdateTable : Events.uploaderCreateTable, {
+        workspaceNamespace: namespace,
+        workspaceName: name,
+        successful: true,
+      });
       onSuccess && onSuccess({ file, metadata });
     } catch (error) {
+      Ajax().Metrics.captureEvent(metadata?.isUpdate ? Events.uploaderUpdateTable : Events.uploaderCreateTable, {
+        workspaceNamespace: namespace,
+        workspaceName: name,
+        successful: false,
+      });
       await reportError('Failed to upload entity metadata', error);
     }
   });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1950

## Summary of changes:
Adds Mixpanel events for various actions in the uploader

### What
* When a user uploads a metadata file (TSV)
* When a user creates a table
* When a user updates an existing table
* When a user clicks the "open data uploader" link in a workspace's data table

### Why
metrics are good

### Testing strategy
Verified by running locally, watching ajax requests, and seeing the events land in the mixpanel ui.

