### PR TITLE
CORE-93: try to unflake preview-drs-uri integration test

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -34,9 +34,6 @@
         },
         {
           "name": "run-workflow"
-        },
-        {
-          "name": "preview-drs-uri"
         }
       ]
     },
@@ -61,6 +58,9 @@
         },
         {
           "name": "request-access"
+        },
+        {
+          "name": "preview-drs-uri"
         }
       ]
     },

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -11,8 +11,8 @@
       "id": "C53JYBV9A"
     },
     {
-      "name": "ia-notification-test",
-      "id": "C03ATF4QXEV",
+      "name": "dsp-analysis-non-prod-alerts",
+      "id": "C07RX0CJV0D",
       "tests": [
         {
           "name": "run-analysis"
@@ -25,13 +25,7 @@
         },
         {
           "name": "run-analysis-azure"
-        }
-      ]
-    },
-    {
-      "name": "cromwell_jenkins_ci_errors",
-      "id": "C01AG7GEJ3D",
-      "tests": [
+        },
         {
           "name": "find-workflow"
         },
@@ -40,6 +34,9 @@
         },
         {
           "name": "run-workflow"
+        },
+        {
+          "name": "preview-drs-uri"
         }
       ]
     },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-93

## Summary of changes:
* change which DOM elements we wait for in the `preview-drs-uri` to try to streamline
* add logging to help debug failures when they happen
* make `preview-drs-uri` alerts go to both Data team and Core Services team
* update the Analysis team alerts to go to their new channel (confirmed with them)

### What
The major functional change in this test is waiting for text to appear on the page - "About the workspace" when entering a workspace, and "test_entity" when waiting for data tables to be ready. Previously, we waited for no spinners to be present in the DOM.

### Why
The relevant page loads have two spinners. First, there's the "main" spinner for the body of the page. Second, there's the spinner in the right-hand context bar that appears when loading the hourly rate for apps/cloud environments. The `waitForNoSpinners` and `noSpinnersAfter` previously in use would detect both of those. We don't care about the second spinner, though; its presence is irrelevant to this test.

### Testing strategy
* Tested by running the integration test locally
* See the tests passing in CircleCI

Only time will tell if the test becomes less flaky, but I believe at least this will not cause any regressions.
