### PR TITLE
[CORE-43] Added Daily Cost Chart to Spend Report Page 

### DIFF
--- a/src/billing/SpendReport/SpendReport.tsx
+++ b/src/billing/SpendReport/SpendReport.tsx
@@ -167,7 +167,7 @@ export const SpendReport = (props: SpendReportProps) => {
         _.map((point: { color: any; series: { name: any }; y: any; percentage: any }) => {
           return `<span style="color:${point.color}">\u25CF</span> ${point.series.name}: ${yAxisLabelsFormatter(
             point.y
-          )} (${point.percentage.toFixed(2)}%)<br/>`;
+          )} ${!_.isNil(point.percentage) ? `(${point.percentage.toFixed(2)}%)` : ''} <br/>`;
         }),
         _.join('')
       )(points)}<br/>Total: ${yAxisLabelsFormatter(total)}`;
@@ -370,6 +370,7 @@ export const SpendReport = (props: SpendReportProps) => {
           setCostPerDay(dailyCosts);
         }
 
+        // Only show workspace costs if the feature preview is not enabled
         if (includeAggregateSpendChart && !isFeaturePreviewEnabled(SPEND_REPORTING)) {
           const workspaceDetails = _.find(
             (details) => details.aggregationKey === 'Workspace',

--- a/src/billing/SpendReport/SpendReport.tsx
+++ b/src/billing/SpendReport/SpendReport.tsx
@@ -428,7 +428,7 @@ export const SpendReport = (props: SpendReportProps) => {
   ]);
 
   return (
-    <>
+    <div style={{ position: 'relative' }}>
       <div style={{ display: 'grid', rowGap: '0.5rem' }}>
         {!!errorMessage && <ErrorAlert errorValue={errorMessage} />}
         <div
@@ -476,8 +476,8 @@ export const SpendReport = (props: SpendReportProps) => {
           </div>
         )}
       </div>
-      {updatingProjectCost && <SpinnerOverlay mode='FullScreen' />}
-    </>
+      {updatingProjectCost && <SpinnerOverlay mode='Fixed' />}
+    </div>
   );
 };
 

--- a/src/libs/ajax/billing/billing-models.ts
+++ b/src/libs/ajax/billing/billing-models.ts
@@ -106,8 +106,17 @@ export interface WorkspaceSpendData {
   workspace: { name: string; namespace: string };
 }
 
+export interface DailySpendData {
+  cost: string;
+  credits: string;
+  currency: string;
+  endTime: string;
+  startTime: string;
+  subAggregation: { aggregationKey: 'Category'; spendData: CategorySpendData[] };
+}
+
 interface AggregatedSpendData {
-  aggregationKey: 'Workspace' | 'Category';
+  aggregationKey: 'Workspace' | 'Category' | 'Daily';
 }
 
 export interface AggregatedWorkspaceSpendData extends AggregatedSpendData {
@@ -118,6 +127,11 @@ export interface AggregatedWorkspaceSpendData extends AggregatedSpendData {
 export interface AggregatedCategorySpendData extends AggregatedSpendData {
   aggregationKey: 'Category';
   spendData: CategorySpendData[];
+}
+
+export interface AggregatedDailySpendData extends AggregatedSpendData {
+  aggregationKey: 'Daily';
+  spendData: DailySpendData[];
 }
 
 export interface SpendReport {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-43

### What

- This PR updates the Spend Report Dashboard to show daily aggregated costs for all workspaces in a billing project, allowing users to track trends over time. This can be accessed by turning on the feature flag `Improved Spend Reports`.
- I moved the fullscreen spinner to cover only the dashboard.

### Why

- To help users understand cost trends and manage billing projects more effectively.

### Testing strategy
- Unit Testing
- Manual Testing
- Stress Testing using the `general-dev-billing-account` billing account with 1900+ workspaces.

https://github.com/user-attachments/assets/ad8d7719-dc0a-4b90-8dcf-08cf76cace90



