### PR TITLE
[CORE-184] Restrict Roadmap Banner Display to Specific Branded Sites

### DIFF
--- a/src/libs/brands.ts
+++ b/src/libs/brands.ts
@@ -87,6 +87,21 @@ export interface BrandConfiguration {
 
   /** Theme for components */
   theme: Theme;
+
+  /** Optional flag to show the roadmap link */
+  showRoadmap?: boolean;
+
+  /** Optional card for the roadmap */
+  roadMapCard?: {
+    /** Card link */
+    link: string;
+
+    /** Card title */
+    title: string;
+
+    /** Card body */
+    body: string;
+  };
 }
 
 export const landingPageCardsDefault = [
@@ -106,6 +121,12 @@ export const landingPageCardsDefault = [
     body: 'Access data from a rich ecosystem of data portals.',
   },
 ];
+
+export const roadMapCardDefault = {
+  link: 'https://support.terra.bio/hc/en-us/sections/30968105851931-Terra-Roadmap',
+  title: 'Terra Roadmap',
+  body: "Stay connected: see what's new, what's next, and try out the latest features on Terra.",
+};
 
 const baseColors: Theme['colorPalette'] = {
   primary: '#74ae43',
@@ -145,6 +166,7 @@ export const brands: Record<string, BrandConfiguration> = {
     theme: {
       colorPalette: { ...baseColors, primary: '#e0dd10', accent: '#035c94', light: '#f6f7f4', dark: '#012840' },
     },
+    showRoadmap: true,
   },
   baseline: {
     name: 'Project Baseline',
@@ -359,6 +381,7 @@ export const brands: Record<string, BrandConfiguration> = {
         dark: '#333F52',
       },
     },
+    showRoadmap: true,
   },
   rareX: {
     name: `The RARE${nonBreakingHyphen}X Data Analysis Platform`,
@@ -420,6 +443,7 @@ export const brands: Record<string, BrandConfiguration> = {
     theme: {
       colorPalette: { ...baseColors },
     },
+    showRoadmap: true,
   },
 };
 

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -8,7 +8,7 @@ import hexButton from 'src/images/hex-button.svg';
 import roadmapBgBanner from 'src/images/roadmap-bg-banner.png';
 import { Ajax } from 'src/libs/ajax';
 import { getEnabledBrand, isFirecloud, isTerra } from 'src/libs/brand-utils';
-import { landingPageCardsDefault } from 'src/libs/brands';
+import { landingPageCardsDefault, roadMapCardDefault } from 'src/libs/brands';
 import colors from 'src/libs/colors';
 import { withErrorHandling } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
@@ -146,20 +146,11 @@ export const LandingPage = () => {
       { style: { display: 'flex', margin: '2rem 0 1rem 0' } },
       makeCard({ ...styles.card }, getEnabledBrand().landingPageCards || landingPageCardsDefault)
     ),
-    div(
-      { style: { display: 'flex', marginTop: '2rem' } },
-      makeCard(
-        { ...styles.roadmapBanner },
-        [
-          {
-            link: 'https://support.terra.bio/hc/en-us/sections/30968105851931-Terra-Roadmap',
-            title: 'Terra Roadmap',
-            body: "Stay connected: see what's new, what's next, and try out the latest features on Terra.",
-          },
-        ],
-        true
-      ) // isExternalLink
-    ),
+    getEnabledBrand().showRoadmap &&
+      div(
+        { style: { display: 'flex', marginTop: '2rem' } },
+        makeCard({ ...styles.roadmapBanner }, [getEnabledBrand().roadMapCard || roadMapCardDefault], true)
+      ),
     (isTerra() || isFirecloud()) &&
       div({ style: { width: 700, marginTop: '4rem' } }, [
         'This project has been funded in whole or in part with Federal funds from the National Cancer Institute, National Institutes of Health, ',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-184

This is a follow-up to [PR #5178](https://github.com/DataBiosphere/terra-ui/pull/5178), which restricts the display of the roadmap banner to the app.terra.bio, anvil.terra.bio, and publichealth.terra.bio branded sites.
