### PR TITLE
[AN-323] Fix opening IGV when data table row includes numeric value

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -88,7 +88,7 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
 
   await Promise.all(
     values.map(async (value) => {
-      if (value.startsWith('drs://')) {
+      if (isDrsUri(value)) {
         const json = await DrsUriResolver(signal).getDataObjectMetadata(value, ['fileName']);
         const filename = json.fileName;
         const isValid = hasValidIgvExtension(filename);
@@ -153,6 +153,10 @@ export const getValidIgvFilesFromAttributeValues = async (attributeValues, signa
   return validIgvFiles;
 };
 
+export const isDrsUri = (value) => {
+  return !!value?.toString().startsWith('drs://');
+};
+
 const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
   const [refGenome, setRefGenome] = useState(defaultIgvReference);
   const isRefGenomeValid = Boolean(_.get('genome', refGenome) || _.get('reference.fastaURL', refGenome));
@@ -169,7 +173,7 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
       // If there are 2 or more DRS URIs in this row, then IGV might be openable.
       // This lets us know we need to show a loading message while awaiting DRS URI
       // resolution to confirm if IGV is indeed openable for the selections.
-      const drsCandidateFiles = allAttributeValues.filter((value) => value.startsWith('drs://'));
+      const drsCandidateFiles = allAttributeValues.filter((value) => isDrsUri(value));
       setHasDrsCandidateFiles(drsCandidateFiles.length >= 2);
 
       const selections = await getValidIgvFilesFromAttributeValues(allAttributeValues, signal);

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -208,6 +208,11 @@ describe('getValidIgvFilesFromAttributeValues', () => {
     const nonDrsUriString = 'gs://bucket/object';
     expect(isDrsUri(nonDrsUriString)).toEqual(false);
 
+    // This assertion confirms no regression in
+    // https://github.com/DataBiosphere/terra-ui/pull/5199
+    const numericValue = 5;
+    expect(isDrsUri(numericValue)).toEqual(false);
+
     const listValue = ['test'];
     expect(isDrsUri(listValue)).toEqual(false);
 

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -1,4 +1,4 @@
-import { getValidIgvFiles, getValidIgvFilesFromAttributeValues } from 'src/components/IGVFileSelector';
+import { getValidIgvFiles, getValidIgvFilesFromAttributeValues, isDrsUri } from 'src/components/IGVFileSelector';
 import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 
@@ -199,6 +199,24 @@ describe('getValidIgvFilesFromAttributeValues', () => {
         },
       ])
     ).toEqual([]);
+  });
+
+  it('robustly detects data table values that are DRS URIs', () => {
+    const drsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4';
+    expect(isDrsUri(drsUri)).toEqual(true);
+
+    const nonDrsUriString = 'gs://bucket/object';
+    expect(isDrsUri(nonDrsUriString)).toEqual(false);
+
+    const listValue = ['test'];
+    expect(isDrsUri(listValue)).toEqual(false);
+
+    const booleanValue = true;
+    expect(isDrsUri(booleanValue)).toEqual(false);
+
+    expect(isDrsUri(null)).toEqual(false);
+
+    expect(isDrsUri(undefined)).toEqual(false);
   });
 
   it('calls to resolve access URLs when two DRS URIs are found', async () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-323

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

If a data table row has eligible IGV data and another field with a _numeric_ value, then IGV can't be opened.  The file selector row erroneously reports "No valid files with indices found".  This bug was introduced by a new DRS URI check in #5191.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

A new unit tests verifies robust DRS URI detection. To manually test:

1.  Go to https://pr-7-dot-bvdp-saturn-dev.appspot.com/#feature-preview
2.  Enable "Enhancements to IGV genome browser integration" feature preview
3.  Go to https://pr-7-dot-bvdp-saturn-dev.appspot.com/#workspaces/anvil-dev-developer-work/igv_drs_test_area/data
4.  Select checkbox for 1st row in the **"table_with_numeric_field"** table
5.  Click "Open With..."
6.  Click "IGV"
7.  Confirm "Searching for valid files with indices..." briefly appears
8.  Confirm "NA06985.haplotypeCalls.er.raw.g.vcf.gz" appears after a few seconds
9.  Select that file, click "Launch IGV"
10.  Confirm IGV loads, and that you see a track labeled "NA06985.haplotypeCalls.er.ra..."
11.  In the IGV search box, type in "LDLR", then press "Enter" / "return" on your keyboard
Confirm you see faint blue and grey features in the NA06985 track
12.  Repeat steps 4-8, but in step 4 use **"table_without_numeric_field"**

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
