### PR TITLE
CORE-216: cost cap validation

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1306,12 +1306,14 @@ export const WorkflowView = _.flow(
                       ]),
                       div({ style: { display: 'flex', alignItems: 'center', marginLeft: '0rem' } }, [
                         span({ style: { marginRight: '0.5rem' } }, ['$']),
-                        h(TextInput, {
+                        h(NumberInput, {
                           id: 'workflow-run-budget',
                           value: perWorkflowCostCap || '',
+                          min: 0.01,
+                          max: 9999999999.99,
                           placeholder: 'Example: 1.00',
                           onChange: (v) => this.setState({ perWorkflowCostCap: v }),
-                          style: { marginTop: '0.5rem', width: '70%', marginLeft: '0.1rem' },
+                          style: { marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                         }),
                       ]),
                     ]

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1312,7 +1312,7 @@ export const WorkflowView = _.flow(
                           min: 0.01,
                           max: 9999999999.99,
                           placeholder: 'Example: 1.00',
-                          onChange: (v) => this.setState({ perWorkflowCostCap: v }),
+                          onChange: (v) => this.setState({ perWorkflowCostCap: v.toFixed(2) }),
                           style: { marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                         }),
                       ]),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-216

## Summary of changes:
Client-side validation of input values for the per-workflow cost limit.
* when entering a value less than 0.01, automatically sets to 0.01
* when entering a value greater than 9999999999.99, automatically sets to 9999999999.99
* when entering a value with more than 2 decimal places, automatically rounds to 2 decimal places
* rejects non-numeric input


https://github.com/user-attachments/assets/7953205d-3b65-409b-98fe-048bc0123cde



### Testing strategy
Tested while running locally. 
