### PR TITLE
AJ-2015 Remove Old Files Section and Add Banner

### DIFF
--- a/src/analysis/ContextBar.ts
+++ b/src/analysis/ContextBar.ts
@@ -48,7 +48,6 @@ import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import Events from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import * as Nav from 'src/libs/nav';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -371,20 +370,19 @@ export const ContextBar = ({
             },
             [icon('terminal', { size: 40 }), span({ className: 'sr-only' }, ['Terminal button'])]
           ),
-        (isAzureWorkspace(workspace) || isFeaturePreviewEnabled('workspace-files')) &&
-          h(
-            Clickable,
-            {
-              style: { paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton },
-              hover: contextBarStyles.hover,
-              tooltipSide: 'left',
-              href: Nav.getLink('workspace-files', { namespace, name }),
-              tooltip: 'Browse workspace files',
-              tooltipDelay: 100,
-              useTooltipAsLabel: false,
-            },
-            [icon('folderSolid', { size: 40 }), span({ className: 'sr-only' }, ['Workspace files'])]
-          ),
+        h(
+          Clickable,
+          {
+            style: { paddingLeft: '1rem', alignItems: 'center', ...contextBarStyles.contextBarButton },
+            hover: contextBarStyles.hover,
+            tooltipSide: 'left',
+            href: Nav.getLink('workspace-files', { namespace, name }),
+            tooltip: 'Browse workspace files',
+            tooltipDelay: 100,
+            useTooltipAsLabel: false,
+          },
+          [icon('folderSolid', { size: 40 }), span({ className: 'sr-only' }, ['Workspace files'])]
+        ),
       ]),
     ]),
   ]);

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -69,15 +69,6 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on JupyterLab (GCP)')}`,
   },
   {
-    id: 'workspace-files',
-    title: 'Workspace Files Browser',
-    description: 'Enabling this feature will allow you to use the new workspace files browser.',
-    groups: ['preview-workspace-files'],
-    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent(
-      'Feedback on workspace files browser'
-    )}`,
-  },
-  {
     id: HAIL_BATCH_AZURE_FEATURE_ID,
     title: 'Hail Batch App on Azure',
     description: 'Enabling this feature will allow you to launch the Hail Batch app in Azure workspaces.',

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1220,19 +1220,13 @@ export const WorkspaceData = _.flow(
                           },
                           ['Workspace Data']
                         ),
-                        h(
-                          DataTypeButton,
-                          {
-                            wrapperProps: { role: 'listitem' },
-                            iconName: 'folder',
-                            iconSize: 18,
-                            selected: selectedData?.type === workspaceDataTypes.bucketObjects,
-                            onClick: () => {
-                              setSelectedData({ type: workspaceDataTypes.bucketObjects });
-                              forceRefresh();
-                            },
-                          },
-                          ['Files']
+                        div(
+                          // File Browser Banner
+                          { style: { padding: '1rem', margin: '0.75rem', backgroundColor: colors.dark(0.1), borderRadius: '0.5rem' } },
+                          [
+                            span({ style: { fontWeight: 'bold' } }, ['Looking for the Files folder?']),
+                            div(['Use the folder icon in the right side-bar to access the workspace Bucket directory.']),
+                          ]
                         ),
                       ]
                     ),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-2015


### What

- Removed the old "Files" section from the workspace.
- Added a temporary banner to guide users to the new file manager.
- Removed workspace-files feature-preview and conditional check

### Why

- The old "Files" section is outdated. The banner helps users find the new file manager and ensures a smooth transition.

### Testing strategy

- Manual Testing: Confirmed both the banner and file manager icon are visible.

**Banner and FileManager Icon**

<img width="1864" alt="Screenshot 2024-10-05 at 10 53 55 PM" src="https://github.com/user-attachments/assets/ffb5d8f5-8f4f-4a70-8b69-0524a37fe23d">

**Feature Preview**

<img width="1864" alt="Screenshot 2024-10-05 at 10 54 10 PM" src="https://github.com/user-attachments/assets/334130c9-3a36-49b8-9aad-ce016906c8f3">

