### PR TITLE
[CORE-196] Updated Feature Preview Page for better feedback and navigation

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -51,6 +51,11 @@ export type FeaturePreview = {
    * Optional date string for the last updated date. Shown on the feature previews page.
    */
   readonly lastUpdated?: string;
+
+  /**
+   * Optional URL for an article about the feature. Shown on the feature previews page.
+   */
+  readonly articleUrl?: string;
 };
 
 const featurePreviewsConfig: readonly FeaturePreview[] = [
@@ -98,6 +103,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on deprecating Firecloud UI'
     )}`,
     lastUpdated: '3/22/2024',
+    articleUrl: 'https://support.terra.bio/hc/en-us/articles/31191238873243',
   },
   {
     id: COHORT_BUILDER_CARD,
@@ -119,6 +125,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Improved Spend Reports'
     )}`,
     lastUpdated: '11/19/2024',
+    articleUrl: 'https://support.terra.bio/hc/en-us/articles/31182586327323',
   },
   {
     id: AUTO_GENERATE_DATA_TABLES,
@@ -129,6 +136,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Autogenerate data table for single and paired end sequencing'
     )}`,
     lastUpdated: '11/26/2024',
+    articleUrl: 'https://support.terra.bio/hc/en-us/articles/31258673632923',
   },
   {
     id: PREVIEW_COST_CAPPING,
@@ -140,6 +148,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Workflow Cost Capping'
     )}`,
     lastUpdated: '12/6/2024',
+    articleUrl: 'https://support.terra.bio/hc/en-us/articles/31269696049307',
   },
   {
     id: IGV_ENHANCEMENTS,

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -134,6 +134,7 @@ export const FeaturePreviews = () => {
             },
           ],
         }),
+        div({ style: { marginTop: '1rem' } }, [h(Link, { href: '#workspaces' }, ['Go to Workspaces List'])]),
       ])
   );
 };

--- a/src/pages/FeaturePreviews.js
+++ b/src/pages/FeaturePreviews.js
@@ -94,7 +94,7 @@ export const FeaturePreviews = () => {
               field: 'description',
               headerRenderer: () => span({ style: { fontWeight: 'bold' } }, ['Description']),
               cellRenderer: ({ rowIndex }) => {
-                const { title, description, documentationUrl, feedbackUrl, groups } = featurePreviews[rowIndex];
+                const { title, description, documentationUrl, feedbackUrl, groups, articleUrl } = featurePreviews[rowIndex];
                 const isPrivate = !_.isEmpty(groups);
                 const privateText = 'This feature is in Private Preview and is only visible to you.';
                 const privateIcon = Icon({
@@ -111,11 +111,13 @@ export const FeaturePreviews = () => {
                 return div([
                   p({ style: { fontWeight: 600, margin: '0.5rem 0 0.5rem' } }, [isPrivate && privateIcon, title]),
                   p({ style: { margin: '0.5rem 0' } }, [description]),
-                  !!(documentationUrl || feedbackUrl) &&
+                  !!(documentationUrl || feedbackUrl || articleUrl) &&
                     p({ style: { margin: '0.5rem 0' } }, [
                       documentationUrl && h(Link, { ...Utils.newTabLinkProps, href: documentationUrl }, ['Documentation']),
                       !!(documentationUrl && feedbackUrl) && ' | ',
-                      feedbackUrl && h(Link, { ...Utils.newTabLinkProps, href: feedbackUrl }, ['Submit feedback']),
+                      articleUrl
+                        ? h(Link, { ...Utils.newTabLinkProps, href: articleUrl }, ['Learn more and provide feedback'])
+                        : feedbackUrl && h(Link, { ...Utils.newTabLinkProps, href: feedbackUrl }, ['Submit feedback']),
                     ]),
                 ]);
               },

--- a/src/pages/FeaturePreviews.test.ts
+++ b/src/pages/FeaturePreviews.test.ts
@@ -109,4 +109,12 @@ describe('FeaturePreviews', () => {
     const link3 = getByRole('link', { name: 'Submit feedback' });
     expect(link3).toHaveAttribute('href', 'mailto:feature2-feedback@example.com');
   });
+
+  it('should render "Go to Workspaces List" link', () => {
+    const { getByRole } = render(h(FeaturePreviews));
+    const link = getByRole('link', { name: 'Go to Workspaces List' });
+
+    expect(link).toBeTruthy();
+    expect(link).toHaveAttribute('href', '#workspaces');
+  });
 });

--- a/src/pages/FeaturePreviews.test.ts
+++ b/src/pages/FeaturePreviews.test.ts
@@ -15,6 +15,7 @@ describe('FeaturePreviews', () => {
           id: 'feature1',
           title: 'Feature #1',
           description: 'A new feature',
+          articleUrl: 'https://example.com/article',
           documentationUrl: 'https://example.com/feature-1-docs',
           lastUpdated: '2024-11-01',
         },
@@ -94,5 +95,18 @@ describe('FeaturePreviews', () => {
     const feedbackLinks = getAllByText('Submit feedback');
     expect(feedbackLinks.length).toBe(1);
     expect(feedbackLinks[0].getAttribute('href')).toBe('mailto:feature2-feedback@example.com');
+  });
+
+  it('displays the correct link based on articleUrl', async () => {
+    const { getByRole } = render(h(FeaturePreviews));
+
+    const link1 = getByRole('link', { name: 'Learn more and provide feedback' });
+    expect(link1).toHaveAttribute('href', 'https://example.com/article');
+
+    const link2 = getByRole('link', { name: 'Documentation' });
+    expect(link2).toHaveAttribute('href', 'https://example.com/feature-1-docs');
+
+    const link3 = getByRole('link', { name: 'Submit feedback' });
+    expect(link3).toHaveAttribute('href', 'mailto:feature2-feedback@example.com');
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-196

### What

- This PR updates the feature preview page with the following changes:
  - Renames the "Submit Feedback" link to "Learn more and provide feedback" for features with articles:
    - Improved Spend Reports
    - Autogenerate data table for single and paired end sequencing
    - Firecloud UI Feature Migration
    - Workflow Cost Capping
  - Adds a "Go to Workspaces List" link below the table for easier navigation to the workspaces page.

### Why

- To improve user experience by:
  - Encouraging feedback directly on feature articles.
  - Simplifying navigation to workspaces.

### Testing strategy

- Manual Testing: Manually test changes in UI
- Unit Testing: Added tests to validate functionality

<img width="2555" alt="Feature Previews" src="https://github.com/user-attachments/assets/ed67adfd-6ef1-4aa2-a591-b19823b6f572" />

