### PR TITLE
[IA-5073] Fix a11y issue with clicking on a non-focusable element.

### DIFF
--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -54,7 +54,7 @@ const testRunAnalysisAzure = _.flowRight(
   await waitForNoModal(page);
 
   // Navigate to analysis launcher
-  await click(page, `//*[@title="${notebookName}.ipynb"]`);
+  await click(page, clickable({ textContains: `${notebookName}.ipynb` }));
   await dismissInfoNotifications(page);
   await findText(page, 'PREVIEW (READ-ONLY)');
   await waitForNoSpinners(page);

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -50,7 +50,7 @@ const testRunAnalysisFn = _.flowRight(
   await waitForNoModal(page);
 
   // Navigate to analysis launcher
-  await click(page, `//*[@title="${notebookName}.ipynb"]`);
+  await click(page, clickable({ textContains: `${notebookName}.ipynb` }));
   await dismissInfoNotifications(page);
   await findText(page, 'PREVIEW (READ-ONLY)');
   await waitForNoSpinners(page);

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -53,7 +53,7 @@ const testRunRStudioFn = _.flowRight(
   await waitForNoModal(page);
 
   // Navigate to analysis launcher
-  await click(page, `//*[@title="${rFileName}.Rmd"]`);
+  await click(page, clickable({ textContains: `${rFileName}.Rmd` }));
   await dismissInfoNotifications(page);
   await findText(page, 'PREVIEW (READ-ONLY)');
   await waitForNoSpinners(page);

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -321,7 +321,6 @@ const AnalysisCard = ({
   // the flex values for columns here correspond to the flex values in the header
   const artifactName = div(
     {
-      onClick: () => Nav.goToPath(analysisLauncherTabName, { namespace, name: workspaceName, analysisName }),
       title: getFileName(name),
       role: 'cell',
       style: {

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -317,6 +317,7 @@ const AnalysisCard = ({
     ]
   );
 
+  const launchAnalysis = () => Nav.goToPath(analysisLauncherTabName, { namespace, name: workspaceName, analysisName });
   // the flex values for columns here correspond to the flex values in the header
   const artifactName = div(
     {
@@ -331,7 +332,7 @@ const AnalysisCard = ({
         ...centerColumnFlex,
       },
     },
-    [getFileName(name)]
+    [h(Clickable, { onClick: launchAnalysis }, [getFileName(name)])]
   );
 
   const toolLogos: Record<RuntimeToolLabel, string> = {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-5073

I noticed this while working on the Puppeteer upgrade, as the newer version of Puppeteer did not want to click on a non-focusable element.

Adding a click handler to a div with no aria roles defined to indicate that the element is interactive is a major problem. Such an element is not keyboard focusable (cannot be reached via tab navigation), and thus is not accessible to people who cannot use a mouse.

Before (not focusable):

![image](https://github.com/user-attachments/assets/fa4dd4ed-bc6b-4460-ad34-a1fdc12d375a)


After (showing my browser keyboard-focus indication):

![image](https://github.com/user-attachments/assets/bf934876-954b-4fa0-ac61-bf65ed9a9d25)
