### PR TITLE
[WOR-1821] Add requester pays to settings modal

### DIFF
--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -32,7 +32,7 @@ export interface MethodConfiguration {
 }
 
 // TYPES RELATED TO WORKSPACE SETTINGS
-export type WorkspaceSetting = BucketLifecycleSetting | SoftDeleteSetting;
+export type WorkspaceSetting = BucketLifecycleSetting | SoftDeleteSetting | RequesterPaysSetting;
 
 export interface BucketLifecycleSetting {
   settingType: 'GcpBucketLifecycle';
@@ -42,6 +42,11 @@ export interface BucketLifecycleSetting {
 export interface SoftDeleteSetting {
   settingType: 'GcpBucketSoftDelete';
   config: { retentionDurationInSeconds: number };
+}
+
+export interface RequesterPaysSetting {
+  settingType: 'GcpBucketRequesterPays';
+  config: { enabled: boolean };
 }
 
 export interface BucketLifecycleRule {

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -177,6 +177,7 @@ const eventsList = {
   workspaceSampleTsvDownload: 'workspace:sample-tsv:download',
   workspaceSettingsBucketLifecycle: 'workspace:settings:bucketLifecycle',
   workspaceSettingsSoftDelete: 'workspace:settings:softDelete',
+  workspaceSettingsRequesterPays: 'workspace:settings:requesterPays',
   workspaceShare: 'workspace:share',
   workspaceShareWithSupport: 'workspace:shareWithSupport',
   workspaceSnapshotDelete: 'workspace:snapshot:delete',

--- a/src/workspaces/SettingsModal/RequesterPays.tsx
+++ b/src/workspaces/SettingsModal/RequesterPays.tsx
@@ -21,12 +21,9 @@ const RequesterPays = (props: RequesterPaysProps): ReactNode => {
       isOwner={isOwner}
       description={
         <>
-          This{' '}
-          <ExternalLink href='https://cloud.google.com/storage/docs/requester-pays'>
-            requester pays setting
-          </ExternalLink>{' '}
-          specifies whether the costs of requests on a storage resource are billed to the project owner or the
-          requester. Requester pays can be enabled or disabled.{' '}
+          When <ExternalLink href='https://cloud.google.com/storage/docs/requester-pays'>requester pays</ExternalLink>{' '}
+          is enabled, requests for the bucket&apos;s data will be billed to the requester&apos;s project instead of the
+          bucket owner. The requester will be prompted to select their own billing project.{' '}
         </>
       }
     />

--- a/src/workspaces/SettingsModal/RequesterPays.tsx
+++ b/src/workspaces/SettingsModal/RequesterPays.tsx
@@ -1,0 +1,36 @@
+import { ExternalLink } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+import Setting from 'src/workspaces/SettingsModal/Setting';
+
+interface RequesterPaysProps {
+  requesterPaysEnabled: boolean;
+  setRequesterPaysEnabled: (enabled: boolean) => void;
+  isOwner: boolean;
+}
+
+const RequesterPays = (props: RequesterPaysProps): ReactNode => {
+  const { requesterPaysEnabled, setRequesterPaysEnabled, isOwner } = props;
+
+  const settingToggled = (checked: boolean) => setRequesterPaysEnabled(checked);
+
+  return (
+    <Setting
+      settingEnabled={requesterPaysEnabled}
+      setSettingEnabled={settingToggled}
+      label='Requester Pays:'
+      isOwner={isOwner}
+      description={
+        <>
+          This{' '}
+          <ExternalLink href='https://cloud.google.com/storage/docs/requester-pays'>
+            requester pays setting
+          </ExternalLink>{' '}
+          specifies whether the costs of requests on a storage resource are billed to the project owner or the
+          requester. Requester pays can be enabled or disabled.{' '}
+        </>
+      }
+    />
+  );
+};
+
+export default RequesterPays;

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -110,13 +110,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
   };
 
   const getRequesterPaysSetting = (settings: WorkspaceSetting[]): RequesterPaysSetting | undefined => {
-    const requesterPaysSettings: RequesterPaysSetting[] = settings.filter((setting: WorkspaceSetting) =>
-      isRequesterPaysSetting(setting)
-    ) as RequesterPaysSetting[];
-    if (requesterPaysSettings.length > 0) {
-      return requesterPaysSettings[0];
-    }
-    return undefined;
+    return settings.find((setting: WorkspaceSetting) => isRequesterPaysSetting(setting)) as RequesterPaysSetting;
   };
 
   useEffect(() => {
@@ -217,7 +211,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     ) {
       // If the bucket had no soft delete setting before, and the current one is the default retention, don't event.
     } else if (!_.isEqual(originalSoftDeleteSetting, newSoftDeleteSetting)) {
-      // Event if an explicit setting existed before and it changed.
+      // Event if the setting changed.
       Ajax().Metrics.captureEvent(Events.workspaceSettingsSoftDelete, {
         enabled: softDeleteEnabled,
         retention: softDeleteRetention, // will be null if soft delete is disabled

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -225,7 +225,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     if (originalRequesterPaysSetting === undefined && !newRequesterPaysSetting?.config.enabled) {
       // If the bucket had no requester pays setting before, and the current one is disabled, don't event.
     } else if (!_.isEqual(originalRequesterPaysSetting, newRequesterPaysSetting)) {
-      // Event if an explicit setting existed before and it changed.
+      // Event if the setting changed.
       Ajax().Metrics.captureEvent(Events.workspaceSettingsRequesterPays, {
         enabled: requesterPaysEnabled,
         ...extractWorkspaceDetails(props.workspace),

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -10,16 +10,20 @@ import { GCP_BUCKET_LIFECYCLE_RULES } from 'src/libs/feature-previews-config';
 import { useCancellation } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import BucketLifecycleSettings from 'src/workspaces/SettingsModal/BucketLifecycleSettings';
+import RequesterPays from 'src/workspaces/SettingsModal/RequesterPays';
 import SoftDelete from 'src/workspaces/SettingsModal/SoftDelete';
 import {
   BucketLifecycleSetting,
   DeleteBucketLifecycleRule,
   isBucketLifecycleSetting,
   isDeleteBucketLifecycleRule,
+  isRequesterPaysSetting,
   isSoftDeleteSetting,
   modifyFirstBucketDeletionRule,
   modifyFirstSoftDeleteSetting,
+  modifyRequesterPaysSetting,
   removeFirstBucketDeletionRule,
+  RequesterPaysSetting,
   secondsInADay,
   softDeleteDefaultRetention,
   SoftDeleteSetting,
@@ -46,6 +50,8 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
 
   const [softDeleteEnabled, setSoftDeleteEnabled] = useState(false);
   const [softDeleteRetention, setSoftDeleteRetention] = useState<number | null>(null);
+
+  const [requesterPaysEnabled, setRequesterPaysEnabled] = useState(false);
 
   // Original settings from server, may contain multiple types
   const [workspaceSettings, setWorkspaceSettings] = useState<WorkspaceSetting[] | undefined>(undefined);
@@ -103,6 +109,16 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     return undefined;
   };
 
+  const getRequesterPaysSetting = (settings: WorkspaceSetting[]): RequesterPaysSetting | undefined => {
+    const requesterPaysSettings: RequesterPaysSetting[] = settings.filter((setting: WorkspaceSetting) =>
+      isRequesterPaysSetting(setting)
+    ) as RequesterPaysSetting[];
+    if (requesterPaysSettings.length > 0) {
+      return requesterPaysSettings[0];
+    }
+    return undefined;
+  };
+
   useEffect(() => {
     const loadSettings = _.flow(
       Utils.withBusyState(setBusy),
@@ -136,6 +152,9 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
         // because it is confusing with the switch being disabled.
         setSoftDeleteRetention(retentionSeconds / secondsInADay);
       }
+      const requesterPays = getRequesterPaysSetting(settings);
+      const requesterPaysEnabled = requesterPays === undefined ? false : requesterPays.config.enabled;
+      setRequesterPaysEnabled(requesterPaysEnabled);
     });
 
     loadSettings();
@@ -154,6 +173,8 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     }
     const softDeleteInDays = softDeleteEnabled ? softDeleteRetention! : 0;
     newSettings = modifyFirstSoftDeleteSetting(newSettings, softDeleteInDays);
+    newSettings = modifyRequesterPaysSetting(newSettings, requesterPaysEnabled);
+
     await Ajax().Workspaces.workspaceV2(namespace, name).updateSettings(newSettings);
     props.onDismiss();
 
@@ -203,6 +224,19 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
         ...extractWorkspaceDetails(props.workspace),
       });
     }
+
+    // Event about requester pays setting only if something actually changed.
+    const originalRequesterPaysSetting = getRequesterPaysSetting(workspaceSettings || []);
+    const newRequesterPaysSetting = getRequesterPaysSetting(newSettings);
+    if (originalRequesterPaysSetting === undefined && !newRequesterPaysSetting?.config.enabled) {
+      // If the bucket had no requester pays setting before, and the current one is disabled, don't event.
+    } else if (!_.isEqual(originalRequesterPaysSetting, newRequesterPaysSetting)) {
+      // Event if an explicit setting existed before and it changed.
+      Ajax().Metrics.captureEvent(Events.workspaceSettingsRequesterPays, {
+        enabled: requesterPaysEnabled,
+        ...extractWorkspaceDetails(props.workspace),
+      });
+    }
   });
 
   const getSaveTooltip = () => {
@@ -241,11 +275,18 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
           />
         </div>
       )}
-      <SoftDelete
-        softDeleteEnabled={softDeleteEnabled}
-        setSoftDeleteEnabled={setSoftDeleteEnabled}
-        softDeleteRetention={softDeleteRetention}
-        setSoftDeleteRetention={setSoftDeleteRetention}
+      <div style={{ paddingBottom: '1.0rem', borderBottom: `1px solid ${colors.accent()}` }}>
+        <SoftDelete
+          softDeleteEnabled={softDeleteEnabled}
+          setSoftDeleteEnabled={setSoftDeleteEnabled}
+          softDeleteRetention={softDeleteRetention}
+          setSoftDeleteRetention={setSoftDeleteRetention}
+          isOwner={isOwner}
+        />
+      </div>
+      <RequesterPays
+        requesterPaysEnabled={requesterPaysEnabled}
+        setRequesterPaysEnabled={setRequesterPaysEnabled}
         isOwner={isOwner}
       />
 


### PR DESCRIPTION
### Jira Ticket: [https://broadworkbench.atlassian.net/browse/1821](https://broadworkbench.atlassian.net/browse/1821)

Extends the workspace settings modal to include a new section for Requester Pays. The setting is represented by a simple toggle switch. This allows users to set requester pays on their workspaces without contacting Support.

Other setting types are implemented to be tolerant of receiving multiple settings of that type when getting the workspace settings. Requester pays is a more unambiguous on/off feature and it would not make sense for there to be multiple to preserve. This implementation still wouldn't error out if there were multiple requester pays settings, but it would silently discard them.

<img width="300" alt="Screenshot 2024-09-27 at 3 07 38 PM" src="https://github.com/user-attachments/assets/46352228-843f-44bc-b5f5-a23da1dbb7c2">

https://github.com/user-attachments/assets/0c19199f-954a-460b-aa27-ec2491f6bb00