### PR TITLE
[CORE-106] Add "Analyze in Seqr" Link to New File Browser

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -25,10 +25,11 @@ interface FileBrowserProps {
   title: string;
   workspace: any; // TODO: Type for workspace
   onChangePath?: (newPath: string) => void;
+  extraMenuItems?: any;
 }
 
 const FileBrowser = (props: FileBrowserProps) => {
-  const { initialPath = '', provider, rootLabel, title, workspace, onChangePath } = props;
+  const { initialPath = '', provider, rootLabel, title, workspace, onChangePath, extraMenuItems } = props;
 
   const [path, _setPath] = useState(initialPath);
   const setPath = useCallback(
@@ -172,6 +173,7 @@ const FileBrowser = (props: FileBrowserProps) => {
               reloadRequests.next(parentPath);
             },
             onError,
+            extraMenuItems,
           }),
         ]
       ),

--- a/src/components/file-browser/FilesInDirectory.ts
+++ b/src/components/file-browser/FilesInDirectory.ts
@@ -33,6 +33,7 @@ interface FilesInDirectoryProps {
   onCreateDirectory: (directory: FileBrowserDirectory) => void;
   onDeleteDirectory: () => void;
   onError: (error: Error) => void;
+  extraMenuItems?: any;
 }
 
 const FilesInDirectory = (props: FilesInDirectoryProps) => {
@@ -48,6 +49,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
     onCreateDirectory,
     onDeleteDirectory,
     onError,
+    extraMenuItems,
   } = props;
 
   const directoryLabel = path === '' ? rootLabel : basename(path);
@@ -128,6 +130,7 @@ const FilesInDirectory = (props: FilesInDirectoryProps) => {
                   reload();
                 },
                 onRefresh: reload,
+                extraMenuItems,
               }),
 
               h(NoticeForPath, {

--- a/src/components/file-browser/FilesMenu.ts
+++ b/src/components/file-browser/FilesMenu.ts
@@ -24,6 +24,7 @@ interface FilesMenuProps {
   onCreateDirectory: (directory: FileBrowserDirectory) => void;
   onDeleteFiles: () => void;
   onRefresh: () => Promise<void>;
+  extraMenuItems?: any;
 }
 
 export const FilesMenu = (props: FilesMenuProps) => {
@@ -37,6 +38,7 @@ export const FilesMenu = (props: FilesMenuProps) => {
     onCreateDirectory,
     onDeleteFiles,
     onRefresh,
+    extraMenuItems,
   } = props;
 
   const [refreshing, withRefreshing] = useBusyState();
@@ -104,6 +106,8 @@ export const FilesMenu = (props: FilesMenuProps) => {
       ),
 
       span({ style: { flex: 1 } }),
+
+      extraMenuItems,
 
       h(
         Link,

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -172,6 +172,7 @@ const eventsList = {
   workspaceDataRenameEntity: 'workspace:data:renameEntity',
   workspaceDataRenameTable: 'workspace:data:rename-table',
   workspaceDataDeleteTable: 'workspace:data:deleteTable',
+  workspaceFilesSeqr: 'workspace:files:seqr',
   workspaceMenu: 'workspace:menu:selected',
   workspaceOpenFromList: 'workspace:open-from-list',
   workspaceOpenFromRecentlyViewed: 'workspace:open-from-recently-viewed',

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -4,8 +4,10 @@ import { div, h } from 'react-hyperscript-helpers';
 import * as breadcrumbs from 'src/components/breadcrumbs';
 import FileBrowser from 'src/components/file-browser/FileBrowser';
 import { icon } from 'src/components/icons';
+import { Ajax } from 'src/libs/ajax';
 import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider';
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider';
+import Events from 'src/libs/events';
 import { useQueryParameter } from 'src/libs/nav';
 import { forwardRefWithName } from 'src/libs/react-utils';
 import { wrapWorkspace } from 'src/workspaces/container/WorkspaceContainer';
@@ -54,6 +56,13 @@ export const Files = _.flow(
             href: `https://seqr.broadinstitute.org/workspace/${workspaceInfo.namespace}/${workspaceInfo.name}`,
             style: { padding: '0.5rem' },
             target: '_blank',
+            onClick: async () => {
+              await Ajax().Metrics.captureEvent(Events.workspaceFilesSeqr, {
+                workspaceNamespace: workspaceInfo.namespace,
+                workspaceName: workspaceInfo.name,
+                success: true,
+              });
+            },
           },
           [icon('pop-out'), ' Analyze in Seqr']
         ),

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -56,11 +56,10 @@ export const Files = _.flow(
             href: `https://seqr.broadinstitute.org/workspace/${workspaceInfo.namespace}/${workspaceInfo.name}`,
             style: { padding: '0.5rem' },
             target: '_blank',
-            onClick: async () => {
-              await Ajax().Metrics.captureEvent(Events.workspaceFilesSeqr, {
+            onClick: () => {
+              Ajax().Metrics.captureEvent(Events.workspaceFilesSeqr, {
                 workspaceNamespace: workspaceInfo.namespace,
                 workspaceName: workspaceInfo.name,
-                success: true,
               });
             },
           },

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -1,7 +1,9 @@
+import { Link } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { div, h } from 'react-hyperscript-helpers';
 import * as breadcrumbs from 'src/components/breadcrumbs';
 import FileBrowser from 'src/components/file-browser/FileBrowser';
+import { icon } from 'src/components/icons';
 import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider';
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider';
 import { useQueryParameter } from 'src/libs/nav';
@@ -46,6 +48,15 @@ export const Files = _.flow(
         rootLabel,
         title: 'Files',
         onChangePath: setPath,
+        extraMenuItems: h(
+          Link,
+          {
+            href: `https://seqr.broadinstitute.org/workspace/${workspaceInfo.namespace}/${workspaceInfo.name}`,
+            style: { padding: '0.5rem' },
+            target: '_blank',
+          },
+          [icon('pop-out'), ' Analyze in Seqr']
+        ),
       }),
     ]
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-106

### What

- This PR restores the "Analyze in Seqr" link in the new file browser, matching functionality in the previous version as described [here](https://support.terra.bio/hc/en-us/articles/4402431367949-Launching-seqr-through-Terra).

### Why

- "Analyze in Seqr" Link: Re-added to the new file browser to allow direct analysis in Seqr.
- Mixpanel Tracking: Added a new event (`workspace:files:seqr`) to monitor usage, helping assess if this feature should be moved closer to other file tools like IGV.

### Testing strategy

- [x] Manual Testing: Verified that the "Analyze in Seqr" link appears in the new file browser, is clickable, and redirects correctly to Seqr.
- [x] Event Tracking Verification: Confirm in Mixpanel that the `workspace:files:seqr` event is logged when the link is clicked.

![Seqr Link](https://github.com/user-attachments/assets/5b212554-bee3-4def-aa46-67f5cbf3d0b3)
