### PR TITLE
[WOR-1830] Updates for new submission directory structure 

### DIFF
--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -32,7 +32,11 @@ export interface MethodConfiguration {
 }
 
 // TYPES RELATED TO WORKSPACE SETTINGS
-export type WorkspaceSetting = BucketLifecycleSetting | SoftDeleteSetting | RequesterPaysSetting;
+export type WorkspaceSetting =
+  | BucketLifecycleSetting
+  | SoftDeleteSetting
+  | RequesterPaysSetting
+  | SeparateSubmissionFinalOutputsSetting;
 
 export interface BucketLifecycleSetting {
   settingType: 'GcpBucketLifecycle';
@@ -46,6 +50,11 @@ export interface SoftDeleteSetting {
 
 export interface RequesterPaysSetting {
   settingType: 'GcpBucketRequesterPays';
+  config: { enabled: boolean };
+}
+
+export interface SeparateSubmissionFinalOutputsSetting {
+  settingType: 'SeparateSubmissionFinalOutputs';
   config: { enabled: boolean };
 }
 

--- a/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
+++ b/src/workspaces/SettingsModal/BucketLifecycleSettings.tsx
@@ -1,7 +1,9 @@
-import { CreatableSelect, ExternalLink, useUniqueId } from '@terra-ui-packages/components';
+import { CreatableSelect, ExternalLink, Icon, useUniqueId } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { ReactNode } from 'react';
 import { NumberInput } from 'src/components/input';
+import colors from 'src/libs/colors';
+import * as Style from 'src/libs/style';
 import Setting from 'src/workspaces/SettingsModal/Setting';
 import { suggestedPrefixes } from 'src/workspaces/SettingsModal/utils';
 
@@ -59,6 +61,25 @@ const BucketLifecycleSettings = (props: BucketLifecycleSettingsProps): ReactNode
       }
     >
       <div style={{ marginTop: '.5rem', marginBottom: '.5rem' }}>
+        <div style={{ ...Style.elements.noticeContainer }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'auto auto',
+              fontStyle: 'italic',
+            }}
+          >
+            <Icon
+              icon='warning-standard'
+              size={24}
+              style={{ color: colors.warning(), flex: 'none', marginRight: '0.5rem' }}
+            />
+            <div style={{ flex: 1 }}>
+              Enabling lifecycle rules will also change the directory structure for future workflow submissions by
+              separating files into submission/intermediates and submissions/final-outputs directories.
+            </div>
+          </div>
+        </div>
         <div style={{ marginTop: '.75rem', marginBottom: '.5rem' }}>Delete objects in:</div>
         <CreatableSelect
           isClearable

--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -5,6 +5,7 @@ import { axe } from 'jest-axe';
 import _ from 'lodash/fp';
 import React from 'react';
 import { Ajax } from 'src/libs/ajax';
