### PR TITLE
CORE-150: persist SeparateSubmissionFinalOutputs on first save of bucket lifecycle rules

### DIFF
--- a/src/workspaces/SettingsModal/utils.test.ts
+++ b/src/workspaces/SettingsModal/utils.test.ts
@@ -198,7 +198,13 @@ describe('modifyFirstBucketDeletionRule', () => {
     const result = modifyFirstBucketDeletionRule([], 1, []);
 
     // Assert
-    expect(result).toEqual([newSetting]);
+    expect(result).toEqual([
+      {
+        settingType: 'SeparateSubmissionFinalOutputs',
+        config: { enabled: true },
+      },
+      newSetting,
+    ]);
   });
 
   it('adds a new setting in the case of no existing delete bucket lifecycle', async () => {

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -95,7 +95,7 @@ export const modifyFirstBucketDeletionRule = (
 
   // If no bucketLifecycleSettings existed, create a new one.
   if (bucketLifecycleSettings.length === 0) {
-    return _.concat(
+    const newSettings = _.concat(
       [
         {
           settingType: 'GcpBucketLifecycle',
@@ -111,7 +111,10 @@ export const modifyFirstBucketDeletionRule = (
       ],
       otherSettings
     );
+    // When enable bucket lifecycle rules, we also enable separate submission outputs.
+    return modifySeparateSubmissionOutputsSetting(newSettings, true);
   }
+
   // If multiple bucketLifecycleSettings, we will modify only the first one.
   const existingSetting = bucketLifecycleSettings[0];
   // Modify the first delete rule in this setting and leave the rest.


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-150

## Summary of changes:
The first time you set a bucket lifecycle rule in a workspace, the `SeparateSubmissionFinalOutputs` was not enabled. This PR fixes that.

### What
The code had an early-return condition for the case where no lifecycle rules pre-exist on the bucket … which in Terra will be true the very first time you try to turn on lifecycle rules. The early return condition did not set `SeparateSubmissionFinalOutputs` at all.

### Testing strategy
- [x] We had a unit test for this, but the unit test had a faulty expectation! I've updated that test.
- [x] Tested manually in my browser by watching ajax requests.

### Visual Aids

Here is the ajax request payload for the very first time you enable a lifecycle rule on a workspace:

Before this PR:
![Screenshot 2024-11-07 dev ](https://github.com/user-attachments/assets/a1e991b4-e2a1-41db-a043-d681a75a02b7)

After this PR:
![Screenshot 2024-11-07 pr](https://github.com/user-attachments/assets/b61f2091-707b-48bb-917c-4935bbdfc347)


