### PR TITLE
CORE-192: ignore errors during integration test cleanup; remove a spinner-wait in preview-drs-uri test

### DIFF
--- a/integration-tests/tests/preview-drs-uri.js
+++ b/integration-tests/tests/preview-drs-uri.js
@@ -54,8 +54,6 @@ const testPreviewDrsUriFn = _.flow(
   await click(page, clickable({ textContains: testEntity.entityType }));
   console.log('opening preview for entity...');
   await click(page, elementInDataTableRow(testEntity.name, testEntity.attributes.file_uri));
-  console.log('waiting for no spinners in preview modal...');
-  await waitForNoSpinners(page);
   console.log('verifying text in preview modal...');
   await findText(page, 'Filename');
   await findText(page, 'File size');

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -210,7 +210,12 @@ const withWorkspace = (test) => async (options) => {
     await test({ ...options, workspaceName });
   } finally {
     console.log('withWorkspace cleanup ...');
-    const didDelete = await withSignedInPage(deleteWorkspaceInUi)({ ...options, workspaceName });
+    let didDelete = false;
+    try {
+      didDelete = await withSignedInPage(deleteWorkspaceInUi)({ ...options, workspaceName });
+    } catch (err) {
+      console.error(`Error during workspace cleanup: ${err}`);
+    }
     if (!didDelete) {
       // Pass test on a failed cleanup - expect leaked resources to be cleaned up by the test `delete-orphaned-workspaces`
       console.error(`Unable to delete workspace ${workspaceName} via the UI. The resource will be leaked!`);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-192

## Summary of changes:
1. Remove a `waitForNoSpinners` call in the `preview-drs-uri` integration test, in hopes of making the test more stable.
2. Adjust the `withWorkspace` test utility so it won't fail the test if cleanup fails. 

Anecdotally, this test fails in the `waitForNoSpinners` call. The last 6 failures I checked have all been in this method, and I believe the test is passing but we hit a failure during cleanup.

### Testing strategy
- [x] Integration tests passed 2x on the latest version of this PR. I don't think I'm making anything worse, at least.

### Visual aids

Here is the expected behavior of the UI:
[Screen Recording 26-11-2024 at 13.35.webm](https://github.com/user-attachments/assets/2e550c0c-6594-4f49-ae47-6a2a6b54721f)

