### PR TITLE
[CORE-62] Load saved ColumnSettings

### DIFF
--- a/src/components/ColumnSettingsList.test.ts
+++ b/src/components/ColumnSettingsList.test.ts
@@ -6,13 +6,13 @@ import { ColumnData, ColumnSettingsList, dragEndNotifier } from 'src/components/
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
 const visibleColumnA: ColumnData = {
-  id: 'a',
+  id: 'Column A',
   name: 'Column A',
   visible: true,
 };
 
 const nonVisibleColumnB: ColumnData = {
-  id: 'b',
+  id: 'Column B',
   name: 'Column B',
   visible: false,
 };

--- a/src/components/ColumnSettingsList.ts
+++ b/src/components/ColumnSettingsList.ts
@@ -182,7 +182,7 @@ export const ColumnSettingsList = ({ items, onChange, toggleVisibility }: Column
   );
 
   const renderItem = (item, index) => {
-    return h(SortableItem, { id: item.id, name: item.name, index: getPosition(item.id) }, [
+    return h(SortableItem, { id: item.name, name: item.name, index: getPosition(item.id) }, [
       h(DragHandle),
       h(Fragment, [
         h(

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1,7 +1,7 @@
 import { Interactive, Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import PropTypes from 'prop-types';
-import { Fragment, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, Fragment, useImperativeHandle, useRef, useState } from 'react';
 import Draggable from 'react-draggable';
 import { button, div, h, label, option, select } from 'react-hyperscript-helpers';
 import Pagination from 'react-paginating';
@@ -1026,15 +1026,20 @@ export const Resizable = ({ onWidthChange, width, minWidth = 100, children }) =>
   );
 };
 
-export const ColumnSettings = ({ columnSettings, onChange }) => {
+export const ColumnSettings = forwardRef(({ columnSettings, onChange }, ref) => {
   const indexedColumnSettings = _.map.convert({ cap: false })((value, index) => {
     return _.merge(value, { id: index.toString() }); // Don't use integer because 0 is falsey.
   })(columnSettings);
   const [items, setItems] = useState(indexedColumnSettings);
 
+  useImperativeHandle(ref, () => ({
+    updateItems,
+  }));
+
   const updateItems = (modifiedItems) => {
     setItems(modifiedItems);
     onChange(modifiedItems);
+    // return modifiedItems;
   };
 
   const toggleVisibility = (index) => {
@@ -1063,7 +1068,7 @@ export const ColumnSettings = ({ columnSettings, onChange }) => {
     ]),
     h(ColumnSettingsList, { items, onChange: updateItems, toggleVisibility }),
   ]);
-};
+});
 
 /**
  * @param {Object} obj

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1039,7 +1039,6 @@ export const ColumnSettings = forwardRef(({ columnSettings, onChange }, ref) => 
   const updateItems = (modifiedItems) => {
     setItems(modifiedItems);
     onChange(modifiedItems);
-    // return modifiedItems;
   };
 
   const toggleVisibility = (index) => {

--- a/src/workspace-data/data-table/entity-service/SavedColumnSettings.js
+++ b/src/workspace-data/data-table/entity-service/SavedColumnSettings.js
@@ -332,12 +332,38 @@ const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetada
   ]);
 };
 
+// export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings: initialColumnSettings, onChange, ...otherProps }) => {
 export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange, ...otherProps }) => {
+  // const [columnSettings, setColumnSettings] = useState(initialColumnSettings);
+  const columnSettingsRef = useRef();
+
+  const updateColumnSettings = (newColumnSettings) => {
+    if (columnSettingsRef.current) {
+      columnSettingsRef.current.updateItems(newColumnSettings);
+    }
+  };
+
+  // const handleColumnSettingsChange = (modifiedItems) => {
+  //   setColumnSettings(modifiedItems);
+  //   if (onChange) {
+  //     console.log('onchange');
+  //     onChange(modifiedItems);
+  //   }
+  // };
+
   return div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
     div({ style: { flex: '1 1 0' } }, [
       h(ColumnSettings, {
+        ref: columnSettingsRef,
         columnSettings,
         onChange,
+        // onChange: handleColumnSettingsChange,
+        // onChange: (modifiedItems) => {
+        //   // setColumnSettings(modifiedItems);
+        //   console.log(modifiedItems);
+        //   const result = onChange(columnSettings);
+        //   console.log('result', result);
+        // },
       }),
     ]),
     div(
@@ -354,7 +380,10 @@ export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange
         h(SavedColumnSettings, {
           ...otherProps,
           columnSettings,
-          onLoad: onChange,
+          onLoad: (updatedColumnSettings) => {
+            onChange(updatedColumnSettings);
+            updateColumnSettings(updatedColumnSettings);
+          },
         }),
       ]
     ),

--- a/src/workspace-data/data-table/entity-service/SavedColumnSettings.js
+++ b/src/workspace-data/data-table/entity-service/SavedColumnSettings.js
@@ -332,24 +332,15 @@ const SavedColumnSettings = ({ workspace, snapshotName, entityType, entityMetada
   ]);
 };
 
-// export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings: initialColumnSettings, onChange, ...otherProps }) => {
 export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange, ...otherProps }) => {
-  // const [columnSettings, setColumnSettings] = useState(initialColumnSettings);
   const columnSettingsRef = useRef();
 
+  // This will update the state of the ColumnSettings component currently in use
   const updateColumnSettings = (newColumnSettings) => {
     if (columnSettingsRef.current) {
       columnSettingsRef.current.updateItems(newColumnSettings);
     }
   };
-
-  // const handleColumnSettingsChange = (modifiedItems) => {
-  //   setColumnSettings(modifiedItems);
-  //   if (onChange) {
-  //     console.log('onchange');
-  //     onChange(modifiedItems);
-  //   }
-  // };
 
   return div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
     div({ style: { flex: '1 1 0' } }, [
@@ -357,13 +348,6 @@ export const ColumnSettingsWithSavedColumnSettings = ({ columnSettings, onChange
         ref: columnSettingsRef,
         columnSettings,
         onChange,
-        // onChange: handleColumnSettingsChange,
-        // onChange: (modifiedItems) => {
-        //   // setColumnSettings(modifiedItems);
-        //   console.log(modifiedItems);
-        //   const result = onChange(columnSettings);
-        //   console.log('result', result);
-        // },
       }),
     ]),
     div(

--- a/src/workspace-data/data-table/entity-service/SavedColumnSettings.test.ts
+++ b/src/workspace-data/data-table/entity-service/SavedColumnSettings.test.ts
@@ -1,0 +1,82 @@
+import { DeepPartial } from '@terra-ui-packages/core-utils';
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { Ajax, AjaxContract } from 'src/libs/ajax';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+import { ColumnSettingsWithSavedColumnSettings } from './SavedColumnSettings';
+
+const onChange = jest.fn();
+
+jest.mock('src/libs/ajax');
+
+const workspaceDetails = jest.fn().mockResolvedValue({
+  workspace: {
+    attributes: {
+      'system:columnSettings': {
+        tables: { sample: { saved: ['Column A', true, 'Column B', false, 'Column C', true] } },
+      },
+    },
+  },
+});
+const workspace = jest.fn(() => ({ details: workspaceDetails }));
+
+asMockedFn(Ajax).mockImplementation(
+  () =>
+    ({
+      Workspaces: { workspace },
+      Metrics: { captureEvent: jest.fn() },
+    } as DeepPartial<AjaxContract> as AjaxContract)
+);
+
+// ColumnSettingsList uses react-virtualized's AutoSizer to size the table.
+// This makes the virtualized window large enough for all rows to be rendered in tests
+jest.mock('react-virtualized', () => ({
+  ...jest.requireActual('react-virtualized'),
+  AutoSizer: ({ children }) => children({ width: 200, height: 200 }),
+}));
+
+describe('ColumnSettingsWithSavedColumnSettings', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads saved column settings', async () => {
+    const user = userEvent.setup();
+    const columnSettings = [
+      { name: 'Column A', visible: true },
+      { name: 'Column B', visible: true },
+      { name: 'Column C', visible: true },
+    ];
+    const entityMetadata = {
+      sample: { count: 1, idName: 'sample_id', attributeNames: ['Column A', 'Column B', 'Column C'] },
+    };
+    // workspace, snapshotName, entityType, entityMetadata, columnSettings, onLoad
+    await act(async () => {
+      render(
+        h(ColumnSettingsWithSavedColumnSettings, {
+          columnSettings,
+          onChange,
+          workspace: defaultGoogleWorkspace,
+          entityType: 'sample',
+          entityMetadata,
+        })
+      );
+    });
+    const columnACheckbox = screen.getByRole('checkbox', { name: 'Show "Column A" in table' });
+    expect(columnACheckbox).toBeChecked();
+    const columnBCheckbox = screen.getByRole('checkbox', { name: 'Show "Column B" in table' });
+    expect(columnBCheckbox).toBeChecked();
+    const columnCCheckbox = screen.getByRole('checkbox', { name: 'Show "Column C" in table' });
+    expect(columnCCheckbox).toBeChecked();
+    // Load saved column settings
+    const menu = screen.getByRole('button', { name: 'Column selection menu' });
+    await user.click(menu);
+    const load = screen.getByRole('button', { name: 'Load' });
+    await user.click(load);
+    expect(columnBCheckbox).not.toBeChecked();
+  });
+});

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -346,7 +346,6 @@ const DataTable = (props) => {
 
   // Render
   const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType]?.attributeNames);
-  // const [columnSettings, setColumnSettings] = useState(applyColumnSettings(columnState, entityMetadata[entityType]?.attributeNames));
 
   const nameWidth = columnWidths.name || 150;
 
@@ -753,10 +752,6 @@ const DataTable = (props) => {
             workspace,
             columnSettings: updatingColumnSettings,
             onChange: setUpdatingColumnSettings,
-            // onChange: (newColumnSettings) => {
-            //   setUpdatingColumnSettings(newColumnSettings);
-            //   setColumnSettings(newColumnSettings);
-            // },
           }),
         ]
       ),

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -346,6 +346,8 @@ const DataTable = (props) => {
 
   // Render
   const columnSettings = applyColumnSettings(columnState || [], entityMetadata[entityType]?.attributeNames);
+  // const [columnSettings, setColumnSettings] = useState(applyColumnSettings(columnState, entityMetadata[entityType]?.attributeNames));
+
   const nameWidth = columnWidths.name || 150;
 
   const showColumnSettingsModal = () => setUpdatingColumnSettings(columnSettings);
@@ -751,6 +753,10 @@ const DataTable = (props) => {
             workspace,
             columnSettings: updatingColumnSettings,
             onChange: setUpdatingColumnSettings,
+            // onChange: (newColumnSettings) => {
+            //   setUpdatingColumnSettings(newColumnSettings);
+            //   setColumnSettings(newColumnSettings);
+            // },
           }),
         ]
       ),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-62

## Summary of changes:
This PR corrects the Column Settings modal to load saved column settings.  Previously, the 'load' button was available, but did nothing.  

Before my change:

https://github.com/user-attachments/assets/3128e383-feb7-48f8-b960-d24e0593c2b7

After my change:


https://github.com/user-attachments/assets/69b8cf72-6b4a-49c3-b229-8c94cc8f7e12




### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
