### PR TITLE
[CORE-136] Add Size Constraints to Images in File Previews to Preserve Layout

### DIFF
--- a/src/workspace-data/data-table/uri-viewer/UriPreview.js
+++ b/src/workspace-data/data-table/uri-viewer/UriPreview.js
@@ -87,7 +87,7 @@ export const UriPreview = ({ metadata, metadata: { uri, bucket, name }, googlePr
             Utils.cond(
               [preview === null, () => 'Unable to load preview.'],
               [preview === undefined, () => 'Loading preview...'],
-              [isImage(metadata), () => img({ src: preview })],
+              [isImage(metadata), () => img({ src: preview, width: '100%', height: 400 })],
               [canRender(metadata), () => h('iframe', { src: preview, width: '100%', height: 400 })],
               () =>
                 div(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-136

### What
- This PR adds size limits to images in file previews to keep them from disrupting the page layout.

### Why
- Currently, images aren’t size-limited, so large images can expand and distort the layout. Adding constraints ensures the layout stays consistent and user-friendly.

### Testing strategy
- Manual Testing: Test with small to large images to confirm they display properly without affecting the layout.

**Before**
<img width="1793" alt="Screenshot 2024-11-01 at 4 19 51 PM" src="https://github.com/user-attachments/assets/9d8e6cce-4005-4567-b059-aee5734dcd04">

**After**
<img width="1793" alt="Screenshot 2024-11-01 at 4 26 48 PM" src="https://github.com/user-attachments/assets/4566ad72-5930-4e29-8587-76b197c08b92">
