### PR TITLE
[DCJ-730] Mock visualizations on the dataset summary page

### DIFF
--- a/src/dataset-builder/DatasetBuilderDetails.test.ts
+++ b/src/dataset-builder/DatasetBuilderDetails.test.ts
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { DataRepo, DataRepoContract, SnapshotBuilderSettings } from 'src/libs/ajax/DataRepo';
+import { useRoute } from 'src/libs/nav';
 import { asMockedFn, renderWithAppContexts as render } from 'src/testing/test-utils';
 
 import { DatasetBuilderDetails } from './DatasetBuilderDetails';
@@ -53,5 +54,37 @@ describe('DatasetBuilderDetails', () => {
     // Assert
     expect(await screen.findByText(testSnapshotBuilderSettings().name)).toBeTruthy();
     expect(await screen.findByText('Learn how to gain access')).toBeTruthy();
+  });
+
+  it('renders the categories and visualizations tabs', async () => {
+    // Arrange
+    mockWithValues(testSnapshotBuilderSettings(), ['aggregate_data_reader']);
+    render(h(DatasetBuilderDetails, { snapshotId: 'id' }));
+    // Assert
+    expect(await screen.findByText('Data Categories')).toBeTruthy();
+    expect(await screen.findByText('Participant Visualizations')).toBeTruthy();
+  });
+
+  it('defaults to the categories tab and renders the dataset summary stats', async () => {
+    // Arrange
+    mockWithValues(testSnapshotBuilderSettings(), ['aggregate_data_reader']);
+    render(h(DatasetBuilderDetails, { snapshotId: 'id' }));
+    asMockedFn(useRoute).mockImplementation(() => ({ query: {} }));
+    // Assert
+    expect(await screen.findByText('EHR Domains')).toBeTruthy();
+  });
+
+  it('renders the visualization graphs on the visualization tab', async () => {
+    // Arrange
+    mockWithValues(testSnapshotBuilderSettings(), ['aggregate_data_reader']);
+    render(h(DatasetBuilderDetails, { snapshotId: 'id' }));
+    asMockedFn(useRoute).mockImplementation(() => ({ query: { tab: 'visualizations' } }));
+    // Assert
+    expect(await screen.findAllByText('Age')).toBeTruthy();
+    expect(await screen.findAllByText('Gender Identity')).toBeTruthy();
+    expect(await screen.findAllByText('Race')).toBeTruthy();
+    expect(await screen.findAllByText('Top 10 Conditions')).toBeTruthy();
+    expect(await screen.findAllByText('Top 10 Drugs')).toBeTruthy();
+    expect(await screen.findAllByText('Top 10 Procedures')).toBeTruthy();
   });
 });

--- a/src/dataset-builder/DatasetBuilderDetails.test.ts
+++ b/src/dataset-builder/DatasetBuilderDetails.test.ts
@@ -9,7 +9,7 @@ import { testSnapshotBuilderSettings } from './TestConstants';
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
   getLink: jest.fn(),
-  useRoute: jest.fn(),
+  useRoute: jest.fn().mockReturnValue({ query: {} }),
 }));
 
 jest.mock('src/libs/ajax/GoogleStorage');

