### PR TITLE
ID-1391 Remove AnVIL Gen3 Link

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -9,7 +9,7 @@
   "dockstoreUrlRoot": "https://staging.dockstore.org",
   "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "externalCreds": {
-    "providers": ["era-commons", "fence", "dcf-fence", "anvil", "kids-first", "ras", "github"],
+    "providers": ["era-commons", "fence", "dcf-fence", "kids-first", "ras", "github"],
     "urlRoot": "https://externalcreds.dsde-dev.broadinstitute.org"
   },
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",

--- a/config/prod.json
+++ b/config/prod.json
@@ -10,7 +10,7 @@
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "externalCreds": {
-    "providers": ["fence", "dcf-fence", "anvil", "kids-first", "github"],
+    "providers": ["fence", "dcf-fence", "kids-first", "github"],
     "urlRoot": "https://externalcreds.dsde-prod.broadinstitute.org"
   },
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -9,7 +9,7 @@
   "dockstoreUrlRoot": "https://staging.dockstore.org",
   "drsHubUrlRoot": "https://drshub.dsde-staging.broadinstitute.org",
   "externalCreds": {
-    "providers": ["era-commons", "fence", "dcf-fence", "anvil", "kids-first", "ras", "github"],
+    "providers": ["era-commons", "fence", "dcf-fence", "kids-first", "ras", "github"],
     "urlRoot": "https://externalcreds.dsde-staging.broadinstitute.org"
   },
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/ID-1391

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
AnVIL data is no longer hosted by Gen3, so we should remove the AnVIL Gen3 link.

### What
- Remove the AnVIL Gen3 Link on the External Identities page.

### Why
- All AnVIL data is hosted in Terra.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
