### PR TITLE
[DT-837] Update Slack channel for data team

### DIFF
--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -38,8 +38,8 @@
       ]
     },
     {
-      "name": "jade-data-explorer",
-      "id": "C01TU3W2AL9",
+      "name": "dsp-data-team",
+      "id": "C07T2DLHD24",
       "tests": [
         {
           "name": "preview-dataset"


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-837

## Summary

Updates the Slack channel for the data team from `#dsp-data-exploration` to `#dsp-data-team`
