### PR TITLE
[WOR-1699][WOR-1701] Consume workspace and billing project admin support APIs

### DIFF
--- a/src/libs/ajax/billing/Billing.ts
+++ b/src/libs/ajax/billing/Billing.ts
@@ -12,6 +12,7 @@ import {
   GoogleBillingAccount,
   SpendReport,
 } from 'src/libs/ajax/billing/billing-models';
+import { SupportSummary } from 'src/support/SupportResourceType';
 
 export const Billing = (signal?: AbortSignal) => ({
   listProjects: async (): Promise<BillingProject[]> => {
@@ -22,6 +23,11 @@ export const Billing = (signal?: AbortSignal) => ({
   getProject: async (projectName: string): Promise<BillingProject> => {
     const route = `billing/v2/${projectName}`;
     const res = await fetchRawls(route, _.merge(authOpts(), { signal, method: 'GET' }));
+    return res.json();
+  },
+
+  adminGetProject: async (projectName: string): Promise<SupportSummary> => {
+    const res = await fetchRawls(`admin/billing/${projectName}`, _.merge(authOpts(), { signal }));
     return res.json();
   },
 

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -24,6 +24,7 @@ import {
 } from 'src/libs/ajax/workspaces/workspace-models';
 import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
+import { SupportSummary } from 'src/support/SupportResourceType';
 
 const getSnapshotEntityMetadata = Utils.memoizeAsync(
   async (
@@ -93,6 +94,11 @@ export const Workspaces = (signal?: AbortSignal) => ({
     }
     const response = await fetchRawls(url, _.mergeAll([authOpts(), { signal }]));
     return response.json();
+  },
+
+  adminGetById: async (workspaceId: string): Promise<SupportSummary> => {
+    const res = await fetchRawls(`admin/workspaces/${workspaceId}`, _.merge(authOpts(), { signal }));
+    return res.json();
   },
 
   workspaceV2: (namespace: string, name: string) => {

--- a/src/support/SupportResourceType.ts
+++ b/src/support/SupportResourceType.ts
@@ -22,7 +22,11 @@ export const supportResources: SupportResourceType[] = [
     resourceType: 'managed-group',
     loadSupportSummaryFn: (id: FullyQualifiedResourceId) => Ajax().Groups.group(id.resourceId).getSupportSummary(),
   },
-  { displayName: 'Workspace', resourceType: 'workspace', loadSupportSummaryFn: undefined },
+  {
+    displayName: 'Workspace',
+    resourceType: 'workspace',
+    loadSupportSummaryFn: (id: FullyQualifiedResourceId) => Ajax().Workspaces.adminGetById(id.resourceId),
+  },
   { displayName: 'Billing Project', resourceType: 'billing-project', loadSupportSummaryFn: undefined },
   { displayName: 'Dataset', resourceType: 'dataset', loadSupportSummaryFn: undefined },
   { displayName: 'Snapshot', resourceType: 'datasnapshot', loadSupportSummaryFn: undefined },

--- a/src/support/SupportResourceType.ts
+++ b/src/support/SupportResourceType.ts
@@ -27,7 +27,11 @@ export const supportResources: SupportResourceType[] = [
     resourceType: 'workspace',
     loadSupportSummaryFn: (id: FullyQualifiedResourceId) => Ajax().Workspaces.adminGetById(id.resourceId),
   },
-  { displayName: 'Billing Project', resourceType: 'billing-project', loadSupportSummaryFn: undefined },
+  {
+    displayName: 'Billing Project',
+    resourceType: 'billing-project',
+    loadSupportSummaryFn: (id: FullyQualifiedResourceId) => Ajax().Billing.adminGetProject(id.resourceId),
+  },
   { displayName: 'Dataset', resourceType: 'dataset', loadSupportSummaryFn: undefined },
   { displayName: 'Snapshot', resourceType: 'datasnapshot', loadSupportSummaryFn: undefined },
 ].sort((a, b) => a.displayName.localeCompare(b.displayName));


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1699 https://broadworkbench.atlassian.net/browse/WOR-1701

### Dependencies 
https://broadworkbench.atlassian.net/browse/WOR-1698
https://broadworkbench.atlassian.net/browse/WOR-1700


## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Consume new billing project and workspace support APIs
![Screenshot 2024-10-02 at 10 29 40 AM](https://github.com/user-attachments/assets/728afbd8-c631-4946-bf62-2cba4f827881)
![Screenshot 2024-10-02 at 10 30 14 AM](https://github.com/user-attachments/assets/f51c370f-742d-4715-a4c3-3ffa071a28a8)


### Why
- The support page was previously only fetching information from Sam for workspaces and billing projects. Now it will also include information from the Rawls database which will make the page more useful for our support team

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
