### PR TITLE
[IA-5074] Improve IA integration test stability

### DIFF
--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -52,7 +52,9 @@ const testRunAnalysisAzure = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
-  // In addition to spinners related to the side modal, there is a spinner over the page.
+  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
+  await delay(Millis.ofSeconds(5));
+  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
   await waitForNoSpinners(page);
 
   // Navigate to analysis launcher

--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -21,7 +21,7 @@ const {
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  waitForNoModal,
+  waitForNoModalDrawer,
   waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -51,7 +51,7 @@ const testRunAnalysisAzure = _.flowRight(
     timeout: Millis.ofMinute,
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
-  await waitForNoModal(page);
+  await waitForNoModalDrawer(page);
   // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
   await delay(Millis.ofSeconds(5));
   // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
@@ -67,7 +67,7 @@ const testRunAnalysisAzure = _.flowRight(
   await click(page, clickable({ textContains: 'Open' }));
   await findText(page, 'Azure Cloud Environment');
   await click(page, clickable({ textContains: 'Create' }));
-  await waitForNoModal(page);
+  await waitForNoModalDrawer(page);
 
   // Wait for env to begin creating
   await findElement(page, clickable({ textContains: 'JupyterLab Environment' }));

--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -52,10 +52,6 @@ const testRunAnalysisAzure = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModalDrawer(page);
-  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
-  await delay(Millis.ofSeconds(5));
-  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
-  await waitForNoSpinners(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${notebookName}.ipynb` }));

--- a/integration-tests/tests/run-analysis-azure.ts
+++ b/integration-tests/tests/run-analysis-azure.ts
@@ -52,6 +52,8 @@ const testRunAnalysisAzure = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
+  // In addition to spinners related to the side modal, there is a spinner over the page.
+  await waitForNoSpinners(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${notebookName}.ipynb` }));

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -48,6 +48,8 @@ const testRunAnalysisFn = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
+  // In addition to spinners related to the side modal, there is a spinner over the page.
+  await waitForNoSpinners(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${notebookName}.ipynb` }));

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -16,7 +16,7 @@ const {
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  waitForNoModal,
+  waitForNoModalDrawer,
   waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -47,11 +47,7 @@ const testRunAnalysisFn = _.flowRight(
     timeout: Millis.ofMinute,
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
-  await waitForNoModal(page);
-  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
-  await delay(Millis.ofSeconds(5));
-  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
-  await waitForNoSpinners(page);
+  await waitForNoModalDrawer(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${notebookName}.ipynb` }));
@@ -65,7 +61,7 @@ const testRunAnalysisFn = _.flowRight(
   });
   await findText(page, 'Jupyter Cloud Environment');
   await click(page, clickable({ text: 'Create' }));
-  await waitForNoModal(page);
+  await waitForNoModalDrawer(page);
 
   // Wait for env to begin creating
   await findElement(page, clickable({ textContains: 'Jupyter Environment' }), { timeout: Millis.ofSeconds(40) });

