### PR TITLE
[DT-1053] Make cohort browser feature preview private

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -102,6 +102,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     title: 'Cohort Builder Card',
     description:
       'Enabling this feature will show the card for the demo cohort builder in the Datasets tab in the Library.',
+    groups: ['CohortBuilderUsers'],
     feedbackUrl: `mailto:dsp-data-exploration@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Cohort Builder Card'
     )}`,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DT-1053

### Summary
Add cohort builder users as a group on the feature preview for the cohort builder page. This group contains the members of the data team. This change does not by default enable the feature preview for this group, but only shows the feature preview option for this group.
 Note the documentation on line 31: 
```
/**
   * Optional list of groups. If specified, the feature will only appear on the feature previews page
   * for users that are a member of at least one of the specified groups.
   * This only applies in production. In dev environments, all features are available to all users.
   */
```

### Testing
The groups attribute only applies to prod. So, I don't believe this can be tested in dev. 

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
