### PR TITLE
Writers cannot grant canCompute to other writers (WOR-1826).

### DIFF
--- a/src/workspaces/ShareWorkspaceModal/Collaborator.tsx
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.tsx
@@ -114,7 +114,7 @@ export const AclInput: React.FC<AclInputProps> = (props: AclInputProps) => {
               ...Utils.switchCase(
                 o?.value,
                 ['READER', () => ({ canCompute: false, canShare: false })],
-                ['WRITER', () => ({ canCompute: !isAzureWorkspace, canShare: false })],
+                ['WRITER', () => ({ canCompute: hasAccessLevel('OWNER', maxAccessLevel), canShare: false })],
                 ['OWNER', () => ({ canCompute: true, canShare: true })]
               ),
             })


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1826

There was a bug in our logic about whether or not to initially enable "canCompute" when someone has opened the Share Workspace modal as a Writer.

Writers cannot grant "canCompute", though they can create other Writers without the "canCompute" permission. The option was correctly disabled, but because we initially enabled it, we always attempted to grant the permission; the result was that the user was granted the Writer role, but the attempt to also add "canCompute" threw an error.

Before (error shown when clicking Save):

![image](https://github.com/user-attachments/assets/d9784d36-69c9-464b-9da6-c840d447fbc9)

After (and pressing Save does not show an error):

![image](https://github.com/user-attachments/assets/a8c1482a-e8b2-4e4f-a409-e67013218978)