+import { SeparateSubmissionFinalOutputsSetting } from 'src/libs/ajax/workspaces/workspace-models';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { GCP_BUCKET_LIFECYCLE_RULES } from 'src/libs/feature-previews-config';
@@ -113,6 +114,16 @@ describe('SettingsModal', () => {
     config: { enabled: false },
   };
 
+  const separateSubmissionOutputsDisabledSetting: SeparateSubmissionFinalOutputsSetting = {
+    settingType: 'SeparateSubmissionFinalOutputs',
+    config: { enabled: false },
+  };
+
+  const separateSubmissionOutputsEnabledSetting: SeparateSubmissionFinalOutputsSetting = {
+    settingType: 'SeparateSubmissionFinalOutputs',
+    config: { enabled: true },
+  };
+
   const setup = (currentSetting: WorkspaceSetting[], updateSettingsMock: jest.Mock<any, any>) => {
     jest.resetAllMocks();
     jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -174,7 +185,7 @@ describe('SettingsModal', () => {
     // Assert
     expect(onDismiss).toHaveBeenCalled();
     expect(captureEvent).not.toHaveBeenCalled();
-    // On save we do persist the default soft delete setting so it now explicit.
+    // On save we do persist the default soft delete setting so it is now explicit.
     expect(updateSettingsMock).toHaveBeenCalledWith([defaultSoftDeleteSetting]);
   });
 
@@ -276,7 +287,11 @@ describe('SettingsModal', () => {
       expect(prefixInput.getSelectedOptions()).toEqual([suggestedPrefixes.allObjects]);
       expect(prefixInput.inputElement).not.toHaveAttribute('disabled');
       const allOptions = await prefixInput.getOptions();
-      expect(allOptions).toEqual([suggestedPrefixes.submissions, suggestedPrefixes.submissionIntermediaries]);
+      expect(allOptions).toEqual([
+        suggestedPrefixes.submissionIntermediaries,
+        suggestedPrefixes.submissionFinalOutputs,
+        suggestedPrefixes.submissions,
+      ]);
 
       const daysInput = getDays();
       expect(daysInput).toHaveValue(4);
@@ -366,7 +381,11 @@ describe('SettingsModal', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       // Assert
-      expect(updateSettingsMock).toHaveBeenCalledWith([defaultSoftDeleteSetting, noLifecycleRules]);
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        defaultSoftDeleteSetting,
+        separateSubmissionOutputsDisabledSetting,
+        noLifecycleRules,
+      ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBucketLifecycle, {
         enabled: false,
         prefix: null,
@@ -401,6 +420,7 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
         defaultSoftDeleteSetting,
+        separateSubmissionOutputsDisabledSetting,
         {
           config: {
             rules: [
@@ -447,6 +467,7 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
         defaultSoftDeleteSetting,
+        separateSubmissionOutputsEnabledSetting,
         {
           config: {
             rules: [
@@ -501,6 +522,7 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
         defaultSoftDeleteSetting,
+        separateSubmissionOutputsEnabledSetting,
         {
           config: {
             rules: [
@@ -558,6 +580,7 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
         defaultSoftDeleteSetting,
+        separateSubmissionOutputsEnabledSetting,
         {
           config: {
             rules: [

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -249,7 +249,7 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
     <Modal
       title='Configure Workspace Settings'
       onDismiss={props.onDismiss}
-      width={550}
+      width={600}
       okButton={
         <ButtonPrimary disabled={!!getSaveTooltip()} onClick={persistSettings} tooltip={getSaveTooltip()}>
           Save

--- a/src/workspaces/SettingsModal/utils.test.ts
+++ b/src/workspaces/SettingsModal/utils.test.ts
@@ -81,6 +81,10 @@ describe('disableFirstBucketDeletionRule', () => {
     // Assert
     expect(result).toEqual([
       {
+        settingType: 'SeparateSubmissionFinalOutputs',
+        config: { enabled: false },
+      },
+      {
         settingType: 'GcpBucketLifecycle',
         config: {
           rules: [
@@ -149,6 +153,10 @@ describe('disableFirstBucketDeletionRule', () => {
 
     // Assert
     expect(result).toEqual([
+      {
+        settingType: 'SeparateSubmissionFinalOutputs',
+        config: { enabled: false },
+      },
       {
         settingType: 'GcpBucketLifecycle',
         config: {
@@ -228,6 +236,10 @@ describe('modifyFirstBucketDeletionRule', () => {
 
     // Assert
     expect(result).toEqual([
+      {
+        settingType: 'SeparateSubmissionFinalOutputs',
+        config: { enabled: true },
+      },
       {
         settingType: 'GcpBucketLifecycle',
         config: {
@@ -324,6 +336,10 @@ describe('modifyFirstBucketDeletionRule', () => {
 
     // Assert
     expect(result).toEqual([
+      {
+        settingType: 'SeparateSubmissionFinalOutputs',
+        config: { enabled: true },
+      },
       {
         settingType: 'GcpBucketLifecycle',
         config: {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1830

This adds a warning message and toggles the new "Separate Submission Final Outputs" setting based on whether or not bucket lifecycle rules are enabled (but only if the user actually changes something).

Remember to enable the feature flag to view/use the UI: https://pr-5-dot-bvdp-saturn-dev.appspot.com/#feature-preview

<img width="652" alt="image" src="https://github.com/user-attachments/assets/531c94f7-584e-4c4b-8901-b9f0bb15d7aa">

Disable response:

```
    "successes": [
        {
            "config": {
                "enabled": false
            },
            "settingType": "SeparateSubmissionFinalOutputs"
        },
        {
            "config": {
                "rules": []
            },`
            "settingType": "GcpBucketLifecycle"
        }
    ]
```

Enable response:

```
  "successes": [
        {
            "config": {
                "enabled": true
            },
            "settingType": "SeparateSubmissionFinalOutputs"
        },
        {
            "config": {
                "rules": [
                    {
                        "action": {
                            "actionType": "Delete"
                        },
                        "conditions": {
                            "age": 5,
                            "matchesPrefix": [
                                "submissions/intermediates/"
                            ]
                        }
                    }
                ]
            },
            "settingType": "GcpBucketLifecycle"
        }
]
```