### PR TITLE
AJ-1932 edit modal nested arrays

### DIFF
--- a/src/workspace-data/data-table/entity-service/AttributeInput.js
+++ b/src/workspace-data/data-table/entity-service/AttributeInput.js
@@ -88,7 +88,8 @@ const defaultValueForAttributeType = (attributeType, referenceEntityType) => {
     ['reference', () => ({ entityName: '', entityType: referenceEntityType })],
     ['number', () => 0],
     ['boolean', () => false],
-    ['json', () => ({})]
+    ['json', () => ({})],
+    ['array', () => []]
   );
 };
 
@@ -107,14 +108,14 @@ const AttributeInput = ({ autoFocus = false, value: attributeValue, initialValue
   const focusLastListItemInput = useRef(false);
   const lastListItemInput = useRef(null);
   useEffect(() => {
-    if (!isList) {
+    if (!isList || attributeType === 'array') {
       lastListItemInput.current = null;
     }
     if (focusLastListItemInput.current && lastListItemInput.current) {
       lastListItemInput.current.focus();
       focusLastListItemInput.current = false;
     }
-  }, [attributeValue, isList]);
+  }, [attributeValue, isList, attributeType]);
 
   return h(Fragment, [
     h(AttributeTypeInput, {

--- a/src/workspace-data/data-table/entity-service/AttributeInput.test.js
+++ b/src/workspace-data/data-table/entity-service/AttributeInput.test.js
@@ -269,6 +269,19 @@ describe('AttributeInput', () => {
       expect(listCheckbox.getAttribute('aria-checked')).toBe('true');
     });
 
+    it('renders a checkbox for list status [Nested Array]', () => {
+      const { getByLabelText } = render(
+        h(AttributeInput, {
+          value: { itemsType: 'AttributeValue', items: [['foo', 'bar'], ['baz']] },
+          onChange: jest.fn(),
+        })
+      );
+
+      const listCheckbox = getByLabelText('Value is a list');
+      expect(listCheckbox.getAttribute('role')).toBe('checkbox');
+      expect(listCheckbox.getAttribute('aria-checked')).toBe('true');
+    });
+
     it('it converts single value to a list when list checkbox is checked', () => {
       const onChange = jest.fn();
       const { getByLabelText } = render(
@@ -314,6 +327,20 @@ describe('AttributeInput', () => {
 
       fireEvent.change(valueInputs[1], { target: { value: 'qux' } });
       expect(onChange).toHaveBeenCalledWith({ itemsType: 'AttributeValue', items: ['foo', 'qux', 'baz'] });
+    });
+
+    it('renders json input for Nested Array', () => {
+      const onChange = jest.fn();
+      const { getByText } = render(
+        h(AttributeInput, {
+          value: { itemsType: 'AttributeValue', items: [['foo', 'bar'], ['baz']] },
+          onChange,
+        })
+      );
+
+      expect(getByText('"foo"')).toBeInTheDocument();
+      expect(getByText('"bar"')).toBeInTheDocument();
+      expect(getByText('"baz"')).toBeInTheDocument();
     });
 
     it('renders buttons to remove items from list', () => {

--- a/src/workspace-data/data-table/entity-service/attribute-utils.js
+++ b/src/workspace-data/data-table/entity-service/attribute-utils.js
@@ -9,7 +9,8 @@ export const getAttributeType = (attributeValue) => {
     [isReference, () => 'reference'],
     // explicit double-equal to check for null and undefined, since entity attribute lists can contain nulls
     // eslint-disable-next-line eqeqeq
-    [(isList ? attributeValue.items[0] : attributeValue) == undefined, () => 'string'],
+    [isList && Array.isArray(attributeValue.items) && attributeValue.items.some(Array.isArray), () => 'array'],
+    [(isList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
     [isList, () => typeof attributeValue.items[0]],
     [typeof attributeValue === 'object', () => 'json'],
     () => typeof attributeValue

--- a/src/workspace-data/data-table/entity-service/attribute-utils.js
+++ b/src/workspace-data/data-table/entity-service/attribute-utils.js
@@ -9,8 +9,8 @@ export const getAttributeType = (attributeValue) => {
     [isReference, () => 'reference'],
     // explicit double-equal to check for null and undefined, since entity attribute lists can contain nulls
     // eslint-disable-next-line eqeqeq
+    [(isList ? attributeValue.items[0] : attributeValue) == undefined, () => 'string'],
     [isList && Array.isArray(attributeValue.items) && attributeValue.items.some(Array.isArray), () => 'array'],
-    [(isList ? attributeValue.items[0] : attributeValue) === undefined, () => 'string'],
     [isList, () => typeof attributeValue.items[0]],
     [typeof attributeValue === 'object', () => 'json'],
     () => typeof attributeValue

--- a/src/workspace-data/data-table/entity-service/attribute-utils.test.js
+++ b/src/workspace-data/data-table/entity-service/attribute-utils.test.js
@@ -28,6 +28,15 @@ describe('getAttributeType', () => {
     expect(getAttributeType({ key: 'value' })).toEqual({ type: 'json', isList: false });
     expect(getAttributeType(['a', 'b', 'c'])).toEqual({ type: 'json', isList: false });
     expect(getAttributeType([{ idx: 0 }, { idx: 1 }, { idx: 2 }])).toEqual({ type: 'json', isList: false });
+    expect(
+      getAttributeType({
+        items: [
+          ['a', 'b'],
+          ['c', 'd'],
+        ],
+        itemsType: 'AttributeValue',
+      })
+    ).toEqual({ type: 'array', isList: true });
   });
 
   it('returns string for null values', () => {

--- a/src/workspace-data/data-table/shared/AttributeInput.ts
+++ b/src/workspace-data/data-table/shared/AttributeInput.ts
@@ -66,6 +66,25 @@ export const renderInputForAttributeType = _.curry((attributeType, props) => {
           onEdit: _.flow(_.get('updated_src'), onChange),
         });
       },
+    ],
+    [
+      'array',
+      () => {
+        const { value, onChange, ...otherProps } = props;
+        return h(ReactJson, {
+          ...otherProps,
+          style: { ...otherProps.style, whiteSpace: 'pre-wrap' },
+          src: value,
+          displayObjectSize: false,
+          displayDataTypes: false,
+          enableClipboard: false,
+          displayArrayKey: false,
+          name: false,
+          onAdd: _.flow(_.get('updated_src'), onChange),
+          onDelete: _.flow(_.get('updated_src'), onChange),
+          onEdit: _.flow(_.get('updated_src'), onChange),
+        });
+      },
     ]
   );
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1932


### What
- This PR fixes the issue where the edit modal doesn't work for cells with nested arrays in GCP data tables. 

### Why
- The current modal is unusable for nested arrays, confusing users. This update improves clarity and usability by enabling edits for nested arrays.

### Testing strategy
- Test that nested arrays can be edited in the modal where possible.
- Verify the behavior for both nested and non-nested arrays.


https://github.com/user-attachments/assets/451b6d49-1045-4449-933e-6971096c2b8f