### PR TITLE
DT-734: update cohort builder snapshot IDs to use new snapshots that include sample data

### DIFF
--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -260,7 +260,7 @@ const cohortBuilder = () =>
           'aria-label': 'View Cohort Builder Demo',
           tooltip: 'View details about this dataset',
           href: Nav.getLink('dataset-builder-details', {
-            snapshotId: getConfig().terraDeploymentEnv === 'dev' ? 'c3eb4708-444f-4cbf-a32c-0d3bb93d4819' : '1f2c98d2-ccec-410e-8242-d995f9aa2ec6',
+            snapshotId: getConfig().terraDeploymentEnv === 'dev' ? '83c121aa-ce3f-4bf7-9084-28d1e5a0387f' : '52d133b0-100b-4b92-b7e1-c5d3c37171cf',
           }),
           onClick: () => captureBrowseDataEvent('Cohort Builder'),
         },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DT-734

## Summary of changes:

The cohort builder feature-preview flag enables a card in the terra library page that opens the cohort builder using a hardcoded TDR snapshot ID. This PR updates the snapshot ID for the card to use a newer snapshot.

### Testing strategy

Verified opening the snapshot locally. Will manually test in the PR deployment once it's complete.

A reviewer can verify these snapshot IDs by opening them in a terra-ui library/builder URL.