--- a/src/dataset-builder/DemographicsChart.ts
+++ b/src/dataset-builder/DemographicsChart.ts
@@ -8,7 +8,7 @@ interface ChartLabel {
 export interface ChartSeries {
   name?: string;
   colorByPoint?: boolean;
-  data: number[] | number[][];
+  data: any /* number[] | number[][] */;
 }
 
 export interface CohortDemographics {

--- a/src/dataset-builder/DemographicsChart.ts
+++ b/src/dataset-builder/DemographicsChart.ts
@@ -7,7 +7,8 @@ interface ChartLabel {
 }
 export interface ChartSeries {
   name?: string;
-  data: number[];
+  colorByPoint?: boolean;
+  data: number[] | number[][];
 }
 
 export interface CohortDemographics {
@@ -18,6 +19,7 @@ export interface CohortDemographics {
   height: string;
   legendEnabled: boolean;
   showSeriesName: boolean;
+  type: string;
 }
 export function chartOptions(cohortDemographics: CohortDemographics) {
   return {
@@ -26,7 +28,7 @@ export function chartOptions(cohortDemographics: CohortDemographics) {
       spacingRight: 30,
       height: cohortDemographics.height,
       style: { fontFamily: 'inherit' },
-      type: 'bar',
+      type: cohortDemographics.type,
     },
     legend: { enabled: cohortDemographics.legendEnabled },
     plotOptions: { series: { stacking: 'normal' } },
@@ -91,6 +93,7 @@ export function generateCohortAgeData(series) {
     height: '250rem',
     legendEnabled: false,
     showSeriesName: false,
+    type: 'bar',
   };
 }
 
@@ -125,6 +128,7 @@ export function generateCohortDemographicData(series) {
     height: '500rem',
     legendEnabled: true,
     showSeriesName: true,
+    type: 'bar',
   };
 }
 

--- a/src/dataset-builder/DemographicsChart.ts
+++ b/src/dataset-builder/DemographicsChart.ts
@@ -8,7 +8,7 @@ interface ChartLabel {
 export interface ChartSeries {
   name?: string;
   colorByPoint?: boolean;
-  data: any /* number[] | number[][] */;
+  data: number[];
 }
 
 export interface CohortDemographics {

--- a/src/dataset-builder/SummaryCharts.ts
+++ b/src/dataset-builder/SummaryCharts.ts
@@ -33,7 +33,7 @@ export function generateGenderChartOptions() {
     series: [
       {
         colorByPoint: true,
-        data: [[28], [31], [11], [10], [6], [14]],
+        data: [28, 31, 11, 10, 6, 14],
       },
     ],
     title: 'Gender Identity',
@@ -59,7 +59,7 @@ export function generateRaceChartOptions() {
     series: [
       {
         colorByPoint: true,
-        data: [[24], [18], [16], [8], [27], [5], [2]],
+        data: [24, 18, 16, 8, 27, 5, 2],
       },
     ],
     title: 'Race',

--- a/src/dataset-builder/SummaryCharts.ts
+++ b/src/dataset-builder/SummaryCharts.ts
@@ -23,17 +23,15 @@ export function generateAgeChartOptions() {
 export function generateGenderChartOptions() {
   return {
     categories: [
-      { short: 'Man' },
-      { short: 'Woman' },
-      { short: 'Nonbinary' },
-      { short: 'Transgender' },
-      { short: 'Other' },
+      { short: 'Female' },
+      { short: 'Male' },
+      { short: 'Other', long: 'Nonbinary, 2 Spirit, Genderqueer, etc.' },
       { short: 'Prefer not to Say' },
     ],
     series: [
       {
         colorByPoint: true,
-        data: [28, 31, 11, 10, 6, 14],
+        data: [36, 38, 22, 4],
       },
     ],
     title: 'Gender Identity',
@@ -49,17 +47,17 @@ export function generateRaceChartOptions() {
   return {
     categories: [
       { short: 'White' },
-      { short: 'Black, African American' },
-      { short: 'Hispanic or Latino' },
+      { short: 'Black or African American' },
       { short: 'Asian' },
+      { short: 'Pacific Islander' },
+      { short: 'Native American' },
       { short: 'More than one' },
-      { short: 'Other' },
       { short: 'Prefer not to Say' },
     ],
     series: [
       {
         colorByPoint: true,
-        data: [24, 18, 16, 8, 27, 5, 2],
+        data: [30, 25, 20, 8, 6, 10, 1],
       },
     ],
     title: 'Race',

--- a/src/dataset-builder/SummaryCharts.ts
+++ b/src/dataset-builder/SummaryCharts.ts
@@ -1,0 +1,150 @@
+export function generateAgeChartOptions() {
+  return {
+    categories: [
+      { short: '0-17' },
+      { short: '18-29' },
+      { short: '30-39' },
+      { short: '40-49' },
+      { short: '50-59' },
+      { short: '60-69' },
+      { short: '70-79' },
+      { short: '80+' },
+    ],
+    series: [{ data: [9, 25, 15, 17, 14, 9, 6, 5] }],
+    title: 'Age',
+    yTitle: 'OVERALL PERCENTAGES',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'bar',
+  };
+}
+
+export function generateGenderChartOptions() {
+  return {
+    categories: [
+      { short: 'Man' },
+      { short: 'Woman' },
+      { short: 'Nonbinary' },
+      { short: 'Transgender' },
+      { short: 'Other' },
+      { short: 'Prefer not to Say' },
+    ],
+    series: [
+      {
+        colorByPoint: true,
+        data: [[28], [31], [11], [10], [6], [14]],
+      },
+    ],
+    title: 'Gender Identity',
+    yTitle: 'OVERALL PERCENTAGES',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'column',
+  };
+}
+
+export function generateRaceChartOptions() {
+  return {
+    categories: [
+      { short: 'White' },
+      { short: 'Black, African American' },
+      { short: 'Hispanic or Latino' },
+      { short: 'Asian' },
+      { short: 'More than one' },
+      { short: 'Other' },
+      { short: 'Prefer not to Say' },
+    ],
+    series: [
+      {
+        colorByPoint: true,
+        data: [[24], [18], [16], [8], [27], [5], [2]],
+      },
+    ],
+    title: 'Race',
+    yTitle: 'OVERALL PERCENTAGES',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'column',
+  };
+}
+
+export function generateTopConditionsChartOptions() {
+  return {
+    categories: [
+      { short: 'Type 2 diabetes mellitus' },
+      { short: 'Atrial fibrillation' },
+      { short: 'Chest pain' },
+      { short: 'Pure hypercholesterolemia' },
+      { short: 'Anemia' },
+      { short: 'Coronary arteriosclerosis' },
+      { short: 'Hypothyroidism' },
+      { short: 'Malaise and fatigue' },
+      { short: 'Congestive heart failure' },
+      { short: 'Urinary tract infectious disease' },
+    ],
+    series: [{ data: [17050, 15800, 10200, 9510, 7900, 5980, 3510, 3400, 2500, 2000] }],
+    title: 'Top 10 Conditions',
+    yTitle: 'PARTICIPANT COUNT',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'bar',
+  };
+}
+
+export function generateTopDrugsChartOptions() {
+  return {
+    categories: [
+      { short: 'Metformin' },
+      { short: 'Epoetin Alfa' },
+      { short: 'Influenza virus vaccine' },
+      { short: 'Simvastatin 40 MG Oral Tablet' },
+      { short: 'Lovastatin 20 MG Oral Tablet' },
+      { short: 'Gemfibrozil 600 MG Oral Tablet' },
+      { short: 'Omeprazole 20 MG Delayed Release Oral Tablet' },
+      { short: 'Levothyroxine' },
+      { short: 'Atorvastatin' },
+      { short: 'Acetaminophen' },
+    ],
+    series: [{ data: [18900, 17500, 16200, 13500, 12040, 7510, 7010, 7000, 2550, 2000] }],
+    title: 'Top 10 Drugs',
+    yTitle: 'PARTICIPANT COUNT',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'bar',
+  };
+}
+
+export function generateTopProceduresChartOptions() {
+  return {
+    categories: [
+      { short: 'Other diagnostic procedures on heart and pericardium' },
+      {
+        short:
+          'Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: An expanded problem focused history; An expanded problem focused examination; Straightforward medical decision making.',
+      },
+      { short: 'Biopsy of lymphatic structure' },
+      { short: 'Biopsy of mouth, unspecified structure' },
+      { short: 'Anemia' },
+      {
+        short:
+          'Therapeutic procedure, 1 or more areas, each 15 minutes; massage, including effleurage, petrissage and/or tapotement (stroking, compression, percussion)',
+      },
+      { short: 'Long-term drug therapy' },
+      { short: 'Surgical procedure' },
+      { short: 'Procedure on trunk' },
+      { short: 'Screening for disorder' },
+    ],
+    series: [{ data: [18100, 12550, 7550, 7480, 5100, 4950, 2690, 2550, 1790, 1700] }],
+    title: 'Top 10 Procedures',
+    yTitle: 'PARTICIPANT COUNT',
+    height: '400rem',
+    legendEnabled: false,
+    showSeriesName: false,
+    type: 'bar',
+  };
+}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DCJ-730

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- On the dataset overview/summary page, added a tab for viewing (mocked) visualizations for that dataset

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] Tested the UI locally
- [ ] Unit tests for the nav bar functionality and rendering of the graphs

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

https://github.com/user-attachments/assets/790e2922-46d7-4153-b6a3-0558bd344c98


