### PR TITLE
[CORE-154] Remove "New and Interesting" Tab and Move Workspaces to Featured

### DIFF
--- a/src/workspaces/list/CategorizedWorkspaces.ts
+++ b/src/workspaces/list/CategorizedWorkspaces.ts
@@ -3,7 +3,6 @@ import { canWrite, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
 export interface CategorizedWorkspaces {
   myWorkspaces: Workspace[];
-  newAndInteresting: Workspace[];
   featured: Workspace[];
   public: Workspace[];
 }
@@ -12,18 +11,12 @@ export const categorizeWorkspaces = (
   workspaces: Workspace[],
   featuredList?: { name: string; namespace: string }[]
 ): CategorizedWorkspaces => {
-  const [newWsList, featuredWsList] = _.partition('isNew', featuredList);
-
   return {
     myWorkspaces: _.filter((ws) => !ws.public || canWrite(ws.accessLevel), workspaces),
     public: _.filter('public', workspaces),
-    newAndInteresting: _.flow(
-      _.map(({ namespace, name }) => _.find({ workspace: { namespace, name } }, workspaces)),
-      _.compact
-    )(newWsList),
     featured: _.flow(
       _.map(({ namespace, name }) => _.find({ workspace: { namespace, name } }, workspaces)),
       _.compact
-    )(featuredWsList),
+    )(featuredList),
   };
 };

--- a/src/workspaces/list/NoContentMessage.test.tsx
+++ b/src/workspaces/list/NoContentMessage.test.tsx
@@ -11,7 +11,6 @@ describe('NoContentMessage', () => {
     // Arrange
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [],
-      newAndInteresting: [],
       featured: [],
       public: [],
     };
@@ -34,7 +33,6 @@ describe('NoContentMessage', () => {
     // Arrange
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [],
-      newAndInteresting: [],
       featured: [],
       public: [],
     };
@@ -60,7 +58,6 @@ describe('NoContentMessage', () => {
     // Arrange
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [],
-      newAndInteresting: [],
       featured: [],
       public: [],
     };
@@ -83,7 +80,6 @@ describe('NoContentMessage', () => {
     // Arrange
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
       public: [],
     };

--- a/src/workspaces/list/WorkspacesListTabs.test.ts
+++ b/src/workspaces/list/WorkspacesListTabs.test.ts
@@ -42,7 +42,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
       public: [defaultAzureWorkspace, defaultGoogleWorkspace],
-      newAndInteresting: [defaultAzureWorkspace, defaultGoogleWorkspace],
       featured: [defaultAzureWorkspace, defaultGoogleWorkspace],
     };
     const filters = getWorkspaceFiltersFromQuery({ tab: 'myWorkspaces', filter: defaultAzureWorkspace.workspace.name });
@@ -54,7 +53,6 @@ describe('The filterWorkspaces method', () => {
     expect(filteredWorkspaces.myWorkspaces).toEqual([defaultAzureWorkspace]);
     // All categories should be filtered
     expect(filteredWorkspaces.public).toEqual([defaultAzureWorkspace]);
-    expect(filteredWorkspaces.newAndInteresting).toEqual([defaultAzureWorkspace]);
     expect(filteredWorkspaces.featured).toEqual([defaultAzureWorkspace]);
   });
 
@@ -63,7 +61,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace, defaultInitializedGoogleWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({
@@ -84,7 +81,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace, defaultInitializedGoogleWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ filter: defaultGoogleWorkspace.workspace.googleProject });
@@ -120,7 +116,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, deleteFailedWorkspace, cloningFailedWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ filter: 'fail' });
@@ -137,7 +132,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
       public: [defaultAzureWorkspace, defaultGoogleWorkspace],
-      newAndInteresting: [defaultAzureWorkspace, defaultGoogleWorkspace],
       featured: [defaultAzureWorkspace, defaultGoogleWorkspace],
     };
     const filters = getWorkspaceFiltersFromQuery({
@@ -152,7 +146,6 @@ describe('The filterWorkspaces method', () => {
     expect(filteredWorkspaces.myWorkspaces).toEqual([defaultGoogleWorkspace]);
     // All categories should be filtered
     expect(filteredWorkspaces.public).toEqual([defaultGoogleWorkspace]);
-    expect(filteredWorkspaces.newAndInteresting).toEqual([defaultGoogleWorkspace]);
     expect(filteredWorkspaces.featured).toEqual([defaultGoogleWorkspace]);
   });
 
@@ -161,7 +154,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace, defaultInitializedGoogleWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ projectsFilter: defaultGoogleWorkspace.workspace.namespace });
@@ -179,7 +171,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ cloudPlatform: cloudProviderTypes.GCP });
@@ -206,7 +197,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, readerWorkspace, writerWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ accessLevelsFilter: ['OWNER', 'WRITER'] });
@@ -249,7 +239,6 @@ describe('The filterWorkspaces method', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, fooTagWorkspace, fooBarTagWorkspace],
       public: [],
