### PR TITLE
UIE-204 Narrow Ajax Usage pt6

### DIFF
--- a/packages/test-utils/src/asMockedFn.ts
+++ b/packages/test-utils/src/asMockedFn.ts
@@ -1,5 +1,6 @@
 export type AnyFn = (...args: any[]) => any;
 
+export type MockedFn<F extends AnyFn> = jest.MockedFunction<F>;
 /**
  * Use when working with a function mocked with jest.mock to tell TypeScript that
  * the function has been mocked and allow accessing mock methods/properties.

--- a/packages/test-utils/src/asMockedFn.ts
+++ b/packages/test-utils/src/asMockedFn.ts
@@ -1,6 +1,7 @@
 export type AnyFn = (...args: any[]) => any;
 
 export type MockedFn<F extends AnyFn> = jest.MockedFunction<F>;
+
 /**
  * Use when working with a function mocked with jest.mock to tell TypeScript that
  * the function has been mocked and allow accessing mock methods/properties.

--- a/src/libs/ajax/Groups.ts
+++ b/src/libs/ajax/Groups.ts
@@ -97,3 +97,4 @@ export const Groups = (signal?: AbortSignal) => ({
   },
 });
 export type GroupsContract = ReturnType<typeof Groups>;
+export type GroupContract = ReturnType<GroupsContract['group']>;

--- a/src/libs/ajax/WorkspaceDataService.ts
+++ b/src/libs/ajax/WorkspaceDataService.ts
@@ -73,7 +73,7 @@ export type Capabilities = {
   [key in Capability]: boolean;
 };
 
-export const WorkspaceData = (signal) => ({
+export const WorkspaceData = (signal?: AbortSignal) => ({
   getSchema: async (root: string, instanceId: string): Promise<RecordTypeSchema[]> => {
     const res = await fetchWDS(root)(`${instanceId}/types/v0.2`, _.merge(authOpts(), { signal }));
     return res.json();
@@ -227,3 +227,5 @@ export const WorkspaceData = (signal) => ({
     return res.json();
   },
 });
+
+export type WorkspaceDataAjaxContract = ReturnType<typeof WorkspaceData>;

--- a/src/libs/ajax/metrics/useMetrics.test.ts
+++ b/src/libs/ajax/metrics/useMetrics.test.ts
@@ -1,32 +1,22 @@
 import { renderHook } from '@testing-library/react';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import Events from 'src/libs/events';
-import { asMockedFn } from 'src/testing/test-utils';
+import { asMockedFn, partial } from 'src/testing/test-utils';
 
 import { useMetricsEvent } from './useMetrics';
 
-type AjaxExports = typeof import('src/libs/ajax');
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
-
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxMetricsContract = AjaxContract['Metrics'];
+jest.mock('src/libs/ajax/Metrics');
 
 describe('useMetricsEvent', () => {
   it('calls event logger', () => {
     // Arrange
     const watchCaptureEvent = jest.fn();
-    const mockMetrics: Partial<AjaxMetricsContract> = {
-      captureEvent: (event, details) => watchCaptureEvent(event, details),
-    };
-    const mockAjax: Partial<AjaxContract> = {
-      Metrics: mockMetrics as AjaxMetricsContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+
+    asMockedFn(Metrics).mockReturnValue(
+      partial<MetricsContract>({
+        captureEvent: (event, details) => watchCaptureEvent(event, details),
+      })
+    );
 
     // Act
     const renderedHook = renderHook(() => useMetricsEvent());

--- a/src/libs/ajax/metrics/useMetrics.ts
+++ b/src/libs/ajax/metrics/useMetrics.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { MetricsEventName } from 'src/libs/events';
 
 export type CaptureEventFn = (event: MetricsEventName, details?: Record<string, any>, refreshAppcues?: boolean) => void;
@@ -9,7 +9,7 @@ export interface MetricsProvider {
 }
 
 export const useMetricsEvent = (): MetricsProvider => {
-  const sendEvent = useMemo(() => Ajax().Metrics.captureEvent, []);
+  const sendEvent = useMemo(() => Metrics().captureEvent, []);
   // By returning a wrapper function, we can handle the fire-and-forget promise mechanics properly here
   // instead of burdening the consumer side with silencing the Typescript/lint complaints, which can be
   // quite awkward in some nested functional uses.

--- a/src/libs/ajax/workflows-app/Cbas.ts
+++ b/src/libs/ajax/workflows-app/Cbas.ts
@@ -4,7 +4,7 @@ import qs from 'qs';
 import { authOpts } from 'src/auth/auth-session';
 import { fetchFromProxy } from 'src/libs/ajax/ajax-common';
 
-export const Cbas = (signal) => ({
+export const Cbas = (signal?: AbortSignal) => ({
   status: async (cbasUrlRoot) => {
     const res = await fetchFromProxy(cbasUrlRoot)('status', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
     return res.json();
@@ -14,19 +14,28 @@ export const Cbas = (signal) => ({
     return res.json();
   },
   capabilities: async (cbasUrlRoot) => {
-    const res = await fetchFromProxy(cbasUrlRoot)('capabilities/v1', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+    const res = await fetchFromProxy(cbasUrlRoot)(
+      'capabilities/v1',
+      _.mergeAll([authOpts(), { signal, method: 'GET' }])
+    );
     return res.json();
   },
   runs: {
     get: async (cbasUrlRoot, submissionId) => {
       const keyParams = qs.stringify({ run_set_id: submissionId });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/runs?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/runs?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
   },
   methods: {
     post: async (cbasUrlRoot, payload) => {
-      const res = await fetchFromProxy(cbasUrlRoot)('api/batch/v1/methods', _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        'api/batch/v1/methods',
+        _.mergeAll([authOpts(), jsonBody(payload), { signal, method: 'POST' }])
+      );
       return res.json();
     },
     archive: async (cbasUrlRoot, methodId) => {
@@ -39,38 +48,62 @@ export const Cbas = (signal) => ({
     },
     getWithVersions: async (cbasUrlRoot) => {
       const keyParams = qs.stringify({ show_versions: true });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/methods?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/methods?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
     getWithoutVersions: async (cbasUrlRoot) => {
       const keyParams = qs.stringify({ show_versions: false });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/methods?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/methods?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
     getById: async (cbasUrlRoot, methodId) => {
       const keyParams = qs.stringify({ method_id: methodId });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/methods?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/methods?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
   },
   runSets: {
     get: async (cbasUrlRoot) => {
-      const res = await fetchFromProxy(cbasUrlRoot)('api/batch/v1/run_sets', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        'api/batch/v1/run_sets',
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
     post: async (cbasUrlRoot, payload) => {
-      const res = await fetchFromProxy(cbasUrlRoot)('api/batch/v1/run_sets', _.mergeAll([authOpts(), { signal, method: 'POST' }, jsonBody(payload)]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        'api/batch/v1/run_sets',
+        _.mergeAll([authOpts(), { signal, method: 'POST' }, jsonBody(payload)])
+      );
       return res.json();
     },
     getForMethod: async (cbasUrlRoot, methodId, pageSize) => {
       const keyParams = qs.stringify({ method_id: methodId, page_size: pageSize }, { arrayFormat: 'repeat' });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/run_sets?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/run_sets?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'GET' }])
+      );
       return res.json();
     },
     cancel: async (cbasUrlRoot, runSetId) => {
       const keyParams = qs.stringify({ run_set_id: runSetId });
-      const res = await fetchFromProxy(cbasUrlRoot)(`api/batch/v1/run_sets/abort?${keyParams}`, _.mergeAll([authOpts(), { signal, method: 'POST' }]));
+      const res = await fetchFromProxy(cbasUrlRoot)(
+        `api/batch/v1/run_sets/abort?${keyParams}`,
+        _.mergeAll([authOpts(), { signal, method: 'POST' }])
+      );
       return res.json();
     },
   },
 });
+
+export type CbasAjaxContract = ReturnType<typeof Cbas>;
+export type CbasMethodsContract = CbasAjaxContract['methods'];

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -641,3 +641,4 @@ export const Workspaces = (signal?: AbortSignal) => ({
 
 export type WorkspacesAjaxContract = ReturnType<typeof Workspaces>;
 export type WorkspaceContract = ReturnType<WorkspacesAjaxContract['workspace']>;
+export type WorkspaceV2Contract = ReturnType<WorkspacesAjaxContract['workspaceV2']>;

--- a/src/pages/ImportWorkflow/ImportWorkflow.js
+++ b/src/pages/ImportWorkflow/ImportWorkflow.js
@@ -8,9 +8,10 @@ import { ValidatedInput } from 'src/components/input';
 import { TopBar } from 'src/components/TopBar';
 import WDLViewer from 'src/components/WDLViewer';
 import importBackground from 'src/images/hex-import-background.svg';
-import { Ajax } from 'src/libs/ajax';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
@@ -96,7 +97,7 @@ export const ImportWorkflow = ({ path, version, source }) => {
         importPage: 'ImportWorkflow',
       });
 
-      const res = await Ajax(signal).Cbas.methods.post(appUrls.cbasUrl, postRequestBody);
+      const res = await Cbas(signal).methods.post(appUrls.cbasUrl, postRequestBody);
       const methodId = res.method_id;
 
       Nav.goToPath('workspace-workflows-app', { name, namespace, methodId });
@@ -125,7 +126,7 @@ export const ImportWorkflow = ({ path, version, source }) => {
           },
           options
         );
-        Ajax(signal).Metrics.captureEvent(Events.workflowImport, { ...eventData, success: true });
+        void Metrics(signal).captureEvent(Events.workflowImport, { ...eventData, success: true });
         Nav.goToPath('workflow', { namespace, name, workflowNamespace: namespace, workflowName });
       } else {
         if (workspace.createdBy !== getTerraUser()?.email) {
@@ -138,7 +139,7 @@ export const ImportWorkflow = ({ path, version, source }) => {
       if (error.status === 409) {
         setConfirmOverwriteInWorkspace(workspace);
       } else {
-        Ajax().Metrics.captureEvent(Events.workflowImport, { ...eventData, success: false });
+        void Metrics().captureEvent(Events.workflowImport, { ...eventData, success: false });
         throw error;
       }
     }

--- a/src/testing/test-utils.ts
+++ b/src/testing/test-utils.ts
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { PropsWithChildren, ReactElement } from 'react';
 import { h } from 'react-hyperscript-helpers';
 
-export { asMockedFn, partial } from '@terra-ui-packages/test-utils';
+export { asMockedFn, type MockedFn, partial } from '@terra-ui-packages/test-utils';
 
 const testTheme: Theme = {
   colorPalette: {

--- a/src/workflows-app/RunDetails.test.js
+++ b/src/workflows-app/RunDetails.test.js
@@ -3,10 +3,11 @@ import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
 import { Ajax } from 'src/libs/ajax';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import * as configStore from 'src/libs/config';
 import Events from 'src/libs/events';
 import { makeCompleteDate } from 'src/libs/utils';
-import { renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
+import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { appendSASTokenIfNecessary, getFilenameFromAzureBlobPath } from 'src/workflows-app/components/InputOutputModal';
 import { collapseCromwellStatus } from 'src/workflows-app/components/job-common';
 import { failedTasks as failedTasksMetadata } from 'src/workflows-app/fixtures/failed-tasks';
@@ -22,6 +23,7 @@ import { isAzureUri } from 'src/workspace-data/data-table/uri-viewer/uri-viewer-
 import { parseFullFilepathToContainerDirectory } from './utils/task-log-utils';
 
 jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/Metrics');
 
 const wdsUrlRoot = 'https://lz-abc/wds-abc-c07807929cd1/';
 const cbasUrlRoot = 'https://lz-abc/terra-app-abc/cbas';
@@ -149,6 +151,7 @@ beforeEach(() => {
   Ajax.mockImplementation(() => {
     return mockObj;
   });
+  asMockedFn(Metrics).mockReturnValue(mockObj.Metrics);
 });
 
 describe('BaseRunDetails - render smoke test', () => {

--- a/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.test.tsx
+++ b/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.test.tsx
@@ -1,22 +1,14 @@
-import { DeepPartial } from '@terra-ui-packages/core-utils';
-import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import LockWorkspaceModal from 'src/workspaces/LockWorkspaceModal/LockWorkspaceModal';
 import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxExports = typeof import('src/libs/ajax');
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 const mockReportError = jest.fn();
 type ErrorExports = typeof import('src/libs/error');
@@ -71,19 +63,17 @@ describe('LockWorkspaceModal', () => {
     const user = userEvent.setup();
     const onDismiss = jest.fn();
     const onSuccess = jest.fn();
-    const mockLock = jest.fn();
+    const lock = jest.fn();
     const workspace: Workspace = {
       ...defaultGoogleWorkspace,
       workspace: { ...defaultGoogleWorkspace.workspace, isLocked: false },
     };
     const props = { workspace, onDismiss, onSuccess };
-    asMockedFn(Ajax).mockReturnValue({
-      Workspaces: {
-        workspace: jest.fn().mockReturnValue({
-          lock: mockLock,
-        }),
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ lock }),
+      })
+    );
 
     // Act
     render(<LockWorkspaceModal {...props} />);
@@ -93,7 +83,7 @@ describe('LockWorkspaceModal', () => {
     // Assert
     expect(onDismiss).toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalled();
-    expect(mockLock).toHaveBeenCalled();
+    expect(lock).toHaveBeenCalled();
   });
 
   it('calls onDismiss, onSuccess, and unlocks locked workspace if the lock is toggled', async () => {
@@ -101,19 +91,17 @@ describe('LockWorkspaceModal', () => {
     const user = userEvent.setup();
     const onDismiss = jest.fn();
     const onSuccess = jest.fn();
-    const mockUnlock = jest.fn();
+    const unlock = jest.fn();
     const workspace: Workspace = {
       ...defaultGoogleWorkspace,
       workspace: { ...defaultGoogleWorkspace.workspace, isLocked: true },
     };
     const props = { workspace, onDismiss, onSuccess };
-    asMockedFn(Ajax).mockReturnValue({
-      Workspaces: {
-        workspace: jest.fn().mockReturnValue({
-          unlock: mockUnlock,
-        }),
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ unlock }),
+      })
+    );
 
     // Act
     render(<LockWorkspaceModal {...props} />);
@@ -123,7 +111,7 @@ describe('LockWorkspaceModal', () => {
     // Assert
     expect(onDismiss).toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalled();
-    expect(mockUnlock).toHaveBeenCalled();
+    expect(unlock).toHaveBeenCalled();
   });
 
   it('calls only onDismiss if the lock toggle is canceled', async () => {
@@ -131,19 +119,17 @@ describe('LockWorkspaceModal', () => {
     const user = userEvent.setup();
     const onDismiss = jest.fn();
     const onSuccess = jest.fn();
-    const mockLock = jest.fn();
+    const lock = jest.fn();
     const workspace: Workspace = {
       ...defaultGoogleWorkspace,
       workspace: { ...defaultGoogleWorkspace.workspace, isLocked: false },
     };
     const props = { workspace, onDismiss, onSuccess };
-    asMockedFn(Ajax).mockReturnValue({
-      Workspaces: {
-        workspace: jest.fn().mockReturnValue({
-          lock: mockLock,
-        }),
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ lock }),
+      })
+    );
 
     // Act
     render(<LockWorkspaceModal {...props} />);
@@ -153,7 +139,7 @@ describe('LockWorkspaceModal', () => {
     // Assert
     expect(onDismiss).toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(mockLock).not.toHaveBeenCalled();
+    expect(lock).not.toHaveBeenCalled();
   });
 
   it('calls only onDismiss if the lock toggle causes an error', async () => {
@@ -166,13 +152,13 @@ describe('LockWorkspaceModal', () => {
       workspace: { ...defaultGoogleWorkspace.workspace, isLocked: true },
     };
     const props = { workspace, onDismiss, onSuccess };
-    asMockedFn(Ajax).mockReturnValue({
-      Workspaces: {
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
         workspace: () => {
           throw new Error();
         },
-      },
-    } as DeepPartial<AjaxContract> as AjaxContract);
+      })
+    );
 
     // Act
     render(<LockWorkspaceModal {...props} />);

--- a/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.tsx
+++ b/src/workspaces/LockWorkspaceModal/LockWorkspaceModal.tsx
@@ -1,7 +1,7 @@
 import { Modal } from '@terra-ui-packages/components';
 import React, { useState } from 'react';
 import { ButtonPrimary, spinnerOverlay } from 'src/components/common';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { reportError } from 'src/libs/error';
 import { withBusyState } from 'src/libs/utils';
 import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
@@ -27,8 +27,8 @@ const LockWorkspaceModal = (props: LockWorkspaceModalProps) => {
   const toggleWorkspaceLock = withBusyState(setTogglingLock)(async () => {
     try {
       isLocked
-        ? await Ajax().Workspaces.workspace(namespace, name).unlock()
-        : await Ajax().Workspaces.workspace(namespace, name).lock();
+        ? await Workspaces().workspace(namespace, name).unlock()
+        : await Workspaces().workspace(namespace, name).lock();
       onDismiss();
       onSuccess();
     } catch (error) {

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.test.ts
@@ -48,7 +48,6 @@ import {
 import NewWorkspaceModal from './NewWorkspaceModal';
 
 jest.mock('src/libs/ajax/AzureStorage');
-jest.mock('src/libs/ajax/AzureStorage');
 jest.mock('src/libs/ajax/billing/Billing');
 jest.mock('src/libs/ajax/firecloud/FirecloudBucket');
 jest.mock('src/libs/ajax/Groups');

--- a/src/workspaces/migration/BillingProjectList.ts
+++ b/src/workspaces/migration/BillingProjectList.ts
@@ -2,7 +2,7 @@ import { Spinner } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { div, h, h2, span } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow, withErrorIgnoring } from 'src/libs/error';
 import { useCancellation, useGetter } from 'src/libs/react-utils';
@@ -38,7 +38,7 @@ export const BillingProjectList = (): ReactNode => {
       }
       if (workspacesWithNamespaces.length > 0) {
         const updatedWorkspaceInfo = parseServerResponse(
-          await Ajax(signal).Workspaces.bucketMigrationProgress(workspacesWithNamespaces)
+          await Workspaces(signal).bucketMigrationProgress(workspacesWithNamespaces)
         );
         const merged = mergeBillingProjectMigrationInfo(getBillingProjectWorkspaces(), updatedWorkspaceInfo);
         setBillingProjectWorkspaces(merged);
@@ -52,7 +52,7 @@ export const BillingProjectList = (): ReactNode => {
         reportErrorAndRethrow('Error loading workspace migration information'),
         Utils.withBusyState(setLoadingMigrationInformation)
       )(async () => {
-        const migrationResponse = await Ajax(signal).Workspaces.bucketMigrationInfo();
+        const migrationResponse = await Workspaces(signal).bucketMigrationInfo();
         const billingProjectsWithWorkspaces = parseServerResponse(migrationResponse);
         setBillingProjectWorkspaces(billingProjectsWithWorkspaces);
 

--- a/src/workspaces/migration/BillingProjectParent.test.ts
+++ b/src/workspaces/migration/BillingProjectParent.test.ts
@@ -2,8 +2,8 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { div, h } from 'react-hyperscript-helpers';
-import { Ajax } from 'src/libs/ajax';
-import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
+import { Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { BillingProjectParent } from 'src/workspaces/migration/BillingProjectParent';
 import { WorkspaceMigrationInfo } from 'src/workspaces/migration/migration-utils';
 import {
@@ -12,9 +12,7 @@ import {
   bpWithSucceededAndUnscheduled,
 } from 'src/workspaces/migration/migration-utils.test';
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type AjaxWorkspacesContract = AjaxContract['Workspaces'];
-jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 describe('BillingProjectParent', () => {
   const mockMigrationStartedCallback = jest.fn();
@@ -30,14 +28,9 @@ describe('BillingProjectParent', () => {
       { migrationStep: 'Unscheduled', name: 'notmigrated1', namespace: 'CARBilling-2' },
       { migrationStep: 'Unscheduled', name: 'notmigrated2', namespace: 'CARBilling-2' },
     ];
-    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
-    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      startBatchBucketMigration: mockStartBatchBucketMigration,
-    };
-    const mockAjax: Partial<AjaxContract> = {
-      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    const startBatchBucketMigration = jest.fn();
+    asMockedFn(startBatchBucketMigration).mockResolvedValue({});
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({ startBatchBucketMigration }));
 
     // Act
     render(
@@ -59,7 +52,7 @@ describe('BillingProjectParent', () => {
 
     // Assert
     expect(screen.queryByText(/Are you sure you want to migrate all workspaces/i)).toBeFalsy();
-    expect(mockStartBatchBucketMigration).not.toHaveBeenCalled();
+    expect(startBatchBucketMigration).not.toHaveBeenCalled();
     expect(mockMigrationStartedCallback).not.toHaveBeenCalled();
   });
 
@@ -70,14 +63,9 @@ describe('BillingProjectParent', () => {
       { migrationStep: 'Unscheduled', name: 'notmigrated1', namespace: 'CARBilling-2' },
       { migrationStep: 'Unscheduled', name: 'notmigrated2', namespace: 'CARBilling-2' },
     ];
-    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
-    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      startBatchBucketMigration: mockStartBatchBucketMigration,
-    };
-    const mockAjax: Partial<AjaxContract> = {
-      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    const startBatchBucketMigration = jest.fn();
+    asMockedFn(startBatchBucketMigration).mockResolvedValue({});
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({ startBatchBucketMigration }));
 
     // Act
     const { container } = render(
@@ -97,7 +85,7 @@ describe('BillingProjectParent', () => {
     await user.click(screen.getByText('Migrate All'));
 
     // Assert
-    expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([
+    expect(startBatchBucketMigration).toHaveBeenCalledWith([
       { name: 'notmigrated1', namespace: 'CARBilling-2' },
       { name: 'notmigrated2', namespace: 'CARBilling-2' },
     ]);
@@ -111,14 +99,9 @@ describe('BillingProjectParent', () => {
     // Arrange
     const user = userEvent.setup();
 
-    const mockStartBatchBucketMigration = jest.fn().mockResolvedValue({});
-    const mockWorkspaces: Partial<AjaxWorkspacesContract> = {
-      startBatchBucketMigration: mockStartBatchBucketMigration,
-    };
-    const mockAjax: Partial<AjaxContract> = {
-      Workspaces: mockWorkspaces as AjaxWorkspacesContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    const startBatchBucketMigration = jest.fn();
+    asMockedFn(startBatchBucketMigration).mockResolvedValue({});
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({ startBatchBucketMigration }));
 
     // Act
     render(
@@ -134,7 +117,7 @@ describe('BillingProjectParent', () => {
 
     // Assert
     expect(screen.queryByText(/Are you sure you want to migrate all remaining workspaces/i)).toBeFalsy();
-    expect(mockStartBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
+    expect(startBatchBucketMigration).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
     await screen.findByText('1 Workspace Migrated');
     expect(mockMigrationStartedCallback).toHaveBeenCalledWith([{ name: 'notmigrated', namespace: 'CARBilling-2' }]);
   });

--- a/src/workspaces/migration/BillingProjectParent.ts
+++ b/src/workspaces/migration/BillingProjectParent.ts
@@ -6,7 +6,7 @@ import { ReactNode, useState } from 'react';
 import { b, div, h, span } from 'react-hyperscript-helpers';
 import Collapse from 'src/components/Collapse';
 import { ButtonOutline, ButtonPrimary } from 'src/components/common';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';
 import {
@@ -81,7 +81,7 @@ export const BillingProjectParent = (props: BillingProjectParentProps): ReactNod
       }
     });
     if (workspacesToMigrate.length > 0) {
-      await Ajax().Workspaces.startBatchBucketMigration(workspacesToMigrate);
+      await Workspaces().startBatchBucketMigration(workspacesToMigrate);
       props.migrationStartedCallback(workspacesToMigrate);
     }
   });

--- a/src/workspaces/migration/WorkspaceItem.ts
+++ b/src/workspaces/migration/WorkspaceItem.ts
@@ -4,7 +4,7 @@ import { b, div, h, span } from 'react-hyperscript-helpers';
 import { ButtonOutline, ButtonPrimary } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors from 'src/libs/colors';
 import { reportErrorAndRethrow } from 'src/libs/error';
 import { useCancellation } from 'src/libs/react-utils';
@@ -70,7 +70,7 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
     // Dismiss confirmation
     setConfirmMigration(false);
 
-    await Ajax().Workspaces.workspaceV2(workspaceInfo.namespace, workspaceInfo.name).migrateWorkspace();
+    await Workspaces().workspaceV2(workspaceInfo.namespace, workspaceInfo.name).migrateWorkspace();
     props.migrationStartedCallback([{ name: workspaceInfo.name, namespace: workspaceInfo.namespace }]);
     setMigrateStarted(true);
   });
@@ -80,8 +80,8 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
       // Set to an empty string as a flag that we have sent an Ajax request.
       setUnmigratedBucketSize('');
       try {
-        const { usageInBytes } = await Ajax(signal)
-          .Workspaces.workspace(workspaceInfo.namespace, workspaceInfo.name)
+        const { usageInBytes } = await Workspaces(signal)
+          .workspace(workspaceInfo.namespace, workspaceInfo.name)
           .bucketUsage();
         setUnmigratedBucketSize(`Bucket Size: ${Utils.formatBytes(usageInBytes)}`);
       } catch (error) {


### PR DESCRIPTION
- more workspaces ajax shifts to use ajax subareas directly.
- converted Cbas ajax sub-module to Typescript (minimal conversion)
- updated a small set of workflow related tests with usage overlap to use shifted ajax mocks.
- shifted useMetrics ajax usage

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
