### PR TITLE
CORE-56: mixpanel events for provenance

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -87,6 +87,8 @@ const eventsList = {
   notificationToggle: 'notification:toggle',
   pageView: 'page:view',
   permissionsSynchronizationDelay: 'permissions:propagationDelay',
+  provenanceColumn: 'provenance:column',
+  provenanceFile: 'provenance:file',
   resourceLeave: 'resource:leave',
   uploaderCreateCollection: 'uploader:collection:create',
   uploaderUploadMetadata: 'uploader:metadata:upload',

--- a/src/workspace-data/data-table/entity-service/EntitiesContent.js
+++ b/src/workspace-data/data-table/entity-service/EntitiesContent.js
@@ -627,13 +627,34 @@ const EntitiesContent = ({
             [
               Utils.cond(
                 [loadingColumnProvenance, () => p([h(Spinner, { size: 12, style: { marginRight: '1ch' } }), 'Loading provenance...'])],
-                [columnProvenanceError, () => p(['Error loading column provenance'])],
-                () =>
-                  h(DataTableColumnProvenance, {
+                [
+                  columnProvenanceError,
+                  () => {
+                    Ajax().Metrics.captureEvent(Events.provenanceColumn, {
+                      workspaceNamespace: workspace?.workspace?.namespace,
+                      workspaceName: workspace?.workspace?.name,
+                      entityType: entityKey,
+                      column: showColumnProvenance,
+                      success: false,
+                    });
+                    return p(['Error loading column provenance']);
+                  },
+                ],
+                () => {
+                  Ajax().Metrics.captureEvent(Events.provenanceColumn, {
+                    workspaceNamespace: workspace?.workspace?.namespace,
+                    workspaceName: workspace?.workspace?.name,
+                    entityType: entityKey,
+                    column: showColumnProvenance,
+                    numSubmissions: columnProvenance[showColumnProvenance] ? columnProvenance[showColumnProvenance].length : 0,
+                    success: true,
+                  });
+                  return h(DataTableColumnProvenance, {
                     workspace,
                     column: showColumnProvenance,
                     provenance: columnProvenance[showColumnProvenance],
-                  })
+                  });
+                }
               ),
             ]
           ),

--- a/src/workspace-data/provenance/workspace-data-provenance-utils.test.js
+++ b/src/workspace-data/provenance/workspace-data-provenance-utils.test.js
@@ -1,6 +1,7 @@
+import _ from 'lodash/fp';
 import { Ajax } from 'src/libs/ajax';
 
-import { fileProvenanceTypes, getFileProvenance } from './workspace-data-provenance-utils';
+import { fileProvenanceTypes, getFileProtocol, getFileProvenance } from './workspace-data-provenance-utils';
 
 jest.mock('src/libs/ajax');
 
@@ -118,4 +119,23 @@ describe('getFileProvenance', () => {
       workflowId: '78f61618-30e6-4405-baf3-2ef2e576a3a3',
     });
   });
+});
+
+describe('getFileProtocol', () => {
+  const testCases = [
+    { input: 'gs://dir1/dir2/my-file.ext', expected: 'gs' },
+    { input: 'drs://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce', expected: 'drs' },
+    { input: 'dos://example.data.service.org/6cbffaae-fc48-4829-9419-1a2ef0ca98ce', expected: 'dos' },
+    { input: 'https://foo.blob.core.windows.net/testContainer/file1.txt', expected: 'https' },
+    { input: 'http://foo.blob.core.windows.net/testContainer/file1.txt', expected: 'http' },
+    { input: 'ftp://why/would/you/use/ftp', expected: 'ftp' },
+    { input: 'relative/file', expected: 'unknown' },
+    { input: '', expected: 'unknown' },
+  ];
+
+  _.forEach(({ input, expected }) => {
+    it(`calculates protocol ${expected} for input ${input}`, () => {
+      expect(getFileProtocol(input)).toEqual(expected);
+    });
+  }, testCases);
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-56

## Summary of changes:
Adds mixpanel events for the file/column provenance, which is currently hidden behind a feature flag.

### What
- adds a `provenance:column` event. This is triggered whenever a user clicks "Show provenance" in the three-dot menu for a data table column. This event includes the workspace namespace/name, the data table name and column name, and the number of submissions in which the column was found (which might be 0). It also includes a success:true|false; the value is false if there was an error trying to calculate provenance.
- adds a `provenance:file` event. This is triggered whenever a user opens the "More Information" toggle in the data table file-preview modal, and is only triggered if provenance is enabled. This event includes the workspace namespace/name, the protocol (gs, https, drs, dos, etc) for the file in question, and the provenance result (workflowOutput, workflowLog, unknown, etc). It also includes a success:true|false; the value is false if there was an error trying to calculate provenance.
    - note that we always fire this event, even though we can't know if the user opened "More Information" to look for provenance or other info like the file creation date

### Why
Metrics are good

### Testing strategy
- unit tests for the new `getFileProtocol` function
- tested mixpanel events by running locally, watching devtools send the events, and confirming the events in the mixpanel ui

### Visual Aids
trigger the `provenance:column` event:
![Screenshot 11-10-2024 at 10 09 (1)](https://github.com/user-attachments/assets/1701bd3a-8244-46a3-89aa-9e5c58476eeb)

trigger the `provenance:file` event (plus cat tax):
![Screenshot 11-10-2024 at 10 09](https://github.com/user-attachments/assets/3140f6f6-b003-47b2-ad20-fdce95ee967c)






