### PR TITLE
UIE-204 Narrow Ajax Usage pt3

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -634,3 +634,4 @@ export const Workspaces = (signal?: AbortSignal) => ({
 });
 
 export type WorkspacesAjaxContract = ReturnType<typeof Workspaces>;
+export type WorkspaceContract = ReturnType<WorkspacesAjaxContract['workspace']>;

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -26,8 +26,12 @@ import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
 import StepButtons from 'src/components/StepButtons';
 import { HeaderCell, SimpleFlexTable, SimpleTable, Sortable, TextCell } from 'src/components/table';
 import WDLViewer from 'src/components/WDLViewer';
-import { Ajax } from 'src/libs/ajax';
+import { Dockstore } from 'src/libs/ajax/Dockstore';
+import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
+import { Methods } from 'src/libs/ajax/methods/Methods';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { makeExportWorkflowFromWorkspaceProvider } from 'src/libs/ajax/workspaces/providers/ExportWorkflowToWorkspaceProvider';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors, { terraSpecial } from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
@@ -265,7 +269,7 @@ const BucketContentModal = ({
     Utils.withBusyState(setLoading),
     withErrorReporting('Error loading bucket data')
   )(async (newPrefix = prefix) => {
-    const { items, prefixes: newPrefixes } = await Ajax(signal).Buckets.list(googleProject, bucketName, newPrefix);
+    const { items, prefixes: newPrefixes } = await GoogleStorage(signal).list(googleProject, bucketName, newPrefix);
     setObjects(items);
     setPrefixes(newPrefixes);
     setPrefix(newPrefix);
@@ -507,7 +511,7 @@ export const WorkflowView = _.flow(
                   } = modifiedConfig;
                   // will only match if the current root entity type comes from a snapshot
                   const snapshot = _.find({ metadata: { name: modifiedConfig.dataReferenceName } }, availableSnapshots);
-                  Ajax().Metrics.captureEvent(Events.workflowLaunch, {
+                  void Metrics().captureEvent(Events.workflowLaunch, {
                     ...extractWorkspaceDetails(workspace),
                     snapshotId: snapshot?.reference.snapshot,
                     referenceId: snapshot?.referenceId,
@@ -536,7 +540,7 @@ export const WorkflowView = _.flow(
 
       this.setState({ snapshotReferenceError: undefined });
       try {
-        return await Ajax(signal).Workspaces.workspace(namespace, name).methodConfig(workflowNamespace, workflowName).validate();
+        return await Workspaces(signal).workspace(namespace, name).methodConfig(workflowNamespace, workflowName).validate();
       } catch (e) {
         if (e.status === 404) {
           const errmsg = await e.text();
@@ -555,7 +559,7 @@ export const WorkflowView = _.flow(
       const { namespace, name, signal } = this.props;
 
       try {
-        return await Ajax(signal).Workspaces.workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName);
+        return await Workspaces(signal).workspace(namespace, name).snapshotEntityMetadata(googleProject, modifiedConfig.dataReferenceName);
       } catch (error) {
         return undefined;
       }
@@ -575,7 +579,7 @@ export const WorkflowView = _.flow(
       } = this.props;
 
       try {
-        const ws = Ajax(signal).Workspaces.workspace(namespace, name);
+        const ws = Workspaces(signal).workspace(namespace, name);
 
         const [entityMetadata, validationResponse, config] = await Promise.all([
           ws.entityMetadata(),
@@ -587,11 +591,11 @@ export const WorkflowView = _.flow(
         } = config;
         const isRedacted = !validationResponse;
 
-        const inputsOutputs = isRedacted ? {} : await Ajax(signal).Methods.configInputsOutputs(config);
+        const inputsOutputs = isRedacted ? {} : await Methods(signal).configInputsOutputs(config);
         const selection = workflowSelectionStore.get();
         const readSelection = selectionKey && selection.key === selectionKey;
 
-        const { gcpDataRepoSnapshots: snapshots } = await Ajax(signal).Workspaces.workspace(namespace, name).listSnapshots(1000, 0);
+        const { gcpDataRepoSnapshots: snapshots } = await Workspaces(signal).workspace(namespace, name).listSnapshots(1000, 0);
         const snapshotMetadata = _.map('metadata', snapshots);
 
         // Dockstore users who target floating tags can change their WDL via Github without explicitly selecting a new version in Terra.
@@ -632,12 +636,12 @@ export const WorkflowView = _.flow(
         });
 
         if (sourceRepo === 'agora') {
-          const methods = await Ajax(signal).Methods.list({ namespace: methodNamespace, name: methodName });
+          const methods = await Methods(signal).list({ namespace: methodNamespace, name: methodName });
           const snapshotIds = _.map('snapshotId', methods);
 
           this.setState({ versionIds: snapshotIds });
         } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
-          const versions = await Ajax(signal).Dockstore.getVersions({ path: methodPath, isTool: sourceRepo === 'dockstoretools' });
+          const versions = await Dockstore(signal).getVersions({ path: methodPath, isTool: sourceRepo === 'dockstoretools' });
           const versionIds = _.map('name', versions);
 
           this.setState({ versionIds });
@@ -728,11 +732,11 @@ export const WorkflowView = _.flow(
       try {
         if (sourceRepo === 'agora') {
           if (!currentSnapRedacted) {
-            const { synopsis, documentation, payload } = await Ajax(signal).Methods.method(methodNamespace, methodName, methodVersion).get();
+            const { synopsis, documentation, payload } = await Methods(signal).method(methodNamespace, methodName, methodVersion).get();
             this.setState({ synopsis, documentation, wdl: payload });
           }
         } else if (sourceRepo === 'dockstore' || sourceRepo === 'dockstoretools') {
-          const wdl = await Ajax(signal).Dockstore.getWdl({ path: methodPath, version: methodVersion, isTool: sourceRepo === 'dockstoretools' });
+          const wdl = await Dockstore(signal).getWdl({ path: methodPath, version: methodVersion, isTool: sourceRepo === 'dockstoretools' });
           this.setState({ wdl });
         } else {
           throw new Error('unknown sourceRepo');
@@ -780,8 +784,8 @@ export const WorkflowView = _.flow(
         },
         currentSnapRedacted,
       } = this.state;
-      const config = await Ajax(signal).Methods.template({ methodNamespace, methodName, methodPath, sourceRepo, methodVersion: newSnapshotId });
-      const modifiedInputsOutputs = await Ajax(signal).Methods.configInputsOutputs(config);
+      const config = await Methods(signal).template({ methodNamespace, methodName, methodPath, sourceRepo, methodVersion: newSnapshotId });
+      const modifiedInputsOutputs = await Methods(signal).configInputsOutputs(config);
       this.setState({ modifiedInputsOutputs, savedSnapRedacted: currentSnapRedacted, currentSnapRedacted: false });
       this.setState(_.update('modifiedConfig', _.flow(_.set('methodRepoMethod', config.methodRepoMethod), filterConfigIO(modifiedInputsOutputs))));
       this.fetchInfo(config);
@@ -1009,8 +1013,8 @@ export const WorkflowView = _.flow(
                         onChange: async ({ value, source }) => {
                           this.setState({ snapshotReferenceError: undefined });
                           if (source === 'snapshot') {
-                            const selectedSnapshotEntityMetadata = await Ajax(signal)
-                              .Workspaces.workspace(namespace, workspaceName)
+                            const selectedSnapshotEntityMetadata = await Workspaces(signal)
+                              .workspace(namespace, workspaceName)
                               .snapshotEntityMetadata(workspace.googleProject, value);
 
                             this.setState(_.set(['modifiedConfig', 'dataReferenceName'], value));
@@ -1350,10 +1354,7 @@ export const WorkflowView = _.flow(
                 this.setState({ deleting: false, updatingConfig: true });
 
                 try {
-                  await Ajax()
-                    .Workspaces.workspace(workspace.namespace, workspace.name)
-                    .methodConfig(savedConfig.namespace, savedConfig.name)
-                    .delete();
+                  await Workspaces().workspace(workspace.namespace, workspace.name).methodConfig(savedConfig.namespace, savedConfig.name).delete();
 
                   Nav.goToPath('workspace-workflows', _.pick(['namespace', 'name'], workspace));
                 } catch (err) {
@@ -1398,7 +1399,7 @@ export const WorkflowView = _.flow(
         const {
           methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
         } = modifiedConfig;
-        Ajax().Metrics.captureEvent(Events.workflowUploadIO, {
+        Metrics().captureEvent(Events.workflowUploadIO, {
           ...extractWorkspaceDetails(workspace.workspace),
           inputsOrOutputs: key,
           methodVersion,
@@ -1425,7 +1426,7 @@ export const WorkflowView = _.flow(
       const {
         methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
       } = modifiedConfig;
-      Ajax().Metrics.captureEvent(Events.workflowClearIO, {
+      Metrics().captureEvent(Events.workflowClearIO, {
         ...extractWorkspaceDetails(workspace.workspace),
         inputsOrOutputs: key,
         methodVersion,
@@ -1572,7 +1573,7 @@ export const WorkflowView = _.flow(
                         const {
                           methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
                         } = modifiedConfig;
-                        Ajax().Metrics.captureEvent(Events.workflowUseDefaultOutputs, {
+                        Metrics().captureEvent(Events.workflowUseDefaultOutputs, {
                           ...extractWorkspaceDetails(workspace.workspace),
                           methodVersion,
                           sourceRepo,
@@ -1604,8 +1605,8 @@ export const WorkflowView = _.flow(
           _.update('outputs', this.isSingle() ? () => ({}) : _.mapValues(_.trim))
         );
 
-        const validationResponse = await Ajax()
-          .Workspaces.workspace(namespace, name)
+        const validationResponse = await Workspaces()
+          .workspace(namespace, name)
           .methodConfig(workflowNamespace, workflowName)
           .save(trimInputOutput(modifiedConfig));
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1399,7 +1399,7 @@ export const WorkflowView = _.flow(
         const {
           methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
         } = modifiedConfig;
-        Metrics().captureEvent(Events.workflowUploadIO, {
+        void Metrics().captureEvent(Events.workflowUploadIO, {
           ...extractWorkspaceDetails(workspace.workspace),
           inputsOrOutputs: key,
           methodVersion,
@@ -1426,7 +1426,7 @@ export const WorkflowView = _.flow(
       const {
         methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
       } = modifiedConfig;
-      Metrics().captureEvent(Events.workflowClearIO, {
+      void Metrics().captureEvent(Events.workflowClearIO, {
         ...extractWorkspaceDetails(workspace.workspace),
         inputsOrOutputs: key,
         methodVersion,
@@ -1573,7 +1573,7 @@ export const WorkflowView = _.flow(
                         const {
                           methodRepoMethod: { methodVersion, methodNamespace, methodName, methodPath, sourceRepo },
                         } = modifiedConfig;
-                        Metrics().captureEvent(Events.workflowUseDefaultOutputs, {
+                        void Metrics().captureEvent(Events.workflowUseDefaultOutputs, {
                           ...extractWorkspaceDetails(workspace.workspace),
                           methodVersion,
                           sourceRepo,

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -1,10 +1,10 @@
-import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { div, h } from 'react-hyperscript-helpers';
 import { MenuTrigger } from 'src/components/PopupTrigger';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, protectedDataPolicy } from 'src/testing/workspace-fixtures';
@@ -13,9 +13,7 @@ import { tooltipText, WorkspaceMenu } from 'src/workspaces/common/WorkspaceMenu'
 import * as WorkspaceUtils from 'src/workspaces/utils';
 import { AzureWorkspace, GoogleWorkspace, WorkspaceAccessLevel } from 'src/workspaces/utils';
 
-type AjaxContract = ReturnType<typeof Ajax>;
-
-jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/Metrics');
 
 type UseWorkspaceDetailsExports = typeof import('src/workspaces/common/state/useWorkspaceDetails');
 jest.mock('src/workspaces/common/state/useWorkspaceDetails', (): UseWorkspaceDetailsExports => {
@@ -421,12 +419,7 @@ describe('WorkspaceMenu - defined workspace (GCP or Azure)', () => {
       loading: false,
     });
     const captureEvent = jest.fn();
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
-        } as Partial<AjaxContract> as AjaxContract)
-    );
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent }));
 
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));
@@ -537,12 +530,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
       loading: false,
     });
     const captureEvent = jest.fn();
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
-        } as Partial<AjaxContract> as AjaxContract)
-    );
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent }));
 
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));
@@ -567,12 +555,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
       loading: false,
     });
     const captureEvent = jest.fn();
-    asMockedFn(Ajax).mockImplementation(
-      () =>
-        ({
-          Metrics: { captureEvent } as Partial<AjaxContract['Metrics']>,
-        } as Partial<AjaxContract> as AjaxContract)
-    );
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent }));
 
     // Act
     render(h(WorkspaceMenu, workspaceMenuProps));

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -183,7 +183,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   );
 
   const menuClicked = (action: string) => {
-    Metrics().captureEvent(Events.workspaceMenu, {
+    void Metrics().captureEvent(Events.workspaceMenu, {
       action,
       origin,
       ...extractWorkspaceDetails({

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -5,7 +5,7 @@ import { h } from 'react-hyperscript-helpers';
 import { Clickable } from 'src/components/common';
 import { MenuButton } from 'src/components/MenuButton';
 import { makeMenuIcon, MenuTrigger } from 'src/components/PopupTrigger';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useWorkspaceDetails } from 'src/workspaces/common/state/useWorkspaceDetails';
 import {
@@ -183,7 +183,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   );
 
   const menuClicked = (action: string) => {
-    Ajax().Metrics.captureEvent(Events.workspaceMenu, {
+    Metrics().captureEvent(Events.workspaceMenu, {
       action,
       origin,
       ...extractWorkspaceDetails({

--- a/src/workspaces/common/WorkspaceTagSelect.tsx
+++ b/src/workspaces/common/WorkspaceTagSelect.tsx
@@ -2,8 +2,8 @@ import debouncePromise from 'debounce-promise';
 import _ from 'lodash/fp';
 import React from 'react';
 import { AsyncCreatableSelect } from 'src/components/common';
-import { Ajax } from 'src/libs/ajax';
 import { WorkspaceTag } from 'src/libs/ajax/workspaces/workspace-models';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { withErrorReporting } from 'src/libs/error';
 import { useCancellation, useInstance } from 'src/libs/react-utils';
 
@@ -24,7 +24,7 @@ export const WorkspaceTagSelect = <isMulti extends boolean>(props: WorkspaceTagS
         return _.map((matchingTag: WorkspaceTag): WorkspaceTagSelectOption => {
           const { tag, count } = matchingTag;
           return { value: tag, label: `${tag} (${count})` };
-        }, await Ajax(signal).Workspaces.getTags(text, 10));
+        }, await Workspaces(signal).getTags(text, 10));
       }),
       250
     )

--- a/src/workspaces/common/state/useWorkspace.test.ts
+++ b/src/workspaces/common/state/useWorkspace.test.ts
@@ -1,10 +1,10 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { act } from '@testing-library/react';
 import _ from 'lodash/fp';
-import { Ajax } from 'src/libs/ajax';
 import { AzureStorage, AzureStorageContract } from 'src/libs/ajax/AzureStorage';
 import * as GoogleStorage from 'src/libs/ajax/GoogleStorage';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import * as Notifications from 'src/libs/notifications';
 import { InitializedWorkspaceWrapper, workspaceStore } from 'src/libs/state';
 import { renderHookInAct } from 'src/testing/test-utils';
@@ -18,9 +18,8 @@ import {
 
 jest.mock('src/libs/ajax/AzureStorage');
 
-type AjaxExports = typeof import('src/libs/ajax');
-jest.mock('src/libs/ajax');
-type AjaxContract = ReturnType<AjaxExports['Ajax']>;
+jest.mock('src/libs/ajax/Metrics');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 jest.mock('src/libs/notifications');
 
@@ -147,14 +146,14 @@ describe('useWorkspace', () => {
 
   it('can initialize from a Google workspace in workspaceStore', async () => {
     // Arrange
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+          }),
+      })
+    );
 
     workspaceStore.set(initializedGoogleWorkspace);
     const expectedStorageDetails = _.merge(
@@ -179,14 +178,14 @@ describe('useWorkspace', () => {
 
   it('can initialize from a requester pays Google workspace in workspaceStore', async () => {
     // Arrange
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          checkBucketLocation: () => Promise.reject(new Response('Mock requester pays error', { status: 400 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            checkBucketLocation: () => Promise.reject(new Response('Mock requester pays error', { status: 400 })),
+          }),
+      })
+    );
 
     workspaceStore.set(initializedGoogleWorkspace);
     // Calling to get the bucket location fails, default options remain except for indication of error state.
@@ -270,17 +269,17 @@ describe('useWorkspace', () => {
       defaultAzureStorageOptions
     );
 
-    const successMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-          storageCostEstimate: jest.fn(),
-          bucketUsage: jest.fn(),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => successMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+            storageCostEstimate: jest.fn(),
+            bucketUsage: jest.fn(),
+          }),
+      })
+    );
 
     // Act
     await act(async () => {
@@ -297,15 +296,15 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
 
-    const errorMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketReadAccess: () => Promise.reject(new Response('Mock permissions error', { status: 500 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketReadAccess: () => Promise.reject(new Response('Mock permissions error', { status: 500 })),
+          }),
+      })
+    );
 
     // Verify initial failure based on error mock.
     const { result } = await verifyGooglePermissionsFailure();
@@ -319,18 +318,16 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
     const captureEventFn = jest.fn();
-    const errorMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketReadAccess: () => Promise.reject(new Response('Mock permissions error', { status: 500 })),
-        }),
-      },
-      Metrics: {
-        captureEvent: captureEventFn,
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent: captureEventFn }));
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketReadAccess: () => Promise.reject(new Response('Mock permissions error', { status: 500 })),
+          }),
+      })
+    );
 
     // Verify initial failure does not fire event
     await verifyGooglePermissionsFailure();
@@ -354,18 +351,19 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
 
-    const errorMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-          storageCostEstimate: () => Promise.reject(new Response('Mock storage cost estimate error', { status: 500 })),
-          bucketUsage: jest.fn(),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+            storageCostEstimate: () =>
+              Promise.reject(new Response('Mock storage cost estimate error', { status: 500 })),
+            bucketUsage: jest.fn(),
+          }),
+      })
+    );
 
     // Verify initial failure based on error mock.
     const { result } = await verifyGooglePermissionsFailure();
@@ -379,18 +377,18 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
 
-    const errorMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-          storageCostEstimate: jest.fn(),
-          bucketUsage: () => Promise.reject(new Response('Mock bucket usage error', { status: 500 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+            storageCostEstimate: jest.fn(),
+            bucketUsage: () => Promise.reject(new Response('Mock bucket usage error', { status: 500 })),
+          }),
+      })
+    );
 
     // Verify initial failure based on error mock.
     const { result } = await verifyGooglePermissionsFailure();
@@ -404,18 +402,18 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
 
-    const errorMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: () => Promise.reject(new Response('Mock check bucket location', { status: 500 })),
-          checkBucketReadAccess: jest.fn(),
-          storageCostEstimate: jest.fn(),
-          bucketUsage: jest.fn(),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => errorMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: () => Promise.reject(new Response('Mock check bucket location', { status: 500 })),
+            checkBucketReadAccess: jest.fn(),
+            storageCostEstimate: jest.fn(),
+            bucketUsage: jest.fn(),
+          }),
+      })
+    );
 
     // Verify initial failure based on error mock.
     const { result } = await verifyGooglePermissionsFailure('ERROR');
@@ -433,18 +431,18 @@ describe('useWorkspace', () => {
 
     // checkBucketAccess and checkBucketLocation succeed, but calls that should only be executed if
     // user has writer permission throw errors (to verify that they aren't called).
-    const successMockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-          storageCostEstimate: () => Promise.reject(new Response('Should not call', { status: 500 })),
-          bucketUsage: () => Promise.reject(new Response('Should not call', { status: 500 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => successMockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+            storageCostEstimate: () => Promise.reject(new Response('Should not call', { status: 500 })),
+            bucketUsage: () => Promise.reject(new Response('Should not call', { status: 500 })),
+          }),
+      })
+    );
 
     const expectedAllSyncedDetails = _.merge(
       {
@@ -470,15 +468,15 @@ describe('useWorkspace', () => {
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
 
     // Throw error from checkBucketReadAccess
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketReadAccess: () => Promise.reject(new Response('Mock requester pays error', { status: 500 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketReadAccess: () => Promise.reject(new Response('Mock requester pays error', { status: 500 })),
+          }),
+      })
+    );
 
     // Will not attempt to retrieve storage details due to requester pays
     const expectedStorageDetails = _.merge(
@@ -508,14 +506,14 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = initializedAzureWorkspace;
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+          }),
+      })
+    );
 
     const errorAzureStorageMock: Partial<AzureStorageContract> = {
       details: () => Promise.reject(new Response('Mock container error', { status: 500 })),
@@ -579,14 +577,14 @@ describe('useWorkspace', () => {
     // remove workspaceInitialized because the server response does not include this information
     const { workspaceInitialized, ...serverWorkspaceResponse } = uninitializedAzureWorkspace;
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+          }),
+      })
+    );
 
     // Because we are mocking the "clone" workflow for an Azure workspace, we expect the first
     // call for Azure storage details after changing namespace/name to fail.
@@ -654,14 +652,14 @@ describe('useWorkspace', () => {
 
   it('returns an access error if workspace details throws a 404', async () => {
     // Arrange
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: () => Promise.reject(new Response('Mock access error', { status: 404 })),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: () => Promise.reject(new Response('Mock access error', { status: 404 })),
+          }),
+      })
+    );
 
     // Act
     const { result } = await renderHookInAct(() => useWorkspace('testNamespace', 'testName'));
@@ -681,16 +679,16 @@ describe('useWorkspace', () => {
 
     const expectedWorkspaceResponse = _.merge(_.clone(serverWorkspaceResponse), { workspaceInitialized: true });
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+          }),
+      })
+    );
 
     const expectStorageDetails = _.merge(
       {
@@ -723,16 +721,16 @@ describe('useWorkspace', () => {
 
     const expectedWorkspaceResponse = _.merge(_.clone(serverWorkspaceResponse), { workspaceInitialized: true });
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () => ({
-          details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-          checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-          checkBucketReadAccess: jest.fn(),
-        }),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
+            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
+            checkBucketReadAccess: jest.fn(),
+          }),
+      })
+    );
 
     const expectStorageDetails = _.merge(
       {

--- a/src/workspaces/dashboard/WorkspaceTags.test.ts
+++ b/src/workspaces/dashboard/WorkspaceTags.test.ts
@@ -1,22 +1,15 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { WorkspaceTags } from 'src/workspaces/dashboard/WorkspaceTags';
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxExports = typeof import('src/libs/ajax');
-
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
+jest.mock('src/libs/ajax/Metrics');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 // set the collapsable panel to be open
 jest.mock('src/libs/prefs', (): typeof import('src/libs/prefs') => ({
@@ -65,16 +58,18 @@ describe('WorkspaceTags', () => {
     const addedTag = 'new tag';
     const mockAddTagsFn = jest.fn().mockResolvedValue([...initialTags, addedTag]);
     const mockCaptureEvent = jest.fn();
-    asMockedFn(Ajax).mockReturnValue({
-      Metrics: { captureEvent: mockCaptureEvent } as Partial<AjaxContract['Metrics']>,
-      Workspaces: {
+    asMockedFn(Metrics).mockReturnValue(
+      partial<MetricsContract>({
+        captureEvent: mockCaptureEvent,
+      })
+    );
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         // the tags select component still calls this
         getTags: jest.fn().mockResolvedValue([initialTags]),
-        workspace: jest.fn().mockReturnValue({
-          addTag: mockAddTagsFn,
-        }),
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+        workspace: jest.fn().mockReturnValue({ addTag: mockAddTagsFn }),
+      })
+    );
     const user = userEvent.setup();
 
     // Act
@@ -126,16 +121,18 @@ describe('WorkspaceTags', () => {
     const initialTags = [remainingTag, deletingTag];
     const mockDeleteTagsFn = jest.fn().mockResolvedValue([remainingTag]);
     const mockCaptureEvent = jest.fn();
-    asMockedFn(Ajax).mockReturnValue({
-      Metrics: { captureEvent: mockCaptureEvent } as Partial<AjaxContract['Metrics']>,
-      Workspaces: {
+    asMockedFn(Metrics).mockReturnValue(
+      partial<MetricsContract>({
+        captureEvent: mockCaptureEvent,
+      })
+    );
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         // the tags select component still calls this
         getTags: jest.fn().mockResolvedValue([]),
-        workspace: jest.fn().mockReturnValue({
-          deleteTag: mockDeleteTagsFn,
-        }),
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+        workspace: jest.fn().mockReturnValue({ deleteTag: mockDeleteTagsFn }),
+      })
+    );
     const user = userEvent.setup();
 
     // Act

--- a/src/workspaces/dashboard/WorkspaceTags.ts
+++ b/src/workspaces/dashboard/WorkspaceTags.ts
@@ -3,7 +3,8 @@ import _ from 'lodash/fp';
 import { CSSProperties, ReactNode, useState } from 'react';
 import { div, h, i, span } from 'react-hyperscript-helpers';
 import { icon } from 'src/components/icons';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
@@ -51,8 +52,8 @@ export const WorkspaceTags = (props: WorkspaceTagsProps): ReactNode => {
     withErrorReporting('Error adding tag'),
     withBusyState(setBusy)
   )(async (tag) => {
-    setTagsList(await Ajax().Workspaces.workspace(namespace, name).addTag(tag));
-    Ajax().Metrics.captureEvent(Events.workspaceDashboardAddTag, {
+    setTagsList(await Workspaces().workspace(namespace, name).addTag(tag));
+    void Metrics().captureEvent(Events.workspaceDashboardAddTag, {
       tag,
       ...extractWorkspaceDetails(workspace),
     });
@@ -62,8 +63,8 @@ export const WorkspaceTags = (props: WorkspaceTagsProps): ReactNode => {
     withErrorReporting('Error removing tag'),
     withBusyState(setBusy)
   )(async (tag) => {
-    setTagsList(await Ajax().Workspaces.workspace(namespace, name).deleteTag(tag));
-    Ajax().Metrics.captureEvent(Events.workspaceDashboardDeleteTag, {
+    setTagsList(await Workspaces().workspace(namespace, name).deleteTag(tag));
+    void Metrics().captureEvent(Events.workspaceDashboardDeleteTag, {
       tag,
       ...extractWorkspaceDetails(workspace),
     });

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -49,7 +49,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         onBlur: (_) => {
           if (keywordLastEvented !== lastKeywordSearched) {
             keywordLastEvented = lastKeywordSearched;
-            Metrics().captureEvent(Events.workspaceListFilter, { filter: 'keyword', option: keywordLastEvented });
+            void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'keyword', option: keywordLastEvented });
           }
         },
         value: filters.keywordFilter,
@@ -65,7 +65,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         'aria-label': 'Filter by tags',
         onChange: (data) => {
           const option = _.map('value', data);
-          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'tags', option });
+          void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'tags', option });
           Nav.updateSearch({ ...query, tagsFilter: option });
         },
       }),
@@ -80,7 +80,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         value: filters.accessLevels,
         onChange: (data) => {
           const option = _.map('value', data);
-          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'access', option });
+          void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'access', option });
           Nav.updateSearch({ ...query, accessLevelsFilter: option });
         },
         options: [...workspaceAccessLevels], // need to re-create the list otherwise the readonly type of workspaceAccessLevels conflicts with the type of options
@@ -97,7 +97,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         hideSelectedOptions: true,
         onChange: (data) => {
           const option = data?.value || undefined;
-          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'billingProject', option });
+          void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'billingProject', option });
           Nav.updateSearch({ ...query, projectsFilter: option });
         },
         options: _.flow(_.map('workspace.namespace'), _.uniq, _.sortBy(_.identity))(workspaces),
@@ -113,7 +113,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         hideSelectedOptions: true,
         onChange: (data) => {
           const option = data?.value || undefined;
-          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'cloudPlatform', option });
+          void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'cloudPlatform', option });
           Nav.updateSearch({ ...query, cloudPlatform: option });
         },
         options: _.sortBy((cloudProvider) => cloudProviderLabels[cloudProvider], _.keys(cloudProviderTypes)),

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -4,7 +4,7 @@ import { div, h } from 'react-hyperscript-helpers';
 import { CloudPlatform } from 'src/billing-core/models';
 import { Select } from 'src/components/common';
 import { DelayedSearchInput } from 'src/components/input';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { useInstance } from 'src/libs/react-utils';
