### PR TITLE
UIE-204 Narrow Ajax Usage pt4

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -251,8 +251,6 @@ describe('Workflow View (GCP)', () => {
   const mockLaunchResponse = jest.fn(() => Promise.resolve({ submissionId: 'abc123', ...initializedGoogleWorkspace.workspaceId }));
 
   const mockDefaultAjax = () => {
-    asMockedFn(leoDiskProvider.list).mockImplementation(jest.fn());
-
     Methods.mockReturnValue({
       list: jest.fn(() => Promise.resolve(methodList)),
       method: () => ({
@@ -290,19 +288,7 @@ describe('Workflow View (GCP)', () => {
     });
     Apps.mockReturnValue({ list: jest.fn().mockReturnValue([]) });
     Runtimes.mockReturnValue({ listV2: jest.fn() });
-    // Ajax.mockImplementation(() => ({
-    //   Disks: {
-    //     disksV1: () => ({
-    //       list: jest.fn(),
-    //     }),
-    //   },
-    //   Runtimes: {
-    //     listV2: jest.fn(),
-    //   },
-    //   Apps: {
-    //     list: jest.fn().mockReturnValue([]),
-    //   },
-    // }));
+    asMockedFn(leoDiskProvider.list).mockImplementation(jest.fn());
   };
 
   it('view workflow in workspace from mock import', async () => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -2,6 +2,7 @@ import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
 import { Methods } from 'src/libs/ajax/methods/Methods';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
@@ -16,6 +17,7 @@ jest.mock('src/libs/ajax');
 
 jest.mock('src/libs/ajax/Dockstore');
 jest.mock('src/libs/ajax/GoogleStorage');
+jest.mock('src/libs/ajax/leonardo/Apps');
 jest.mock('src/libs/ajax/methods/Methods');
 jest.mock('src/libs/ajax/Metrics');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
@@ -284,6 +286,7 @@ describe('Workflow View (GCP)', () => {
         }),
       }),
     });
+    Apps.mockReturnValue({ list: jest.fn().mockReturnValue([]) });
     Ajax.mockImplementation(() => ({
       Disks: {
         disksV1: () => ({

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -4,6 +4,7 @@ import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { leoDiskProvider } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { Methods } from 'src/libs/ajax/methods/Methods';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
@@ -18,6 +19,7 @@ jest.mock('src/libs/ajax');
 jest.mock('src/libs/ajax/Dockstore');
 jest.mock('src/libs/ajax/GoogleStorage');
 jest.mock('src/libs/ajax/leonardo/Apps');
+jest.mock('src/libs/ajax/leonardo/Runtimes');
 jest.mock('src/libs/ajax/methods/Methods');
 jest.mock('src/libs/ajax/Metrics');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
@@ -287,6 +289,7 @@ describe('Workflow View (GCP)', () => {
       }),
     });
     Apps.mockReturnValue({ list: jest.fn().mockReturnValue([]) });
+    Runtimes.mockReturnValue({ listV2: jest.fn() });
     Ajax.mockImplementation(() => ({
       Disks: {
         disksV1: () => ({

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -290,19 +290,19 @@ describe('Workflow View (GCP)', () => {
     });
     Apps.mockReturnValue({ list: jest.fn().mockReturnValue([]) });
     Runtimes.mockReturnValue({ listV2: jest.fn() });
-    Ajax.mockImplementation(() => ({
-      Disks: {
-        disksV1: () => ({
-          list: jest.fn(),
-        }),
-      },
-      Runtimes: {
-        listV2: jest.fn(),
-      },
-      Apps: {
-        list: jest.fn().mockReturnValue([]),
-      },
-    }));
+    // Ajax.mockImplementation(() => ({
+    //   Disks: {
+    //     disksV1: () => ({
+    //       list: jest.fn(),
+    //     }),
+    //   },
+    //   Runtimes: {
+    //     listV2: jest.fn(),
+    //   },
+    //   Apps: {
+    //     list: jest.fn().mockReturnValue([]),
+    //   },
+    // }));
   };
 
   it('view workflow in workspace from mock import', async () => {

--- a/src/workspaces/common/state/useAppPolling.ts
+++ b/src/workspaces/common/state/useAppPolling.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/workspaces/common/state/useWorkspace';
@@ -30,14 +30,14 @@ export const useAppPolling = (name: string, namespace: string, workspace?: Works
     try {
       const newGoogleApps =
         workspace?.workspaceInitialized && isGoogleWorkspace(workspace)
-          ? await Ajax(signal).Apps.list(workspace.workspace.googleProject, {
+          ? await Apps(signal).list(workspace.workspace.googleProject, {
               role: 'creator',
               saturnWorkspaceName: workspace.workspace.name,
             })
           : [];
       const newAzureApps =
         workspace?.workspaceInitialized && isAzureWorkspace(workspace)
-          ? await Ajax(signal).Apps.listAppsV2(workspace.workspace.workspaceId)
+          ? await Apps(signal).listAppsV2(workspace.workspace.workspaceId)
           : [];
       const combinedNewApps = [...newGoogleApps, ...newAzureApps];
 

--- a/src/workspaces/common/state/useCloningWorkspaceNotifications.test.tsx
+++ b/src/workspaces/common/state/useCloningWorkspaceNotifications.test.tsx
@@ -2,10 +2,10 @@ import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { NotificationType } from '@terra-ui-packages/notifications';
 import { waitFor } from '@testing-library/react';
 import React from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { clearNotification, notify } from 'src/libs/notifications';
 import { cloningWorkspacesStore } from 'src/libs/state';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace } from 'src/testing/workspace-fixtures';
 import {
   notifyNewWorkspaceClone,
@@ -14,15 +14,7 @@ import {
 import { WORKSPACE_UPDATE_POLLING_INTERVAL } from 'src/workspaces/common/state/useWorkspaceStatePolling';
 import { WorkspaceInfo, WorkspaceState, WorkspaceWrapper } from 'src/workspaces/utils';
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxWorkspacesContract = AjaxContract['Workspaces'];
-
-jest.mock('src/libs/ajax', (): typeof import('src/libs/ajax') => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 type NotificationExports = typeof import('src/libs/notifications');
 jest.mock<NotificationExports>(
@@ -95,15 +87,11 @@ describe('useCloningWorkspaceNotifications', () => {
         },
       };
       const mockDetailsFn = jest.fn().mockResolvedValue(update);
-      const mockAjax: DeepPartial<AjaxContract> = {
-        Workspaces: {
-          workspace: () =>
-            ({
-              details: mockDetailsFn,
-            } as Partial<AjaxWorkspacesContract['workspace']>),
-        },
-      };
-      asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+      asMockedFn(Workspaces).mockReturnValue(
+        partial<WorkspacesAjaxContract>({
+          workspace: () => partial<WorkspaceContract>({ details: mockDetailsFn }),
+        })
+      );
 
       // Act
       render(<CloningTestComponent />);
@@ -136,12 +124,11 @@ describe('useCloningWorkspaceNotifications', () => {
         },
       };
       const mockDetailsFn = jest.fn().mockImplementation(() => Promise.resolve(update));
-      const mockAjax: DeepPartial<AjaxContract> = {
-        Workspaces: {
-          workspace: () => ({ details: mockDetailsFn }),
-        },
-      };
-      asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+      asMockedFn(Workspaces).mockReturnValue(
+        partial<WorkspacesAjaxContract>({
+          workspace: () => partial<WorkspaceContract>({ details: mockDetailsFn }),
+        })
+      );
       jest.useFakeTimers();
       // Act
       render(<CloningTestComponent />);
@@ -170,15 +157,11 @@ describe('useCloningWorkspaceNotifications', () => {
       },
     };
     const mockDetailsFn = jest.fn().mockResolvedValue(update);
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        workspace: () =>
-          ({
-            details: mockDetailsFn,
-          } as Partial<AjaxWorkspacesContract['workspace']>),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ details: mockDetailsFn }),
+      })
+    );
     jest.useFakeTimers();
 
     // Act

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
@@ -1,17 +1,15 @@
 import { generateTestDiskWithGoogleWorkspace } from 'src/analysis/_testData/testData';
-import { Ajax } from 'src/libs/ajax';
 import { leoDiskProvider, PersistentDisk } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
-import { RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
-import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+import { Runtimes, RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
+import { asMockedFn, partial, renderHookInAct } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, defaultInitializedGoogleWorkspace } from 'src/testing/workspace-fixtures';
 
 import { useCloudEnvironmentPolling } from './useCloudEnvironmentPolling';
 
-jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/leonardo/Runtimes');
 jest.mock('src/libs/ajax/leonardo/providers/LeoDiskProvider');
 
 // This code will be needed when we mock and test the runtime methods
-type AjaxContract = ReturnType<typeof Ajax>;
 type RuntimesNeeds = Pick<RuntimesAjaxContract, 'listV2'>;
 interface RuntimeMockNeeds {
   topLevel: RuntimesNeeds;
@@ -30,9 +28,9 @@ const mockAjaxNeeds = (): AjaxMockNeeds => {
   const partialRuntimes: RuntimesNeeds = {
     listV2: jest.fn(),
   };
-  const mockRuntimes = partialRuntimes as RuntimesAjaxContract;
+  const mockRuntimes = partial<RuntimesAjaxContract>(partialRuntimes);
 
-  asMockedFn(Ajax).mockReturnValue({ Runtimes: mockRuntimes } as AjaxContract);
+  asMockedFn(Runtimes).mockReturnValue(mockRuntimes);
 
   return {
     Runtimes: {
@@ -69,7 +67,7 @@ describe('useCloudEnvironmentPolling', () => {
 
     // Assert
     // Runtimes and disk ajax calls
-    expect(Ajax).toBeCalledTimes(1);
+    expect(Runtimes).toBeCalledTimes(1);
     expect(leoDiskProvider.list).toBeCalledTimes(1);
     expect(result.current.persistentDisks).toEqual([persistentDisk]);
     expect(result.current.appDataDisks).toEqual([appDisk]);

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.ts
@@ -2,9 +2,9 @@ import _ from 'lodash/fp';
 import { useEffect, useRef, useState } from 'react';
 import { getDiskAppType } from 'src/analysis/utils/app-utils';
 import { getConvertedRuntimeStatus, getCurrentRuntime } from 'src/analysis/utils/runtime-utils';
-import { Ajax } from 'src/libs/ajax';
 import { ListRuntimeItem } from 'src/libs/ajax/leonardo/models/runtime-models';
 import { leoDiskProvider, PersistentDisk } from 'src/libs/ajax/leonardo/providers/LeoDiskProvider';
+import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { withErrorIgnoring, withErrorReporting } from 'src/libs/error';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/workspaces/common/state/useWorkspace';
 
@@ -58,7 +58,7 @@ export const useCloudEnvironmentPolling = (
           },
           { signal: controller.current.signal }
         ),
-        Ajax(controller.current.signal).Runtimes.listV2(cloudEnvFilters),
+        Runtimes(controller.current.signal).listV2(cloudEnvFilters),
       ]);
 
       setRuntimes(newRuntimes);

--- a/src/workspaces/common/state/useWorkspace.test.ts
+++ b/src/workspaces/common/state/useWorkspace.test.ts
@@ -17,7 +17,6 @@ import {
 } from 'src/workspaces/common/state/useWorkspace';
 
 jest.mock('src/libs/ajax/AzureStorage');
-
 jest.mock('src/libs/ajax/Metrics');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
 

--- a/src/workspaces/common/state/useWorkspaceById.test.ts
+++ b/src/workspaces/common/state/useWorkspaceById.test.ts
@@ -1,31 +1,16 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { act } from '@testing-library/react';
-import { Ajax } from 'src/libs/ajax';
-import { asMockedFn, renderHookInAct } from 'src/testing/test-utils';
+import { Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
+import { asMockedFn, partial, renderHookInAct } from 'src/testing/test-utils';
 
 import { useWorkspaceById } from './useWorkspaceById';
 
-type AjaxExports = typeof import('src/libs/ajax');
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  const actual = jest.requireActual<AjaxExports>('src/libs/ajax');
-  return {
-    ...actual,
-    Ajax: jest.fn(),
-  };
-});
-
-type AjaxContract = ReturnType<typeof Ajax>;
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 describe('useWorkspaceById', () => {
   it('fetches a workspace by ID', async () => {
     // Arrange
     const getWorkspaceById = jest.fn().mockResolvedValue({});
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        getById: getWorkspaceById,
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({ getById: getWorkspaceById }));
 
     // Act
     await renderHookInAct(() => useWorkspaceById('test-workspace'));
@@ -37,12 +22,7 @@ describe('useWorkspaceById', () => {
   it('fetches workspace when ID changes', async () => {
     // Arrange
     const getWorkspaceById = jest.fn().mockResolvedValue({});
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
-        getById: getWorkspaceById,
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({ getById: getWorkspaceById }));
 
     const { rerender } = await renderHookInAct(useWorkspaceById, { initialProps: 'workspace-1' });
 

--- a/src/workspaces/common/state/useWorkspaceById.ts
+++ b/src/workspaces/common/state/useWorkspaceById.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { useCancellation } from 'src/libs/react-utils';
 import { WorkspaceWrapper } from 'src/workspaces/utils';
 
@@ -27,7 +27,7 @@ export const useWorkspaceById = (workspaceId: string, fields?: string[]): UseWor
       const loadWorkspace = async () => {
         setState({ status: 'Loading', workspace: null });
         try {
-          const workspace = await Ajax(signal).Workspaces.getById(workspaceId, fields);
+          const workspace = await Workspaces(signal).getById(workspaceId, fields);
           setState({ status: 'Ready', workspace });
         } catch (error: unknown) {
           setState({ status: 'Error', workspace: null, error });

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { useState } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { withErrorReporting } from 'src/libs/error';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
@@ -18,7 +18,7 @@ export const useWorkspaceDetails = (workspaceName: { namespace: string; name: st
     withErrorReporting('Error loading workspace details'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws: Workspace = await Ajax(signal).Workspaces.workspace(namespace, name).details(fields);
+    const ws: Workspace = await Workspaces(signal).workspace(namespace, name).details(fields);
     setWorkspace(ws);
   });
 

--- a/src/workspaces/common/state/useWorkspaceStatePolling.ts
+++ b/src/workspaces/common/state/useWorkspaceStatePolling.ts
@@ -1,7 +1,7 @@
 import { LoadedState } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { useEffect, useRef } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { workspacesStore, workspaceStore } from 'src/libs/state';
 import { pollWithCancellation } from 'src/libs/utils';
 import { BaseWorkspaceInfo, WorkspaceInfo, WorkspaceState, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
@@ -47,8 +47,8 @@ const checkWorkspaceState = async (
 ): Promise<WorkspaceUpdate | undefined> => {
   const startingState = workspace.state;
   try {
-    const wsResp: Workspace = await Ajax(signal)
-      .Workspaces.workspace(workspace.namespace, workspace.name)
+    const wsResp: Workspace = await Workspaces(signal)
+      .workspace(workspace.namespace, workspace.name)
       .details(['workspace.state', 'workspace.errorMessage']);
     const state = wsResp.workspace.state;
 

--- a/src/workspaces/container/WorkspaceContainer.test.ts
+++ b/src/workspaces/container/WorkspaceContainer.test.ts
@@ -1,10 +1,9 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
 import { screen, waitFor, within } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { goToPath } from 'src/libs/nav';
 import { workspacesStore, workspaceStore } from 'src/libs/state';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultAzureWorkspace, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { InitializedWorkspaceWrapper } from 'src/workspaces/common/state/useWorkspace';
 import { WORKSPACE_UPDATE_POLLING_INTERVAL } from 'src/workspaces/common/state/useWorkspaceStatePolling';
@@ -21,16 +20,9 @@ jest.mock(
   })
 );
 
-type AjaxExports = typeof import('src/libs/ajax');
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxWorkspacesContract = AjaxContract['Workspaces'];
-
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
+jest.mock('src/libs/ajax/AzureStorage');
+jest.mock('src/libs/ajax/Metrics');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 type StateExports = typeof import('src/libs/state');
 jest.mock<StateExports>(
@@ -128,15 +120,14 @@ describe('WorkspaceContainer', () => {
 
     const mockDetailsFn = jest.fn();
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         workspace: () =>
-          ({
+          partial<WorkspaceContract>({
             details: mockDetailsFn,
-          } as Partial<AjaxWorkspacesContract['workspace']>),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+          }),
+      })
+    );
 
     const workspace: InitializedWorkspaceWrapper = {
       ...defaultAzureWorkspace,
@@ -186,15 +177,14 @@ describe('WorkspaceContainer', () => {
     };
     const mockDetailsFn = jest.fn().mockResolvedValue({ workspace: { state: 'Deleting' } });
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         workspace: () =>
-          ({
+          partial<WorkspaceContract>({
             details: mockDetailsFn,
-          } as Partial<AjaxWorkspacesContract['workspace']>),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+          }),
+      })
+    );
 
     const props = {
       namespace: workspace.workspace.namespace,
@@ -239,15 +229,14 @@ describe('WorkspaceContainer', () => {
     // Arrange
     const mockDetailsFn = jest.fn().mockRejectedValue(new Response(null, { status: 404 }));
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         workspace: () =>
-          ({
+          partial<WorkspaceContract>({
             details: mockDetailsFn,
-          } as Partial<AjaxWorkspacesContract['workspace']>),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+          }),
+      })
+    );
 
     const workspace: InitializedWorkspaceWrapper = {
       ...defaultAzureWorkspace,
@@ -310,15 +299,14 @@ describe('WorkspaceContainer', () => {
     const errorMessage = 'this is an error message';
     const mockDetailsFn = jest.fn().mockResolvedValue({ workspace: { state: 'DeleteFailed', errorMessage } });
 
-    const mockAjax: DeepPartial<AjaxContract> = {
-      Workspaces: {
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         workspace: () =>
-          ({
+          partial<WorkspaceContract>({
             details: mockDetailsFn,
-          } as Partial<AjaxWorkspacesContract['workspace']>),
-      },
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+          }),
+      })
+    );
 
     const workspace: InitializedWorkspaceWrapper = {
       ...defaultAzureWorkspace,

--- a/src/workspaces/list/WorkspacesList.ts
+++ b/src/workspaces/list/WorkspacesList.ts
@@ -6,7 +6,7 @@ import { Link, topSpinnerOverlay, transparentSpinnerOverlay } from 'src/componen
 import FooterWrapper from 'src/components/FooterWrapper';
 import { icon } from 'src/components/icons';
 import { TopBar } from 'src/components/TopBar';
-import { Ajax } from 'src/libs/ajax';
+import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
 import { withErrorIgnoring } from 'src/libs/error';
 import { updateSearch, useRoute } from 'src/libs/nav';
 import { useOnMount } from 'src/libs/react-utils';
@@ -79,7 +79,7 @@ export const WorkspacesList = (): ReactNode => {
 
   useOnMount(() => {
     const loadFeatured = withErrorIgnoring(async () => {
-      setFeaturedList(await Ajax().FirecloudBucket.getFeaturedWorkspaces());
+      setFeaturedList(await FirecloudBucket().getFeaturedWorkspaces());
     });
     loadFeatured();
   });


### PR DESCRIPTION
- 2nd wave of shared Workspaces area ajax import fixes to call ajax sub-areas directly.
- fixed related unit test mocks, and added a bit of extra type safety.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability and potential code sharing

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
