### PR TITLE
CORE-54: change alerts/emails to core services

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -92,8 +92,8 @@
       ]
     },
     {
-      "name": "dsp-analysis-journeys-alerts",
-      "id": "C031KGQUVB4",
+      "name": "dsp-core-services-alerts",
+      "id": "C07Q8H7F8LV",
       "tests": [
         {
           "name": "import-cohort-data"

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -44,18 +44,6 @@
       ]
     },
     {
-      "name": "dsp-workspaces-test-alerts",
-      "id": "C03F21QEWV7",
-      "tests": [
-        {
-          "name": "billing-projects"
-        },
-        {
-          "name": "delete-orphaned-workspaces"
-        }
-      ]
-    },
-    {
       "name": "jade-data-explorer",
       "id": "C01TU3W2AL9",
       "tests": [
@@ -80,18 +68,6 @@
       ]
     },
     {
-      "name": "identiteam-alerts",
-      "id": "C03HV2AD20N",
-      "tests": [
-        {
-          "name": "register-user"
-        },
-        {
-          "name": "request-access"
-        }
-      ]
-    },
-    {
       "name": "dsp-core-services-alerts",
       "id": "C07Q8H7F8LV",
       "tests": [
@@ -103,6 +79,18 @@
         },
         {
           "name": "import-tdr-snapshot"
+        },
+        {
+          "name": "billing-projects"
+        },
+        {
+          "name": "delete-orphaned-workspaces"
+        },
+        {
+          "name": "register-user"
+        },
+        {
+          "name": "request-access"
         }
       ]
     }

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -80,7 +80,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'Azure PFB Import',
     description: 'Enabling this feature will allow PFB import into Azure workspaces.',
     groups: ['preview-azure-pfb-import'],
-    feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
+    feedbackUrl: `mailto:dsp-core-services@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure PFB Import'
     )}`,
   },
@@ -89,7 +89,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'Azure TDR Import',
     description: 'Enabling this feature will allow importing TDR snapshots into Azure workspaces.',
     groups: ['preview-azure-tdr-import'],
-    feedbackUrl: `mailto:dsp-analysis-journeys@broadinstitute.org?subject=${encodeURIComponent(
+    feedbackUrl: `mailto:dsp-core-services@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Azure TDR snapshot Import'
     )}`,
   },

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -51,7 +51,9 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     description:
       'Enabling this feature will allow you to save uniquely named versions of data tables. These saved versions will appear in the Data tab and can be restored at any time.',
     groups: ['preview-data-versioning-and-provenance'],
-    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table versioning')}`,
+    feedbackUrl: `mailto:dsp-core-services@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on data table versioning'
+    )}`,
   },
   {
     id: 'data-table-provenance',
@@ -59,7 +61,9 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     description:
       'Enabling this feature will allow you to view information about the workflow that generated data table columns and files.',
     groups: ['preview-data-versioning-and-provenance'],
-    feedbackUrl: `mailto:dsp-sue@broadinstitute.org?subject=${encodeURIComponent('Feedback on data table provenance')}`,
+    feedbackUrl: `mailto:dsp-core-services@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on data table provenance'
+    )}`,
   },
   {
     id: JUPYTERLAB_GCP_FEATURE_ID,
@@ -115,7 +119,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'GCP Workspace Bucket Lifecycle Rules',
     description:
       'Enabling this feature will allow GCP bucket lifecycle rules to be set via the Workspace Settings dialog.',
-    feedbackUrl: `mailto:dsp-workspaces@broadinstitute.org?subject=${encodeURIComponent(
+    feedbackUrl: `mailto:dsp-core-services@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on GCP Bucket Lifecycle Rules'
     )}`,
   },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-54

## Summary of changes:
Email addresses and Slack channels for AJ, Workspace, and Identiteam change to CORE team.
