### PR TITLE
[CORE-239] Restore Azure workspace writer sharing

### DIFF
--- a/src/workspaces/ShareWorkspaceModal/Collaborator.tsx
+++ b/src/workspaces/ShareWorkspaceModal/Collaborator.tsx
@@ -113,7 +113,10 @@ export const AclInput: React.FC<AclInputProps> = (props: AclInputProps) => {
               ...Utils.switchCase(
                 o?.value,
                 ['READER', () => ({ canCompute: false, canShare: false })],
-                ['WRITER', () => ({ canCompute: hasAccessLevel('OWNER', maxAccessLevel), canShare: false })],
+                [
+                  'WRITER',
+                  () => ({ canCompute: !isAzureWorkspace && hasAccessLevel('OWNER', maxAccessLevel), canShare: false }),
+                ],
                 ['OWNER', () => ({ canCompute: true, canShare: true })]
               ),
             })


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-239

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Users cannot be granted `canCompute` on Azure workspaces. If the workspace is an Azure workspace, set `canCompute` to false.

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