@@ -49,7 +49,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         onBlur: (_) => {
           if (keywordLastEvented !== lastKeywordSearched) {
             keywordLastEvented = lastKeywordSearched;
-            Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'keyword', option: keywordLastEvented });
+            Metrics().captureEvent(Events.workspaceListFilter, { filter: 'keyword', option: keywordLastEvented });
           }
         },
         value: filters.keywordFilter,
@@ -65,7 +65,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         'aria-label': 'Filter by tags',
         onChange: (data) => {
           const option = _.map('value', data);
-          Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'tags', option });
+          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'tags', option });
           Nav.updateSearch({ ...query, tagsFilter: option });
         },
       }),
@@ -80,7 +80,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         value: filters.accessLevels,
         onChange: (data) => {
           const option = _.map('value', data);
-          Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'access', option });
+          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'access', option });
           Nav.updateSearch({ ...query, accessLevelsFilter: option });
         },
         options: [...workspaceAccessLevels], // need to re-create the list otherwise the readonly type of workspaceAccessLevels conflicts with the type of options
@@ -97,7 +97,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         hideSelectedOptions: true,
         onChange: (data) => {
           const option = data?.value || undefined;
-          Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'billingProject', option });
+          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'billingProject', option });
           Nav.updateSearch({ ...query, projectsFilter: option });
         },
         options: _.flow(_.map('workspace.namespace'), _.uniq, _.sortBy(_.identity))(workspaces),
@@ -113,7 +113,7 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         hideSelectedOptions: true,
         onChange: (data) => {
           const option = data?.value || undefined;
-          Ajax().Metrics.captureEvent(Events.workspaceListFilter, { filter: 'cloudPlatform', option });
+          Metrics().captureEvent(Events.workspaceListFilter, { filter: 'cloudPlatform', option });
           Nav.updateSearch({ ...query, cloudPlatform: option });
         },
         options: _.sortBy((cloudProvider) => cloudProviderLabels[cloudProvider], _.keys(cloudProviderTypes)),


### PR DESCRIPTION
- switch first wave of shared src/workspaces code to call Ajax sub-modules directly.
- updated related unit test mocks.
- updated workflows WorkflowView tests to honor Ajax shifts in useWorkspace related changes, and shifted its own Ajax calls.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability and potential for code sharing.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
