### PR TITLE
[CORE-113] Update File Browser with Workspace Name and "Open Bucket in Browser" Link for GCP

### DIFF
--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -22,7 +22,7 @@ interface FileBrowserProps {
   initialPath?: string;
   provider: FileBrowserProvider;
   rootLabel: string;
-  title: string;
+  title: any;
   workspace: any; // TODO: Type for workspace
   onChangePath?: (newPath: string) => void;
   extraMenuItems?: any;

--- a/src/components/file-browser/FileBrowser.ts
+++ b/src/components/file-browser/FileBrowser.ts
@@ -1,6 +1,6 @@
-import { Modal } from '@terra-ui-packages/components';
+import { Link, Modal } from '@terra-ui-packages/components';
 import { subscribable } from '@terra-ui-packages/core-utils';
-import { Fragment, useCallback, useEffect, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import DirectoryTree from 'src/components/file-browser/DirectoryTree';
 import { basename, dirname } from 'src/components/file-browser/file-browser-utils';
@@ -22,7 +22,7 @@ interface FileBrowserProps {
   initialPath?: string;
   provider: FileBrowserProvider;
   rootLabel: string;
-  title: any;
+  title: string | React.ReactElement<typeof Link>;
   workspace: any; // TODO: Type for workspace
   onChangePath?: (newPath: string) => void;
   extraMenuItems?: any;

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -11,7 +11,7 @@ import Events from 'src/libs/events';
 import { useQueryParameter } from 'src/libs/nav';
 import { forwardRefWithName } from 'src/libs/react-utils';
 import { wrapWorkspace } from 'src/workspaces/container/WorkspaceContainer';
-import { isAzureWorkspace, WorkspaceWrapper } from 'src/workspaces/utils';
+import { WorkspaceWrapper } from 'src/workspaces/utils';
 import { useMemo } from 'use-memo-one';
 
 export const Files = _.flow(
@@ -31,7 +31,7 @@ export const Files = _.flow(
     return GCSFileBrowserProvider({ bucket: bucketName, project: googleProject });
   }, [workspaceInfo]);
 
-  const rootLabel = isAzureWorkspace(workspace) ? 'Workspace cloud storage' : 'Workspace bucket';
+  const rootLabel = workspaceInfo.name;
 
   const [path, setPath] = useQueryParameter('path');
 

--- a/src/pages/workspaces/workspace/Files.ts
+++ b/src/pages/workspaces/workspace/Files.ts
@@ -1,17 +1,19 @@
 import { Link } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { div, h } from 'react-hyperscript-helpers';
+import { bucketBrowserUrl } from 'src/auth/auth';
 import * as breadcrumbs from 'src/components/breadcrumbs';
 import FileBrowser from 'src/components/file-browser/FileBrowser';
 import { icon } from 'src/components/icons';
-import { Ajax } from 'src/libs/ajax';
 import AzureBlobStorageFileBrowserProvider from 'src/libs/ajax/file-browser-providers/AzureBlobStorageFileBrowserProvider';
 import GCSFileBrowserProvider from 'src/libs/ajax/file-browser-providers/GCSFileBrowserProvider';
-import Events from 'src/libs/events';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useQueryParameter } from 'src/libs/nav';
 import { forwardRefWithName } from 'src/libs/react-utils';
+import { newTabLinkProps } from 'src/libs/utils';
 import { wrapWorkspace } from 'src/workspaces/container/WorkspaceContainer';
-import { WorkspaceWrapper } from 'src/workspaces/utils';
+import { isAzureWorkspace, WorkspaceWrapper } from 'src/workspaces/utils';
 import { useMemo } from 'use-memo-one';
 
 export const Files = _.flow(
@@ -48,16 +50,31 @@ export const Files = _.flow(
         workspace,
         provider: fileBrowserProvider,
         rootLabel,
-        title: 'Files',
+        title: isAzureWorkspace(workspace)
+          ? 'Files'
+          : h(
+              Link,
+              {
+                href: bucketBrowserUrl(workspaceInfo.bucketName),
+                style: { margin: '1rem 0.5rem' },
+                ...newTabLinkProps,
+                onClick: () => {
+                  void Metrics().captureEvent(Events.workspaceOpenedBucketInBrowser, {
+                    ...extractWorkspaceDetails(workspace),
+                  });
+                },
+              },
+              ['Open bucket in browser ', icon('pop-out', { size: 12 })]
+            ),
         onChangePath: setPath,
         extraMenuItems: h(
           Link,
           {
             href: `https://seqr.broadinstitute.org/workspace/${workspaceInfo.namespace}/${workspaceInfo.name}`,
             style: { padding: '0.5rem' },
-            target: '_blank',
+            ...newTabLinkProps,
             onClick: () => {
-              Ajax().Metrics.captureEvent(Events.workspaceFilesSeqr, {
+              void Metrics().captureEvent(Events.workspaceFilesSeqr, {
                 workspaceNamespace: workspaceInfo.namespace,
                 workspaceName: workspaceInfo.name,
               });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-113

### What
- Replaced "Workspace bucket" text with the workspace name.
- Added an "Open bucket in browser" link in the "Files" section, allowing users to navigate directly to the bucket's root directory in GCP.

### Why
- Replacing "Workspace bucket" with the workspace name for clearer identification.
- Updating the "Files" section (top left) in GCP to display "Open bucket in browser," which links directly to the storage bucket.

### Testing strategy
- Manual Testing: Conducted manual testing to ensure the "Open bucket in browser" link is visible and functions correctly within the file browser UI.

<img width="1793" alt="Screenshot 2024-11-01 at 3 13 29 PM" src="https://github.com/user-attachments/assets/dfe86f2f-7ffe-4db6-8217-05efbf6b2a87">