-      newAndInteresting: [],
       featured: [],
     };
     const filters = getWorkspaceFiltersFromQuery({ tagsFilter: ['foo', 'bar'] });
@@ -272,7 +261,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(useRoute).mockImplementation(() => ({ params: {}, query: { tab: 'public' } }));
@@ -298,7 +286,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(useRoute).mockImplementation(() => ({ params: {}, query: { tab: 'public' } }));
@@ -322,7 +309,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(useRoute).mockImplementation(() => ({
@@ -349,7 +335,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(useRoute).mockImplementation(() => ({ params: {}, query: {} }));
@@ -375,7 +360,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(useRoute).mockImplementation(() => ({ params: {}, query: {} }));
@@ -402,7 +386,6 @@ describe('The WorkspacesListTabs component', () => {
     const workspaces: CategorizedWorkspaces = {
       myWorkspaces: [defaultAzureWorkspace],
       public: [defaultGoogleWorkspace],
-      newAndInteresting: [],
       featured: [],
     };
     asMockedFn(updateSearch);
@@ -422,7 +405,7 @@ describe('The WorkspacesListTabs component', () => {
 
     // Assert
     const tabs = screen.getAllByRole('tab');
-    const publicTab = tabs[3];
+    const publicTab = tabs[2];
     act(() => fireEvent.click(publicTab));
     expect(updateSearch).toHaveBeenCalledWith({ tab: 'public' });
     expect(captureEvent).toHaveBeenNthCalledWith(1, `${Events.workspacesListSelectTab}:view:myWorkspaces`, {});

--- a/src/workspaces/list/WorkspacesListTabs.ts
+++ b/src/workspaces/list/WorkspacesListTabs.ts
@@ -36,7 +36,7 @@ export const WorkspacesListTabs = (props: WorkspacesListTabsProps): ReactNode =>
       title: span([_.upperCase(key), ` (${loadingWorkspaces ? '...' : filteredWorkspaces[key].length})`]),
       tableName: _.lowerCase(key),
     }),
-    ['myWorkspaces', 'newAndInteresting', 'featured', 'public']
+    ['myWorkspaces', 'featured', 'public']
   );
 
   return h(
@@ -96,7 +96,6 @@ export const filterWorkspaces = (
   return {
     myWorkspaces: filterWorkspacesCategory(workspaces.myWorkspaces, filters),
     public: filterWorkspacesCategory(workspaces.public, filters),
-    newAndInteresting: filterWorkspacesCategory(workspaces.newAndInteresting, filters),
     featured: filterWorkspacesCategory(workspaces.featured, filters),
   };
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-154

### What
- This PR removes the outdated "New and Interesting" tab from the workspace list page and moves its five workspaces to the "Featured Workspaces" tab.

### Why
- The "New and Interesting" tab hasn’t been updated since 2022 due to the marketing team no longer managing it, making Terra appear outdated. Consolidating these workspaces into "Featured Workspaces" keeps the workspace list relevant and streamlined.

### Testing strategy
- Manual Testing
   - Verify that the "New and Interesting" tab is removed and the five workspaces appear under "Featured Workspaces."
   - Ensure all workspaces in "Featured Workspaces" are accessible and there are no references to the removed tab.
   - Confirm no unexpected changes on the workspace list page.
   
 **Before**
<img width="1788" alt="old" src="https://github.com/user-attachments/assets/0d0ffecb-9397-4da3-b57f-859919aa1fc4">

 **After**
<img width="1788" alt="new" src="https://github.com/user-attachments/assets/e3947e7e-5240-4b64-8a98-446ef7d6d6c2">
