### PR TITLE
CORE-216: allow per-workflow cost cap to be empty

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1312,7 +1312,7 @@ export const WorkflowView = _.flow(
                           min: 0.01,
                           max: 9999999999.99,
                           placeholder: 'Example: 1.00',
-                          onChange: (v) => this.setState({ perWorkflowCostCap: v.toFixed(2) }),
+                          onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : null }),
                           style: { marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                         }),
                       ]),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1312,7 +1312,7 @@ export const WorkflowView = _.flow(
                           min: 0.01,
                           max: 9999999999.99,
                           placeholder: 'Example: 1.00',
-                          onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : null }),
+                          onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : undefined }),
                           style: { marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                         }),
                       ]),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-216

## Summary of changes:
Allows the per-workflow cost cap input field to be empty

### What
There was previously a JS error if the input was empty, which in turn reset the value to its previous state. This acted as if the input did not allow clearing an existing value.

### Testing strategy
- [ ] tested locally

_after this PR:_

https://github.com/user-attachments/assets/d72ec2a5-a195-4a5d-a051-f08c6856af58

_before this PR:_

https://github.com/user-attachments/assets/60e76342-f957-4afe-a6d5-7b3d2b9cb214



