### PR TITLE
AJ-1003 Standardize File Upload Banner for GCP and Azure Workspaces

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1170,13 +1170,15 @@ export const WorkspaceData = _.flow(
                   uploadingFile &&
                     h(EntityUploader, {
                       onDismiss: () => setUploadingFile(false),
-                      onSuccess: (recordType) => {
+                      onSuccess: (recordType, isSync) => {
                         setUploadingFile(false);
                         forceRefresh();
                         loadMetadata();
-                        notify('success', `Data imported successfully to table ${recordType}.`, {
-                          id: `${recordType}_success`,
-                        });
+                        // Show success message only for synchronous uploads
+                        isSync &&
+                          notify('success', `Data imported successfully to table ${recordType}.`, {
+                            id: `${recordType}_success`,
+                          });
                       },
                       namespace,
                       name,

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1170,15 +1170,10 @@ export const WorkspaceData = _.flow(
                   uploadingFile &&
                     h(EntityUploader, {
                       onDismiss: () => setUploadingFile(false),
-                      onSuccess: (recordType, isSync) => {
+                      onSuccess: () => {
                         setUploadingFile(false);
                         forceRefresh();
                         loadMetadata();
-                        // Show success message only for synchronous uploads
-                        isSync &&
-                          notify('success', `Data imported successfully to table ${recordType}.`, {
-                            id: `${recordType}_success`,
-                          });
                       },
                       namespace,
                       name,

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1170,10 +1170,13 @@ export const WorkspaceData = _.flow(
                   uploadingFile &&
                     h(EntityUploader, {
                       onDismiss: () => setUploadingFile(false),
-                      onSuccess: () => {
+                      onSuccess: (recordType) => {
                         setUploadingFile(false);
                         forceRefresh();
                         loadMetadata();
+                        notify('success', `Data imported successfully to table ${recordType}.`, {
+                          id: `${recordType}_success`,
+                        });
                       },
                       namespace,
                       name,

--- a/src/workspace-data/data-table/shared/EntityUploader.js
+++ b/src/workspace-data/data-table/shared/EntityUploader.js
@@ -17,7 +17,7 @@ import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
 import Events from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
-import { clearNotification } from 'src/libs/notifications';
+import { clearNotification, notify } from 'src/libs/notifications';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
 import validate from 'validate.js';
@@ -56,7 +56,7 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const doUpload = async () => {
     setUploading(true);
     try {
-      const uploaderResponse = await dataProvider.uploadTsv({
+      const isSyncUpload = !!(await dataProvider.uploadTsv({
         workspaceId,
         recordType,
         file,
@@ -64,8 +64,13 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
         deleteEmptyValues,
         namespace,
         name,
-      });
-      onSuccess(recordType, !!uploaderResponse);
+      }));
+      onSuccess(recordType);
+      // Show success message only for synchronous uploads
+      isSyncUpload &&
+        notify('success', `Data imported successfully to table ${recordType}.`, {
+          id: `${recordType}_success`,
+        });
       clearNotification(recordType);
       Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
         workspaceNamespace: namespace,

--- a/src/workspace-data/data-table/shared/EntityUploader.js
+++ b/src/workspace-data/data-table/shared/EntityUploader.js
@@ -56,8 +56,16 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
   const doUpload = async () => {
     setUploading(true);
     try {
-      await dataProvider.uploadTsv({ workspaceId, recordType, file, useFireCloudDataModel, deleteEmptyValues, namespace, name });
-      onSuccess(recordType);
+      const uploaderResponse = await dataProvider.uploadTsv({
+        workspaceId,
+        recordType,
+        file,
+        useFireCloudDataModel,
+        deleteEmptyValues,
+        namespace,
+        name,
+      });
+      onSuccess(recordType, !!uploaderResponse);
       clearNotification(recordType);
       Ajax().Metrics.captureEvent(Events.workspaceDataUpload, {
         workspaceNamespace: namespace,

--- a/src/workspace-data/data-table/shared/EntityUploader.js
+++ b/src/workspace-data/data-table/shared/EntityUploader.js
@@ -66,8 +66,9 @@ export const EntityUploader = ({ onSuccess, onDismiss, namespace, name, entityTy
         name,
       }));
       onSuccess(recordType);
-      // Show success message only for synchronous uploads
+      // Show success message only for synchronous Google Workspace uploads
       isSyncUpload &&
+        isGoogleWorkspace &&
         notify('success', `Data imported successfully to table ${recordType}.`, {
           id: `${recordType}_success`,
         });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1003

### What
- In GCP workspaces, the upload banner currently appears only for files larger than 512k, while in Azure, it shows for all uploads. This PR updates GCP to display the upload banner for all file sizes, matching Azure's behavior.


### Why
- A user requested the banner to always appear for file uploads to confirm success without checking tables. We want to ensure consistent upload confirmation across GCP and Azure workspaces.


### Testing strategy
- Manual testing of functionality by uploading TSV files in GCP workspaces.


https://github.com/user-attachments/assets/e19039b5-78ef-4277-b97b-2a5c25c876c7