--- a/integration-tests/tests/run-analysis.js
+++ b/integration-tests/tests/run-analysis.js
@@ -48,7 +48,9 @@ const testRunAnalysisFn = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
-  // In addition to spinners related to the side modal, there is a spinner over the page.
+  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
+  await delay(Millis.ofSeconds(5));
+  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
   await waitForNoSpinners(page);
 
   // Navigate to analysis launcher

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -51,7 +51,9 @@ const testRunRStudioFn = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
-  // In addition to spinners related to the side modal, there is a spinner over the page.
+  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
+  await delay(Millis.ofSeconds(5));
+  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
   await waitForNoSpinners(page);
 
   // Navigate to analysis launcher

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -51,6 +51,8 @@ const testRunRStudioFn = _.flowRight(
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
   await waitForNoModal(page);
+  // In addition to spinners related to the side modal, there is a spinner over the page.
+  await waitForNoSpinners(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${rFileName}.Rmd` }));

--- a/integration-tests/tests/run-rstudio.js
+++ b/integration-tests/tests/run-rstudio.js
@@ -16,7 +16,7 @@ const {
   getAnimatedDrawer,
   input,
   noSpinnersAfter,
-  waitForNoModal,
+  waitForNoModalDrawer,
   waitForNoSpinners,
 } = require('../utils/integration-utils');
 const { registerTest } = require('../utils/jest-utils');
@@ -50,11 +50,7 @@ const testRunRStudioFn = _.flowRight(
     timeout: Millis.ofMinute,
   });
   await click(page, clickable({ textContains: 'Close' }), { timeout: Millis.ofMinute });
-  await waitForNoModal(page);
-  // Debugging to see if waiting helps (still not clear if modal animation is causing the problem)
-  await delay(Millis.ofSeconds(5));
-  // In addition to spinners related to the side modal, there is a spinner over the page while content loads.
-  await waitForNoSpinners(page);
+  await waitForNoModalDrawer(page);
 
   // Navigate to analysis launcher
   await click(page, clickable({ textContains: `${rFileName}.Rmd` }));
@@ -67,7 +63,7 @@ const testRunRStudioFn = _.flowRight(
     action: () => click(page, clickable({ textContains: 'Open' })),
   });
   await click(page, clickable({ text: 'Create' }));
-  await waitForNoModal(page);
+  await waitForNoModalDrawer(page);
 
   // Wait for env to begin creating
   await findElement(page, clickable({ textContains: 'RStudio Environment' }), { timeout: Millis.ofMinutes(2) });

--- a/integration-tests/utils/integration-utils.js
+++ b/integration-tests/utils/integration-utils.js
@@ -233,6 +233,12 @@ const waitForModal = (page, { timeout = 30000 } = {}) => {
   return page.waitForSelector('.ReactModal__Overlay', { hidden: false, timeout });
 };
 
+const waitForNoModalDrawer = async (page) => {
+  await waitForNoModal(page);
+  // Matches the animation transition time
+  await delay(200);
+};
+
 // Puppeteer works by internally using MutationObserver. We are setting up the listener before
 // the action to ensure that the spinner rendering is captured by the observer, followed by
 // waiting for the spinner to be removed
@@ -631,6 +637,7 @@ module.exports = {
   waitForNoModal,
   waitForMenu,
   waitForModal,
+  waitForNoModalDrawer,
   waitForNoSpinners,
   withPageLogging,
   withScreenshot,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-5074

We are seeing sporadic failures in these tests that indicate that clicking on the name of the newly created notebook failed (the item to click on _did_ exist as no error was thrown, but apparently it was obscured and the click callback did not get triggered). The notebook/analyses is clicked on immediately after the compute modal slides shut, and given that it has an animated transition, I am guessing that is the cause of the problem.

Example failure:

```
Test: run-rstudio
Status: failed
Failure messages: TimeoutError: Waiting for selector `//*[contains(normalize-space(.),"PREVIEW (READ-ONLY)")]` failed: Waiting failed: 30000ms exceeded
    at new WaitTask (/mnt/ramdisk/.yarn/cache/puppeteer-core-npm-22.7.1-6da5f6bf12-893a366c16.zip/node_modules/puppeteer-core/src/common/WaitTask.ts:82:28)
    at IsolatedWorld.waitForFunction (/mnt/ramdisk/.yarn/cache/puppeteer-core-npm-22.7.1-6da5f6bf12-893a366c16.zip/node_modules/puppeteer-core/src/api/Realm.ts:74:22)
    at Function.waitFor (/mnt/ramdisk/.yarn/cache/puppeteer-core-npm-22.7.1-6da5f6bf12-893a366c16.zip/node_modules/puppeteer-core/src/common/QueryHandler.ts:159:50)
    at CdpFrame.waitForSelector (/mnt/ramdisk/.yarn/cache/puppeteer-core-npm-22.7.1-6da5f6bf12-893a366c16.zip/node_modules/puppeteer-core/src/api/Frame.ts:660:13)
    at CdpPage.waitForSelector (/mnt/ramdisk/.yarn/cache/puppeteer-core-npm-22.7.1-6da5f6bf12-893a366c16.zip/node_modules/puppeteer-core/src/api/Page.ts:2819:12)
Failure details: [
  {
    "name": "TimeoutError"
  }
]
```

Using a delay of 5 seconds passed 4/4 runs. This PR attempts to use a delay that matches the transition animation time, but that may turn out to be flaky given the other operations that are also occurring (spinners in both the side modal and over the page itself).