### PR TITLE
[CORE-82] Make workspace data type dropdown menu drop up

### DIFF
--- a/src/workspace-data/WorkspaceAttributes.js
+++ b/src/workspace-data/WorkspaceAttributes.js
@@ -351,14 +351,19 @@ export const WorkspaceAttributes = ({
                             h(Fragment, [
                               h(Select, {
                                 'aria-label': 'data type',
-                                styles: { container: (base) => ({ ...base, marginLeft: '1rem', width: 150 }) },
+                                styles: {
+                                  container: (base) => ({ ...base, marginLeft: '1rem', display: 'inline-block', width: 150 }),
+                                  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+                                },
                                 isSearchable: false,
                                 isClearable: false,
-                                menuPortalTarget: document.getElementById('root'),
                                 getOptionLabel: ({ value }) => _.startCase(value),
                                 value: editType,
                                 onChange: ({ value }) => setEditType(value),
                                 options: ['string', 'number', 'boolean', 'string list', 'number list', 'boolean list'],
+                                menuPortalTarget: document.body,
+                                menuPosition: 'fixed',
+                                menuPlacement: 'top',
                               }),
                             ]),
                         ]);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-82

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Previously, attempting to edit the data type in the last row of workspace data attributes would crash the page.  In order to maintain functionality with a minimal of developer-effort, this PR simply makes the dropdown menu go up instead of down.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
Before change:

https://github.com/user-attachments/assets/d28034e5-1069-406c-b9d7-53e649bf22f2

After change:

https://github.com/user-attachments/assets/eaf4a768-7579-49f8-8802-54eae549d43d


