### PR TITLE
UIE-204 Narrow Ajax Usage pt18

### DIFF
--- a/src/libs/ajax/azure-storage-utils.test.ts
+++ b/src/libs/ajax/azure-storage-utils.test.ts
@@ -1,0 +1,66 @@
+import { partial } from 'src/testing/test-utils';
+
+import { convert, isAzureBlobSasResult } from './azure-storage-utils';
+import { AzureBlobContent, AzureBlobResult, AzurePublicBlobResult } from './AzureStorage';
+
+describe('isAzureBlobSasResult', () => {
+  it('returns true', () => {
+    // Arrange
+    const blob = partial<AzureBlobResult>({
+      azureSasStorageUrl: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/privateFile.txt',
+      textContent: 'data123',
+    });
+
+    // Act
+    const result = isAzureBlobSasResult(blob);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it('returns false', () => {
+    // Arrange
+    const blob = partial<AzurePublicBlobResult>({
+      azureStorageUrl: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/publicFile.txt',
+    });
+
+    // Act
+    const result = isAzureBlobSasResult(blob);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+describe('convert - azureBlobResult', () => {
+  it('converts to AzureBlobContent for private sas url', () => {
+    // Arrange
+    const blob = partial<AzureBlobResult>({
+      azureSasStorageUrl: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/privateFile.txt',
+      textContent: 'data123',
+    });
+
+    // Act
+    const result = convert.azureBlobResult.toAzureBlobContent(blob);
+
+    // Assert
+    expect(result).toEqual({
+      textContent: 'data123',
+      downloadUri: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/privateFile.txt',
+    } satisfies AzureBlobContent);
+  });
+
+  it('converts to AzureBlobContent for public url', () => {
+    // Arrange
+    const blob = partial<AzurePublicBlobResult>({
+      azureStorageUrl: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/publicFile.txt',
+    });
+
+    // Act
+    const result = convert.azureBlobResult.toAzureBlobContent(blob);
+
+    // Assert
+    expect(result).toEqual({
+      downloadUri: 'https://coaexternalstorage.blob.core.windows.net/cromwell/user-inputs/publicFile.txt',
+    } satisfies AzureBlobContent);
+  });
+});

--- a/src/libs/ajax/azure-storage-utils.ts
+++ b/src/libs/ajax/azure-storage-utils.ts
@@ -1,0 +1,17 @@
+import _ from 'lodash/fp';
+import { AzureBlobContent, AzureBlobResult, AzurePublicBlobResult } from 'src/libs/ajax/AzureStorage';
+
+export const isAzureBlobSasResult = (result: AzureBlobResult | AzurePublicBlobResult): result is AzureBlobResult => {
+  return !_.isEmpty((result as AzureBlobResult).azureSasStorageUrl);
+};
+
+export const convert = {
+  azureBlobResult: {
+    toAzureBlobContent: (blobResult: AzureBlobResult | AzurePublicBlobResult): AzureBlobContent => {
+      const isSasBlob = isAzureBlobSasResult(blobResult);
+      const uri = !isSasBlob ? blobResult.azureStorageUrl : blobResult.azureSasStorageUrl;
+      const textContent = !isSasBlob ? undefined : blobResult.textContent;
+      return { textContent, downloadUri: uri };
+    },
+  },
+};

--- a/src/libs/ajax/workflows-app/CromwellApp.ts
+++ b/src/libs/ajax/workflows-app/CromwellApp.ts
@@ -36,12 +36,21 @@ export const CromwellApp = (signal) => ({
       callB: thatCallFqn,
       indexB: thatIndex !== -1 ? thatIndex : undefined,
     };
-    const res = await fetchFromProxy(cromwellUrlRoot)(`api/workflows/v1/callcaching/diff?${qs.stringify(params)}`, _.merge(authOpts(), { signal }));
+    const res = await fetchFromProxy(cromwellUrlRoot)(
+      `api/workflows/v1/callcaching/diff?${qs.stringify(params)}`,
+      _.merge(authOpts(), { signal })
+    );
     return res.json();
   },
   engineStatus: async (cromwellUrlRoot) => {
-    const res = await fetchFromProxy(cromwellUrlRoot)('engine/v1/status', _.mergeAll([authOpts(), { signal, method: 'GET' }]));
+    const res = await fetchFromProxy(cromwellUrlRoot)(
+      'engine/v1/status',
+      _.mergeAll([authOpts(), { signal, method: 'GET' }])
+    );
 
     return res.json();
   },
 });
+
+export type CromwellAppAjaxContract = ReturnType<typeof CromwellApp>;
+export type WorkflowsContract = ReturnType<CromwellAppAjaxContract['workflows']>;

--- a/src/workflows-app/RunDetails.ts
+++ b/src/workflows-app/RunDetails.ts
@@ -3,8 +3,9 @@ import _ from 'lodash';
 import { Fragment, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { collapseStatus, statusType } from 'src/components/job-common';
-import { Ajax } from 'src/libs/ajax';
+import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
+import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
 import Events from 'src/libs/events';
 import { notify } from 'src/libs/notifications';
 import { useCancellation, usePollingEffect } from 'src/libs/react-utils';
@@ -87,7 +88,7 @@ export const BaseRunDetails = (props: RunDetailsProps, _ref): ReactNode => {
    Cached here so we only fetch it once. */
   const [cromwellProxyState, setCromwellProxyState] = useState<CromwellProxyUrlState>();
 
-  /* Workflow metadta, which includes the call objects array, among other things. 
+  /* Workflow metadta, which includes the call objects array, among other things.
   The web request to fetch this data may be slow. */
   const [workflowMetadata, setWorkflowMetadata] = useState<WorkflowMetadata>();
   const [callObjects, setCallObjects] = useState<any[] | undefined>([]);
@@ -162,7 +163,7 @@ export const BaseRunDetails = (props: RunDetailsProps, _ref): ReactNode => {
     if (!workspaceId) return;
     const fetchSasToken = async () => {
       try {
-        const { sas } = await Ajax(signal).AzureStorage.details(workspaceId);
+        const { sas } = await AzureStorage(signal).details(workspaceId);
         setSasToken(sas.token);
       } catch (error) {
         notify('error', 'Error fetching SAS token for workspace.', {
@@ -189,7 +190,7 @@ export const BaseRunDetails = (props: RunDetailsProps, _ref): ReactNode => {
           let failedTasks: any;
           if (metadata?.status?.toLocaleLowerCase() === 'failed') {
             try {
-              failedTasks = await Ajax(signal).CromwellApp.workflows(workflowId).failedTasks(cromwellProxyState.state);
+              failedTasks = await CromwellApp(signal).workflows(workflowId).failedTasks(cromwellProxyState.state);
             } catch (error) {
               // do nothing, failure here means that user may not have access to an updated version of Cromwell
             }
@@ -268,7 +269,7 @@ export const BaseRunDetails = (props: RunDetailsProps, _ref): ReactNode => {
         return undefined;
       }
       if (cromwellProxyState.status === AppProxyUrlStatus.Ready) {
-        return Ajax(signal).CromwellApp.callCacheDiff(cromwellProxyState.state, thisWorkflow, thatWorkflow);
+        return CromwellApp(signal).callCacheDiff(cromwellProxyState.state, thisWorkflow, thatWorkflow);
       }
     },
     [signal, cromwellProxyState]
@@ -280,7 +281,7 @@ export const BaseRunDetails = (props: RunDetailsProps, _ref): ReactNode => {
         return undefined;
       }
       if (cromwellProxyState.status === AppProxyUrlStatus.Ready) {
-        return Ajax(signal).CromwellApp.workflows(wfId).metadata(cromwellProxyState.state, { includeKey, excludeKey });
+        return CromwellApp(signal).workflows(wfId).metadata(cromwellProxyState.state, { includeKey, excludeKey });
       }
     },
     [signal, cromwellProxyState]

--- a/src/workflows-app/SubmissionDetails.js
+++ b/src/workflows-app/SubmissionDetails.js
@@ -4,8 +4,9 @@ import { div, h, h2, h3 } from 'react-hyperscript-helpers';
 import { Link } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
 import { SimpleTabBar } from 'src/components/tabBars';
-import { Ajax } from 'src/libs/ajax';
+import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { useMetricsEvent } from 'src/libs/ajax/metrics/useMetrics';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
@@ -53,7 +54,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
   const loadMethodsData = useCallback(
     async (cbasUrlRoot, methodId, methodVersion) => {
       try {
-        const methodsResponse = await Ajax(signal).Cbas.methods.getById(cbasUrlRoot, methodId, methodVersion);
+        const methodsResponse = await Cbas(signal).methods.getById(cbasUrlRoot, methodId, methodVersion);
         const allMethods = methodsResponse.methods;
         if (allMethods) {
           setMethodsData(allMethods);
@@ -70,7 +71,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
   const loadRuns = useCallback(
     async (cbasUrlRoot) => {
       try {
-        return await Ajax(signal).Cbas.runs.get(cbasUrlRoot, submissionId);
+        return await Cbas(signal).runs.get(cbasUrlRoot, submissionId);
       } catch (error) {
         notify('error', 'Error loading saved workflows', { detail: error instanceof Response ? await error.text() : error });
       }
@@ -90,7 +91,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
   const loadRunSets = useCallback(
     async (cbasUrlRoot) => {
       try {
-        const runSets = await Ajax(signal).Cbas.runSets.get(cbasUrlRoot);
+        const runSets = await Cbas(signal).runSets.get(cbasUrlRoot);
         const newRunSetData = runSets.run_sets.find((runSet) => runSet.run_set_id === submissionId);
         setRunSetData(runSets.run_sets);
         setConfiguredInputDefinition(maybeParseJSON(newRunSetData.input_definition));
@@ -173,7 +174,7 @@ export const BaseSubmissionDetails = ({ name, namespace, workspace, submissionId
 
   useOnMount(() => {
     const fetchSasToken = async () => {
-      const { sas } = await Ajax(signal).AzureStorage.details(workspaceId);
+      const { sas } = await AzureStorage(signal).details(workspaceId);
       setSasToken(sas.token);
     };
 

--- a/src/workflows-app/SubmissionDetails.test.ts
+++ b/src/workflows-app/SubmissionDetails.test.ts
@@ -5,9 +5,21 @@ import { h } from 'react-hyperscript-helpers';
 import { useDirectoriesInDirectory, useFilesInDirectory } from 'src/components/file-browser/file-browser-hooks';
 import FileBrowser from 'src/components/file-browser/FileBrowser';
 import FilesTable from 'src/components/file-browser/FilesTable';
-import { Ajax } from 'src/libs/ajax';
+import {
+  AzureBlobByUriContract,
+  AzureBlobResult,
+  AzureStorage,
+  AzureStorageContract,
+  SasInfo,
+  StorageDetails,
+} from 'src/libs/ajax/AzureStorage';
+import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
+import { Apps, AppsAjaxContract } from 'src/libs/ajax/leonardo/Apps';
+import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { Cbas, CbasAjaxContract } from 'src/libs/ajax/workflows-app/Cbas';
+import { CromwellApp, CromwellAppAjaxContract, WorkflowsContract } from 'src/libs/ajax/workflows-app/CromwellApp';
 import { getLink } from 'src/libs/nav';
-import { asMockedFn, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
+import { asMockedFn, MockedFn, partial, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { metadata as runDetailsMetadata } from 'src/workflows-app/fixtures/test-workflow';
 import { BaseSubmissionDetails } from 'src/workflows-app/SubmissionDetails';
 import {
@@ -32,49 +44,92 @@ const cbasUrlRoot = 'https://lz-abc/terra-app-abc/cbas';
 const cromwellUrlRoot = 'https://lz-abc/terra-app-abc/cromwell';
 const wdsUrlRoot = 'https://lz-abc/wds-abc-c07807929cd1/';
 
+const defaultSasToken = '1234-this-is-a-mock-sas-token-5678';
+const defaultBlobResult: AzureBlobResult = {
+  uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
+  sasToken: defaultSasToken,
+  fileName: 'inputFile.txt',
+  name: 'inputFile.txt',
+  workspaceId: 'user-inputs',
+  lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
+  size: '324',
+  textContent: 'this is the text of a mock file',
+  azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
+};
+
 // Necessary to mock the AJAX module.
-jest.mock('src/libs/ajax');
-jest.mock('src/libs/notifications');
+jest.mock('src/libs/ajax/AzureStorage');
 jest.mock('src/libs/ajax/leonardo/Apps');
-jest.mock('src/libs/nav', () => ({
-  getCurrentUrl: jest.fn().mockReturnValue(new URL('https://app.terra.bio')),
-  getLink: jest.fn(),
-  goToPath: jest.fn(),
-}));
-jest.mock('src/libs/state', () => ({
-  ...jest.requireActual('src/libs/state'),
-  getTerraUser: jest.fn(),
-}));
+jest.mock('src/libs/ajax/workflows-app/Cbas');
+jest.mock('src/libs/ajax/workflows-app/CromwellApp');
+jest.mock('src/libs/ajax/Metrics');
+
+jest.mock('src/libs/notifications');
+
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    getCurrentUrl: jest.fn(() => new URL('https://app.terra.bio')),
+    getLink: jest.fn(),
+    goToPath: jest.fn(),
+  })
+);
+
+type StateExports = typeof import('src/libs/state');
+jest.mock(
+  'src/libs/state',
+  (): StateExports => ({
+    ...jest.requireActual<StateExports>('src/libs/state'),
+    getTerraUser: jest.fn(),
+  })
+);
+
 // Mocking feature preview setup
-jest.mock('src/libs/feature-previews', () => ({
-  ...jest.requireActual('src/libs/feature-previews'),
-  isFeaturePreviewEnabled: jest.fn(),
-}));
+type FeaturePreviewsExports = typeof import('src/libs/feature-previews');
+jest.mock(
+  'src/libs/feature-previews',
+  (): FeaturePreviewsExports => ({
+    ...jest.requireActual<FeaturePreviewsExports>('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn(),
+  })
+);
 
-jest.mock('src/libs/config', () => ({
-  ...jest.requireActual('src/libs/config'),
-  getConfig: jest.fn().mockReturnValue({ cbasUrlRoot, cromwellUrlRoot, wdsUrlRoot }),
-}));
+type ConfigExports = typeof import('src/libs/config');
+jest.mock(
+  'src/libs/config',
+  (): ConfigExports => ({
+    ...jest.requireActual<ConfigExports>('src/libs/config'),
+    getConfig: jest.fn(() => ({ cbasUrlRoot, cromwellUrlRoot, wdsUrlRoot })),
+  })
+);
 
-jest.mock('src/components/file-browser/file-browser-hooks', () => ({
-  ...jest.requireActual('src/components/file-browser/file-browser-hooks'),
-  useDirectoriesInDirectory: jest.fn(),
-  useFilesInDirectory: jest.fn(),
-}));
+type FileBrowserHooksExports = typeof import('src/components/file-browser/file-browser-hooks');
+jest.mock(
+  'src/components/file-browser/file-browser-hooks',
+  (): FileBrowserHooksExports => ({
+    ...jest.requireActual<FileBrowserHooksExports>('src/components/file-browser/file-browser-hooks'),
+    useDirectoriesInDirectory: jest.fn(),
+    useFilesInDirectory: jest.fn(),
+  })
+);
 
-jest.mock('src/components/file-browser/FilesTable', () => {
+type FilesTableExports = typeof import('src/components/file-browser/FilesTable') & { __esModule: true };
+jest.mock('src/components/file-browser/FilesTable', (): FilesTableExports => {
   const { div } = jest.requireActual('react-hyperscript-helpers');
   return {
-    ...jest.requireActual('src/components/file-browser/FilesTable'),
+    ...jest.requireActual<FilesTableExports>('src/components/file-browser/FilesTable'),
     __esModule: true,
-    default: jest.fn().mockReturnValue(div()),
+    default: jest.fn(() => div()),
   };
 });
 
 // The test does not allot space for the table on the input/output modal, so this mock
 // creates space for the table thereby allowing it to render and preventing test failures.
+type ReactVirtualizedExports = typeof import('react-virtualized');
 jest.mock('react-virtualized', () => {
-  const actual = jest.requireActual('react-virtualized');
+  const actual = jest.requireActual<ReactVirtualizedExports>('react-virtualized');
 
   const { AutoSizer } = actual;
   class MockAutoSizer extends AutoSizer {
@@ -92,7 +147,46 @@ jest.mock('react-virtualized', () => {
   };
 });
 
-const captureEvent = jest.fn();
+const captureEvent: MockedFn<MetricsContract['captureEvent']> = jest.fn();
+
+interface MockCbasArgs {
+  getRuns?: MockedFn<CbasAjaxContract['runs']['get']>;
+  getRunsSets?: MockedFn<CbasAjaxContract['runSets']['get']>;
+  getMethods?: MockedFn<CbasAjaxContract['methods']['getById']>;
+}
+const mockCbas = (fns: MockCbasArgs) => {
+  asMockedFn(Cbas).mockReturnValue(
+    partial<CbasAjaxContract>({
+      runs: {
+        get: fns.getRuns || jest.fn(),
+      },
+      runSets: partial<CbasAjaxContract['runSets']>({
+        get: fns.getRunsSets || jest.fn(),
+      }),
+      methods: partial<CbasAjaxContract['methods']>({
+        getById: fns.getMethods || jest.fn(),
+      }),
+    })
+  );
+};
+
+interface MockCbasWithArgs {
+  runs?: Awaited<ReturnType<Required<MockCbasArgs>['getRuns']>>;
+  runSets?: Awaited<ReturnType<Required<MockCbasArgs>['getRunsSets']>>;
+  methods?: Awaited<ReturnType<Required<MockCbasArgs>['getMethods']>>;
+}
+
+const mockCbasWith = (results: MockCbasWithArgs): Required<MockCbasArgs> => {
+  const { runs, runSets, methods } = results;
+  const args: Required<MockCbasArgs> = {
+    getRuns: runs ? jest.fn(async (_root, _id) => runs) : jest.fn(),
+    getRunsSets: runSets ? jest.fn(async (_root) => runSets) : jest.fn(),
+    getMethods: methods ? jest.fn(async (_root, _id) => methods) : jest.fn(),
+  };
+  mockCbas(args);
+
+  return args;
+};
 
 describe('Submission Details page', () => {
   beforeEach(() => {
@@ -102,59 +196,41 @@ describe('Submission Details page', () => {
     // (see https://github.com/bvaughn/react-virtualized/issues/493 and https://stackoverflow.com/a/62214834)
     Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { configurable: true, value: 1000 });
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { configurable: true, value: 800 });
+
+    // arrange ajax data call defaults
+    asMockedFn(Apps).mockReturnValue(
+      partial<AppsAjaxContract>({
+        listAppsV2: jest.fn(async () => mockAzureApps as any),
+      })
+    );
+    asMockedFn(CromwellApp).mockReturnValue(
+      partial<CromwellAppAjaxContract>({
+        workflows: () => partial<WorkflowsContract>({ metadata: jest.fn(async () => runDetailsMetadata) }),
+      })
+    );
+    asMockedFn(AzureStorage).mockReturnValue(
+      partial<AzureStorageContract>({
+        blobByUri: jest.fn(() =>
+          partial<AzureBlobByUriContract>({
+            getMetadataAndTextContent: async () => defaultBlobResult,
+          })
+        ),
+        details: jest.fn(async () =>
+          partial<StorageDetails>({
+            sas: partial<SasInfo>({ token: defaultSasToken }),
+          })
+        ),
+      })
+    );
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent }));
   });
 
   it('should correctly display previous 2 runs', async () => {
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    // Arrange
+    const { getRuns, getRunsSets, getMethods } = mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -206,48 +282,18 @@ describe('Submission Details page', () => {
   });
 
   it('should correctly display Queued runs', async () => {
-    const getRuns = jest.fn(() => Promise.resolve(mockQueuedRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(queuedRunSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockCollaborativeAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    // Arrange
+    const { getRuns, getRunsSets, getMethods } = mockCbasWith({
+      runs: mockQueuedRunsData,
+      runSets: queuedRunSetData,
+      methods: methodData,
     });
+
+    asMockedFn(Apps).mockReturnValue(
+      partial<AppsAjaxContract>({
+        listAppsV2: jest.fn(async () => mockCollaborativeAzureApps as any),
+      })
+    );
 
     // Act
     await act(async () => {
@@ -300,56 +346,11 @@ describe('Submission Details page', () => {
   });
 
   it('should display standard message when there are no saved workflows', async () => {
-    const getRuns = jest.fn(() => Promise.resolve([]));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    // Arrange
+    const { getRuns, getRunsSets, getMethods } = mockCbasWith({
+      runs: [],
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -379,50 +380,10 @@ describe('Submission Details page', () => {
   });
 
   it('should sort by duration column properly', async () => {
+    // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
-    });
+
+    mockCbasWith({ runs: mockRunsData });
 
     // Act
     await act(async () => {
@@ -484,53 +445,12 @@ describe('Submission Details page', () => {
   });
 
   it('display run set details', async () => {
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    const { getRunsSets, getMethods } = mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
+
     // Act
     await act(async () => {
       render(
@@ -569,53 +489,12 @@ describe('Submission Details page', () => {
   });
 
   it('should correctly select and change results', async () => {
+    // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    const { getRuns, getRunsSets, getMethods } = mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -664,6 +543,7 @@ describe('Submission Details page', () => {
   });
 
   it('should correctly display a very recently started run', async () => {
+    // Arrange
     const recentRunsData = {
       runs: [
         {
@@ -682,46 +562,7 @@ describe('Submission Details page', () => {
         },
       ],
     };
-
-    const getRecentRunsMethod = jest.fn(() => Promise.resolve(recentRunsData));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRecentRunsMethod,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
-    });
+    mockCbasWith({ runs: recentRunsData });
 
     // Act
     await act(async () => {
@@ -760,6 +601,7 @@ describe('Submission Details page', () => {
   });
 
   it('should correctly display a run with undefined engine id', async () => {
+    // Arrange
     const recentRunsData = {
       runs: [
         {
@@ -778,37 +620,7 @@ describe('Submission Details page', () => {
         },
       ],
     };
-
-    const getRecentRunsMethod = jest.fn(() => Promise.resolve(recentRunsData));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRecentRunsMethod,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
-    });
+    mockCbasWith({ runs: recentRunsData });
 
     // Act
     await act(async () => {
@@ -847,45 +659,8 @@ describe('Submission Details page', () => {
   });
 
   it('should indicate fully updated polls', async () => {
-    const getRecentRunsMethod = jest.fn(() => Promise.resolve(simpleRunsData));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRecentRunsMethod,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
-    });
+    // Arrange
+    mockCbasWith({ runs: simpleRunsData });
 
     // Act
     await act(async () => {
@@ -903,45 +678,9 @@ describe('Submission Details page', () => {
   });
 
   it('should indicate incompletely updated polls', async () => {
-    const getRecentRunsMethod = jest.fn(() => Promise.resolve(_.merge(simpleRunsData, { fully_updated: false })));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRecentRunsMethod,
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
-    });
+    // Arrange
+    const updatedRunsData = _.merge(simpleRunsData, { fully_updated: false });
+    mockCbasWith({ runs: updatedRunsData });
 
     // Act
     await act(async () => {
@@ -955,62 +694,18 @@ describe('Submission Details page', () => {
       );
     });
 
-    expect(screen.getByText('Some workflow statuses are not up to date. Refreshing the page may update more statuses.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some workflow statuses are not up to date. Refreshing the page may update more statuses.')
+    ).toBeInTheDocument();
   });
 
   it('should display inputs on the Inputs tab', async () => {
     // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -1055,56 +750,10 @@ describe('Submission Details page', () => {
   it('Inputs tab handles literal values', async () => {
     // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetDataWithLiteral));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetDataWithLiteral,
+      methods: methodData,
     });
 
     // Act
@@ -1139,62 +788,16 @@ describe('Submission Details page', () => {
   });
 
   it('should display outputs on the Outputs tab', async () => {
+    // Arrange
     // Add output definition to temporary runset data variable
     const tempRunSetData = runSetData;
     tempRunSetData.run_sets[0].output_definition = runSetResponse.run_sets[0].output_definition;
 
-    // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(tempRunSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        Metrics: {
-          captureEvent,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: tempRunSetData,
+      methods: methodData,
     });
 
     // Act
@@ -1242,56 +845,10 @@ describe('Submission Details page', () => {
   it('should open the log viewer modal when Execution Logs button is clicked', async () => {
     // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-        Metrics: {
-          captureEvent,
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -1327,56 +884,10 @@ describe('Submission Details page', () => {
   it('should open the task data modal when Inputs button is clicked', async () => {
     // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-        Metrics: {
-          captureEvent,
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -1420,56 +931,10 @@ describe('Submission Details page', () => {
   it('should open the task data modal when Outputs button is clicked', async () => {
     // Arrange
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-        Metrics: {
-          captureEvent,
-        },
-      };
+    mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
 
     // Act
@@ -1521,57 +986,29 @@ describe('Submission Details page', () => {
 
   it('should generate the correect link when clicking on a workflow ID', async () => {
     const user = userEvent.setup();
-    const getRuns = jest.fn(() => Promise.resolve(mockRunsData));
-    const getRunsSets = jest.fn(() => Promise.resolve(runSetData));
-    const getMethods = jest.fn(() => Promise.resolve(methodData));
-    const mockLeoResponse = jest.fn(() => Promise.resolve(mockAzureApps));
-    Ajax.mockImplementation(() => {
-      return {
-        Cbas: {
-          runs: {
-            get: getRuns,
-          },
-          runSets: {
-            get: getRunsSets,
-          },
-          methods: {
-            getById: getMethods,
-          },
-        },
-        Apps: {
-          listAppsV2: mockLeoResponse,
-        },
-        CromwellApp: {
-          workflows: () => {
-            return {
-              metadata: jest.fn(() => {
-                return Promise.resolve(runDetailsMetadata);
-              }),
-            };
-          },
-        },
-        Metrics: {
-          captureEvent,
-        },
-        AzureStorage: {
-          blobByUri: jest.fn(() => ({
-            getMetadataAndTextContent: () =>
-              Promise.resolve({
-                uri: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-                sasToken: '1234-this-is-a-mock-sas-token-5678',
-                fileName: 'inputFile.txt',
-                name: 'inputFile.txt',
-                lastModified: 'Mon, 22 May 2023 17:12:58 GMT',
-                size: '324',
-                contentType: 'text/plain',
-                textContent: 'this is the text of a mock file terra-app-123456',
-                azureSasStorageUrl: 'https://someBlobFilePath.blob.core.windows.net/cromwell/user-inputs/inputFile.txt',
-              }),
-          })),
-          details: jest.fn().mockResolvedValue({ sas: { token: '1234-this-is-a-mock-sas-token-5678' } }),
-        },
-      };
+    const { getRuns, getRunsSets, getMethods } = mockCbasWith({
+      runs: mockRunsData,
+      runSets: runSetData,
+      methods: methodData,
     });
+
+    asMockedFn(AzureStorage).mockReturnValue(
+      partial<AzureStorageContract>({
+        blobByUri: jest.fn(() =>
+          partial<AzureBlobByUriContract>({
+            getMetadataAndTextContent: async () => ({
+              ...defaultBlobResult,
+              textContent: 'this is the text of a mock file terra-app-123456',
+            }),
+          })
+        ),
+        details: jest.fn(async () =>
+          partial<StorageDetails>({
+            sas: partial<SasInfo>({ token: defaultSasToken }),
+          })
+        ),
+      })
+    );
 
     // Act
     await act(async () => {
@@ -1602,7 +1039,7 @@ describe('Submission Details page', () => {
 
   it('navigates to a sub-directory of the root', () => {
     // Arrange
-    const mockFileBrowserProvider = {};
+    const mockFileBrowserProvider = partial<FileBrowserProvider>({});
     const directories = [
       {
         path: 'workspace-services/cbas/terra-app-/fetch_sra_to_bam/d16721eb-8745-4aa2-b71e-9ade2d6575aa/folder/',
@@ -1627,7 +1064,7 @@ describe('Submission Details page', () => {
       reload: () => Promise.resolve(),
     };
 
-    const useFilesInDirectoryResult = {
+    const useFilesInDirectoryResult: ReturnType<typeof useFilesInDirectory> = {
       state: { files, status: 'Ready' },
       hasNextPage: false,
       loadNextPage: () => Promise.resolve(),

--- a/src/workflows-app/SubmissionDetails.test.ts
+++ b/src/workflows-app/SubmissionDetails.test.ts
@@ -1058,7 +1058,7 @@ describe('Submission Details page', () => {
       },
     ];
 
-    const useDirectoriesInDirectoryResult = {
+    const useDirectoriesInDirectoryResult: ReturnType<typeof useDirectoriesInDirectory> = {
       state: { directories, status: 'Ready' },
       hasNextPage: false,
       loadNextPage: () => Promise.resolve(),

--- a/src/workflows-app/SubmissionDetails.test.ts
+++ b/src/workflows-app/SubmissionDetails.test.ts
@@ -200,6 +200,7 @@ describe('Submission Details page', () => {
     // arrange ajax data call defaults
     asMockedFn(Apps).mockReturnValue(
       partial<AppsAjaxContract>({
+        // TODO: remove any type: mockAzureApps type does not match what lsitAppsV2 actually returns
         listAppsV2: jest.fn(async () => mockAzureApps as any),
       })
     );
@@ -291,6 +292,7 @@ describe('Submission Details page', () => {
 
     asMockedFn(Apps).mockReturnValue(
       partial<AppsAjaxContract>({
+        // TODO: remove any type: mockCollaborativeAzureApps type does not match what lsitAppsV2 actually returns
         listAppsV2: jest.fn(async () => mockCollaborativeAzureApps as any),
       })
     );

--- a/src/workflows-app/components/FilterableWorkflowTable.ts
+++ b/src/workflows-app/components/FilterableWorkflowTable.ts
@@ -7,7 +7,8 @@ import { ClipboardButton } from 'src/components/ClipboardButton';
 import { ButtonPrimary, Clickable, Link } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { FlexTable, Paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
-import { Ajax } from 'src/libs/ajax';
+import { convert } from 'src/libs/ajax/azure-storage-utils';
+import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { useCancellation } from 'src/libs/react-utils';
@@ -234,9 +235,8 @@ const FilterableWorkflowTable = ({
         return null;
       }
       try {
-        const response = await Ajax(signal).AzureStorage.blobByUri(azureBlobUri).getMetadataAndTextContent();
-        const uri = _.isEmpty(response.azureSasStorageUrl) ? response.azureStorageUrl : response.azureSasStorageUrl;
-        return { textContent: response.textContent, downloadUri: uri };
+        const response = await AzureStorage(signal).blobByUri(azureBlobUri).getMetadataAndTextContent();
+        return convert.azureBlobResult.toAzureBlobContent(response);
       } catch (e) {
         return null;
       }


### PR DESCRIPTION
- narrowed Ajax() usage within more of src/workflows-app area to call Ajax().SubAreaX directly.
- updated some of shared components and related tests.
- improved mock types where possible.
- light Typescript conversions to assist in safer code udpates.
- minor improvements to AzureStorage to remove duplicate code.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
