### PR TITLE
[AN-149] Rename 'namespace' to 'collection' & update feature preview section

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -97,12 +97,13 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
   },
   {
     id: FIRECLOUD_UI_MIGRATION,
-    title: 'Firecloud UI Feature Migration',
-    description: 'Enabling this feature will update replaceable links to Firecloud UI with new links to Terra UI',
-    feedbackUrl: `mailto:dsp-workflow-management@broadinstitute.org?subject=${encodeURIComponent(
-      'Feedback on deprecating Firecloud UI'
+    title: 'Terra Workflow Repository Improvements',
+    description:
+      "Enabling this feature will gives users access to the new Terra Workflow Repository UI. This replaces the Broad Methods Repository UI (and doesn't affect any workflows previously created).",
+    feedbackUrl: `mailto:dsp-analysis@broadinstitute.org?subject=${encodeURIComponent(
+      'Feedback on Terra Workflow Repository Improvements'
     )}`,
-    lastUpdated: '3/22/2024',
+    lastUpdated: '1/7/2025',
     articleUrl: 'https://support.terra.bio/hc/en-us/articles/31191238873243',
   },
   {

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -99,7 +99,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     id: FIRECLOUD_UI_MIGRATION,
     title: 'Terra Workflow Repository Improvements',
     description:
-      "Enabling this feature will gives users access to the new Terra Workflow Repository UI. This replaces the Broad Methods Repository UI (and doesn't affect any workflows previously created).",
+      'Enabling this feature will allow creating and editing workflows with the built-in Terra Workflow Repository UI. This replaces the external Broad Methods Repository. Changes made in Terra are reflected in the external Broad Methods Repository, and vice-versa.',
     feedbackUrl: `mailto:dsp-analysis@broadinstitute.org?subject=${encodeURIComponent(
       'Feedback on Terra Workflow Repository Improvements'
     )}`,

--- a/src/pages/workflows/WorkflowList.test.tsx
+++ b/src/pages/workflows/WorkflowList.test.tsx
@@ -262,7 +262,7 @@ describe('workflows table', () => {
     expect(methodCells[4]).toHaveTextContent('1');
   });
 
-  it('allows editing permissions for namespace owned by user', async () => {
+  it('allows editing permissions for collection owned by user', async () => {
     // Arrange
     asMockedFn(Methods).mockReturnValue(mockMethods([revaliMethod]));
     const user: UserEvent = userEvent.setup();
@@ -291,14 +291,14 @@ describe('workflows table', () => {
     await user.click(actionsMenu);
 
     // Assert
-    expect(screen.getByText('Edit namespace permissions'));
+    expect(screen.getByText('Edit collection permissions'));
 
     // Act
-    await user.click(screen.getByRole('button', { name: 'Edit namespace permissions' }));
+    await user.click(screen.getByRole('button', { name: 'Edit collection permissions' }));
 
     // Assert
     expect(
-      screen.queryByRole('dialog', { name: /Edit permissions for namespace revali bird namespace/i })
+      screen.queryByRole('dialog', { name: /Edit permissions for collection revali bird namespace/i })
     ).toBeInTheDocument();
   });
 
@@ -960,8 +960,8 @@ describe('create workflow modal', () => {
     expect(within(createWorkflowModal).getByText('Create New Workflow')).toBeInTheDocument();
     expect(within(createWorkflowModal).getByRole('button', { name: 'Upload' })).toBeInTheDocument();
 
-    expect(within(createWorkflowModal).getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('');
-    expect(within(createWorkflowModal).getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('');
+    expect(within(createWorkflowModal).getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('');
+    expect(within(createWorkflowModal).getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue('');
     expect(within(createWorkflowModal).getByTestId('wdl editor')).toHaveDisplayValue('');
     expect(within(createWorkflowModal).getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('');
     expect(
@@ -985,8 +985,10 @@ describe('create workflow modal', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create New Workflow' }));
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), { target: { value: 'testnamespace' } });
-    fireEvent.change(screen.getByRole('textbox', { name: 'Name *' }), { target: { value: 'testname' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), {
+      target: { value: 'testnamespace' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name *' }), { target: { value: 'testname' } });
     fireEvent.change(screen.getByTestId('wdl editor'), { target: { value: 'workflow hi {}' } });
     fireEvent.change(screen.getByRole('textbox', { name: 'Documentation' }), { target: { value: 'docs' } });
     fireEvent.change(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' }), {

--- a/src/pages/workflows/WorkflowList.tsx
+++ b/src/pages/workflows/WorkflowList.tsx
@@ -89,6 +89,15 @@ interface WorkflowListProps {
   };
 }
 
+/**
+ * Note: During the migration and release of the new Terra Workflow Repository UI, some terminology changes were
+ *       introduced. As a result, certain terms in the UI may differ from those used in the code. Below are the
+ *       terms in this component that have been renamed (or is referred as) specifically for user-facing purposes:
+ *          method    -> workflow
+ *          namespace -> collection
+ *          name      -> workflow name
+ *          snapshot  -> version
+ */
 // TODO: consider wrapping query updates in useEffect
 export const WorkflowList = (props: WorkflowListProps) => {
   const { queryParams = {} } = props;

--- a/src/pages/workflows/WorkflowList.tsx
+++ b/src/pages/workflows/WorkflowList.tsx
@@ -285,7 +285,7 @@ export const WorkflowList = (props: WorkflowListProps) => {
         </div>
         {editNamespacePermissionsModalOpen && (
           <PermissionsModal
-            versionOrNamespace='Namespace'
+            versionOrCollection='Collection'
             namespace={namespacePermissionsToEdit}
             setPermissionsModalOpen={setEditNamespacePermissionsModalOpen}
             refresh={() => {}} // there is no need to refresh the page as permissions are always fetched when opening PermissionsModal
@@ -347,7 +347,7 @@ const getColumns = (
             content={
               <MenuButton tooltipSide='right' onClick={() => onEditNamespacePermissions(namespace)}>
                 {makeMenuIcon('edit')}
-                Edit namespace permissions
+                Edit collection permissions
               </MenuButton>
             }
           >

--- a/src/pages/workflows/workflow-details/WorkflowSummary.ts
+++ b/src/pages/workflows/workflow-details/WorkflowSummary.ts
@@ -16,6 +16,14 @@ import { wrapWorkflows } from 'src/pages/workflows/workflow-details/WorkflowWrap
 import { WorkflowRightBoxSection } from 'src/workflows/WorkflowRightBoxSection';
 import { InfoRow } from 'src/workspaces/dashboard/InfoRow';
 
+/**
+ * Note: During the migration and release of the new Terra Workflow Repository UI, some terminology changes were
+ *       introduced. As a result, certain terms in the UI may differ from those used in the code. Below are few
+ *       terms in this component that have been renamed (or is referred as) specifically for user-facing purposes:
+ *          namespace -> collection
+ *          name      -> workflow name
+ *          snapshot  -> version
+ */
 export const BaseWorkflowSummary = () => {
   const {
     namespace,

--- a/src/pages/workflows/workflow-details/WorkflowWrapper.test.tsx
+++ b/src/pages/workflows/workflow-details/WorkflowWrapper.test.tsx
@@ -465,8 +465,8 @@ describe('workflows container', () => {
 
     // Assert
     expect(dialog).toBeInTheDocument();
-    expect(within(dialog).getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('');
-    expect(within(dialog).getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('testname_copy');
+    expect(within(dialog).getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('');
+    expect(within(dialog).getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue('testname_copy');
     expect(within(dialog).getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('mock documentation');
     expect(within(dialog).getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('');
     expect(within(dialog).getByRole('textbox', { name: 'Version comment' })).toHaveDisplayValue('');
@@ -500,15 +500,15 @@ describe('workflows container', () => {
 
     // Assert
     expect(dialog).toBeInTheDocument();
-    expect(within(dialog).getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('');
-    expect(within(dialog).getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('testname_copy');
+    expect(within(dialog).getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('');
+    expect(within(dialog).getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue('testname_copy');
     expect(within(dialog).getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('mock documentation');
     expect(within(dialog).getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('');
     expect(within(dialog).getByRole('textbox', { name: 'Version comment' })).toHaveDisplayValue('');
     expect(within(dialog).getByTestId('wdl editor')).toHaveDisplayValue(mockSnapshot.payload.toString());
 
     // Act
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), {
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), {
       target: { value: 'groot-new-namespace' },
     });
     fireEvent.change(screen.getByRole('textbox', { name: 'Version comment' }), {
@@ -599,10 +599,13 @@ describe('workflows container', () => {
 
     // Assert
     expect(dialog).toBeInTheDocument();
-    expect(within(dialog).getByRole('textbox', { name: 'Namespace' })).toHaveAttribute('placeholder', 'testnamespace');
-    expect(within(dialog).getByRole('textbox', { name: 'Namespace' })).toHaveAttribute('disabled');
-    expect(within(dialog).getByRole('textbox', { name: 'Name' })).toHaveAttribute('placeholder', 'testname');
-    expect(within(dialog).getByRole('textbox', { name: 'Name' })).toHaveAttribute('disabled');
+    expect(within(dialog).getByRole('textbox', { name: 'Collection name' })).toHaveAttribute(
+      'placeholder',
+      'testnamespace'
+    );
+    expect(within(dialog).getByRole('textbox', { name: 'Collection name' })).toHaveAttribute('disabled');
+    expect(within(dialog).getByRole('textbox', { name: 'Workflow name' })).toHaveAttribute('placeholder', 'testname');
+    expect(within(dialog).getByRole('textbox', { name: 'Workflow name' })).toHaveAttribute('disabled');
     expect(within(dialog).getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('mock documentation');
     expect(within(dialog).getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('');
     expect(within(dialog).getByRole('textbox', { name: 'Version comment' })).toHaveDisplayValue('');

--- a/src/pages/workflows/workflow-details/WorkflowWrapper.ts
+++ b/src/pages/workflows/workflow-details/WorkflowWrapper.ts
@@ -291,7 +291,7 @@ export const WorkflowsContainer = (props: WorkflowContainerProps) => {
       }),
     permissionsModalOpen &&
       h(PermissionsModal, {
-        versionOrNamespace: 'Version',
+        versionOrCollection: 'Version',
         namespace,
         setPermissionsModalOpen,
         refresh: loadSnapshot,

--- a/src/pages/workflows/workflow-details/WorkflowWrapper.ts
+++ b/src/pages/workflows/workflow-details/WorkflowWrapper.ts
@@ -58,6 +58,15 @@ interface NotFoundMessageProps {
 
 type WrappedWorkflowComponent = (props: WrappedComponentProps) => ReactNode;
 
+/**
+ * Note: During the migration and release of the new Terra Workflow Repository UI, some terminology changes were
+ *       introduced. As a result, certain terms in the UI may differ from those used in the code. Below are the
+ *       terms in this component that have been renamed (or is referred as) specifically for user-facing purposes:
+ *          method    -> workflow
+ *          namespace -> collection
+ *          name      -> workflow name
+ *          snapshot  -> version
+ */
 export const wrapWorkflows = (opts: WrapWorkflowOptions) => {
   const { breadcrumbs, activeTab } = opts;
   return (WrappedComponent: WrappedWorkflowComponent) => {

--- a/src/workflows/modals/CreateWorkflowModal.test.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.test.tsx
@@ -61,8 +61,8 @@ describe('CreateWorkflowModal', () => {
 
     // Assert
     expect(screen.getByText('Create New Workflow'));
-    expect(screen.getByText('Namespace *'));
-    expect(screen.getByText('Name *'));
+    expect(screen.getByText('Collection name *'));
+    expect(screen.getByText('Workflow name *'));
     expect(screen.getByText('WDL *'));
     expect(screen.getByRole('button', { name: 'Load WDL from file' }));
     expect(screen.getByText('Documentation'));
@@ -71,8 +71,8 @@ describe('CreateWorkflowModal', () => {
     expect(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.getByRole('button', { name: 'Upload' }));
 
-    expect(screen.getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('');
-    expect(screen.getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('');
+    expect(screen.getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('');
+    expect(screen.getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue('');
     expect(screen.getByTestId('wdl editor')).toHaveDisplayValue('');
     expect(screen.getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('');
     expect(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('');
@@ -102,11 +102,11 @@ describe('CreateWorkflowModal', () => {
     // Act
 
     // errors only need to appear after the inputs have been modified
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), { target: { value: 'n' } });
-    fireEvent.change(screen.getByRole('textbox', { name: 'Name *' }), { target: { value: 'n' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), { target: { value: 'n' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name *' }), { target: { value: 'n' } });
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), { target: { value: '' } });
-    fireEvent.change(screen.getByRole('textbox', { name: 'Name *' }), { target: { value: '' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), { target: { value: '' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name *' }), { target: { value: '' } });
 
     // Assert
 
@@ -114,8 +114,8 @@ describe('CreateWorkflowModal', () => {
     // the error messages shown in the modal (under the inputs and in the
     // button tooltip) do not easily correspond to those found by the testing
     // framework
-    expect(screen.getAllByText("Namespace can't be blank"));
-    expect(screen.getAllByText("Name can't be blank"));
+    expect(screen.getAllByText("Collection name can't be blank"));
+    expect(screen.getAllByText("Workflow name can't be blank"));
 
     expect(uploadButton).toHaveAttribute('aria-disabled', 'true');
   });
@@ -145,8 +145,8 @@ describe('CreateWorkflowModal', () => {
     // the error messages shown in the modal (under the inputs and in the
     // button tooltip) do not easily correspond to those found by the testing
     // framework
-    expect(screen.getAllByText('Namespace can only contain letters, numbers, underscores, dashes, and periods'));
-    expect(screen.getAllByText('Name can only contain letters, numbers, underscores, dashes, and periods'));
+    expect(screen.getAllByText('Collection name can only contain letters, numbers, underscores, dashes, and periods'));
+    expect(screen.getAllByText('Workflow name can only contain letters, numbers, underscores, dashes, and periods'));
 
     expect(uploadButton).toHaveAttribute('aria-disabled', 'true');
   });
@@ -179,7 +179,7 @@ describe('CreateWorkflowModal', () => {
     // the error messages shown in the modal (under the inputs and in the
     // button tooltip) do not easily correspond to those found by the testing
     // framework
-    expect(screen.getAllByText('Namespace and name are too long (maximum is 250 characters total)'));
+    expect(screen.getAllByText('Collection and workflow name are too long (maximum is 250 characters total)'));
 
     expect(uploadButton).toHaveAttribute('aria-disabled', 'true');
   });
@@ -305,8 +305,8 @@ describe('CreateWorkflowModal', () => {
       );
     });
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), { target: { value: 'newnamespace' } });
-    fireEvent.change(screen.getByRole('textbox', { name: 'Name *' }), { target: { value: 'newname' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), { target: { value: 'newnamespace' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Workflow name *' }), { target: { value: 'newname' } });
     fireEvent.change(screen.getByTestId('wdl editor'), { target: { value: 'workflow new {}' } });
     fireEvent.change(screen.getByRole('textbox', { name: 'Documentation' }), { target: { value: 'new docs' } });
     fireEvent.change(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' }), {
@@ -356,8 +356,8 @@ describe('CreateWorkflowModal', () => {
     });
 
     // Assert
-    expect(screen.getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('testnamespace');
-    expect(screen.getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('testname');
+    expect(screen.getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('testnamespace');
+    expect(screen.getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue('testname');
     expect(screen.getByTestId('wdl editor')).toHaveDisplayValue('workflow hi {}');
     expect(screen.getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('test docs');
     expect(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('test synopsis');
@@ -502,8 +502,10 @@ describe('CreateWorkflowModal', () => {
     });
 
     // Assert
-    expect(screen.getByRole('textbox', { name: 'Namespace *' })).toHaveDisplayValue('');
-    expect(screen.getByRole('textbox', { name: 'Name *' })).toHaveDisplayValue('groot-scientific-workflow_copy');
+    expect(screen.getByRole('textbox', { name: 'Collection name *' })).toHaveDisplayValue('');
+    expect(screen.getByRole('textbox', { name: 'Workflow name *' })).toHaveDisplayValue(
+      'groot-scientific-workflow_copy'
+    );
     expect(screen.getByTestId('wdl editor')).toHaveDisplayValue('workflow do-great-stuff {}');
     expect(screen.getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('I am Groot');
     expect(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('I am Groot');
@@ -515,7 +517,7 @@ describe('CreateWorkflowModal', () => {
     expect(cloneMethodButton).toHaveAttribute('aria-disabled', 'true');
 
     // user enters value for 'Namespace' text box
-    fireEvent.change(screen.getByRole('textbox', { name: 'Namespace *' }), {
+    fireEvent.change(screen.getByRole('textbox', { name: 'Collection name *' }), {
       target: { value: 'groot-test-namespace' },
     });
     // user enters value for 'Version comment' text box

--- a/src/workflows/modals/CreateWorkflowModal.test.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.test.tsx
@@ -179,7 +179,7 @@ describe('CreateWorkflowModal', () => {
     // the error messages shown in the modal (under the inputs and in the
     // button tooltip) do not easily correspond to those found by the testing
     // framework
-    expect(screen.getAllByText('Collection and workflow name are too long (maximum is 250 characters total)'));
+    expect(screen.getAllByText('Collection and workflow names are too long (maximum is 250 characters total)'));
 
     expect(uploadButton).toHaveAttribute('aria-disabled', 'true');
   });

--- a/src/workflows/modals/CreateWorkflowModal.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.tsx
@@ -50,7 +50,7 @@ validate.validators.maxNamespaceNameCombinedLength = <OtherFieldName extends str
   attributes: Record<OtherFieldName, string>
 ): string | null =>
   value.length + attributes[options.otherField].length > 250
-    ? '^Collection and workflow name are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
+    ? '^Collection and workflow names are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
     : null;
 
 const createWorkflowModalConstraints = {

--- a/src/workflows/modals/CreateWorkflowModal.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.tsx
@@ -50,7 +50,7 @@ validate.validators.maxNamespaceNameCombinedLength = <OtherFieldName extends str
   attributes: Record<OtherFieldName, string>
 ): string | null =>
   value.length + attributes[options.otherField].length > 250
-    ? '^Collection name and workflow name are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
+    ? '^Collection and workflow name are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
     : null;
 
 const createWorkflowModalConstraints = {
@@ -98,7 +98,7 @@ const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
       <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
         <div style={{ marginBottom: '0.1667em' }}>
           <FormLabel htmlFor={namespaceInputId} required>
-            Collection Name
+            Collection name
           </FormLabel>
           <ValidatedInput
             inputProps={{
@@ -117,7 +117,7 @@ const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
       <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
         <div style={{ marginBottom: '0.1667em' }}>
           <FormLabel htmlFor={nameInputId} required>
-            Workflow Name
+            Workflow name
           </FormLabel>
           <ValidatedInput
             inputProps={{
@@ -137,7 +137,7 @@ const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
 };
 
 /**
- * Component for inputting workflow information to facilitate creating new workflow or cloning a workflow version.
+ * Component for inputting workflow information to facilitate creating new workflow or cloning a workflow snapshot.
  */
 export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
   const {
@@ -165,7 +165,7 @@ export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
 
   const validationErrors = validate({ namespace, name, synopsis, wdl }, createWorkflowModalConstraints, {
     prettify: (v) =>
-      ({ namespace: 'Collection Name', name: 'Workflow Name', synopsis: 'Synopsis', wdl: 'WDL' }[v] ||
+      ({ namespace: 'Collection name', name: 'Workflow name', synopsis: 'Synopsis', wdl: 'WDL' }[v] ||
       validate.prettify(v)),
   });
 

--- a/src/workflows/modals/CreateWorkflowModal.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.tsx
@@ -50,7 +50,7 @@ validate.validators.maxNamespaceNameCombinedLength = <OtherFieldName extends str
   attributes: Record<OtherFieldName, string>
 ): string | null =>
   value.length + attributes[options.otherField].length > 250
-    ? '^Namespace and name are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
+    ? '^Collection name and workflow name are too long (maximum is 250 characters total)' // ^ character prevents attribute from being prepended
     : null;
 
 const createWorkflowModalConstraints = {
@@ -77,7 +77,7 @@ const createWorkflowModalConstraints = {
   },
 };
 
-interface NamespaceNameSectionProps {
+interface CollectionAndNameSectionProps {
   namespace: string | undefined;
   name: string | undefined;
   setWorkflowNamespace: (value: string) => void;
@@ -85,7 +85,7 @@ interface NamespaceNameSectionProps {
   errors: any;
 }
 
-const NamespaceNameSection = (props: NamespaceNameSectionProps) => {
+const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
   const { namespace, name, setWorkflowNamespace, setWorkflowName, errors } = props;
   const [namespaceModified, setNamespaceModified] = useState<boolean>(false);
   const [nameModified, setNameModified] = useState<boolean>(false);
@@ -98,7 +98,7 @@ const NamespaceNameSection = (props: NamespaceNameSectionProps) => {
       <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
         <div style={{ marginBottom: '0.1667em' }}>
           <FormLabel htmlFor={namespaceInputId} required>
-            Namespace
+            Collection Name
           </FormLabel>
           <ValidatedInput
             inputProps={{
@@ -117,7 +117,7 @@ const NamespaceNameSection = (props: NamespaceNameSectionProps) => {
       <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
         <div style={{ marginBottom: '0.1667em' }}>
           <FormLabel htmlFor={nameInputId} required>
-            Name
+            Workflow Name
           </FormLabel>
           <ValidatedInput
             inputProps={{
@@ -137,7 +137,7 @@ const NamespaceNameSection = (props: NamespaceNameSectionProps) => {
 };
 
 /**
- * Component for inputting workflow information to facilitate creating new workflow or cloning a workflow snapshot.
+ * Component for inputting workflow information to facilitate creating new workflow or cloning a workflow version.
  */
 export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
   const {
@@ -165,7 +165,8 @@ export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
 
   const validationErrors = validate({ namespace, name, synopsis, wdl }, createWorkflowModalConstraints, {
     prettify: (v) =>
-      ({ namespace: 'Namespace', name: 'Name', synopsis: 'Synopsis', wdl: 'WDL' }[v] || validate.prettify(v)),
+      ({ namespace: 'Collection Name', name: 'Workflow Name', synopsis: 'Synopsis', wdl: 'WDL' }[v] ||
+      validate.prettify(v)),
   });
 
   const onSubmitWorkflow = withBusyState(setBusy, async () => {
@@ -190,7 +191,7 @@ export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
     >
       <div style={{ padding: '0.5rem 0' }}>
         <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: '16px' }}>
-          <NamespaceNameSection
+          <CollectionAndNameSection
             namespace={namespace}
             name={name}
             setWorkflowNamespace={setNamespace}

--- a/src/workflows/modals/CreateWorkflowModal.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.tsx
@@ -77,7 +77,7 @@ const createWorkflowModalConstraints = {
   },
 };
 
-interface CollectionAndNameSectionProps {
+interface CollectionAndWfNameSectionProps {
   namespace: string | undefined;
   name: string | undefined;
   setWorkflowNamespace: (value: string) => void;
@@ -85,7 +85,7 @@ interface CollectionAndNameSectionProps {
   errors: any;
 }
 
-const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
+const CollectionAndWfNameSection = (props: CollectionAndWfNameSectionProps) => {
   const { namespace, name, setWorkflowNamespace, setWorkflowName, errors } = props;
   const [namespaceModified, setNamespaceModified] = useState<boolean>(false);
   const [nameModified, setNameModified] = useState<boolean>(false);
@@ -138,6 +138,13 @@ const CollectionAndNameSection = (props: CollectionAndNameSectionProps) => {
 
 /**
  * Component for inputting workflow information to facilitate creating new workflow or cloning a workflow snapshot.
+ * Note: During the migration and release of the new Terra Workflow Repository UI, some terminology changes were
+ *       introduced. As a result, certain terms in the UI may differ from those used in the code. Below are the
+ *       terms in this component that have been renamed (or is referred as) specifically for user-facing purposes:
+ *          method    -> workflow
+ *          namespace -> collection
+ *          name      -> workflow name
+ *          snapshot  -> version
  */
 export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
   const {
@@ -191,7 +198,7 @@ export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
     >
       <div style={{ padding: '0.5rem 0' }}>
         <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: '16px' }}>
-          <CollectionAndNameSection
+          <CollectionAndWfNameSection
             namespace={namespace}
             name={name}
             setWorkflowNamespace={setNamespace}

--- a/src/workflows/modals/EditWorkflowModal.test.tsx
+++ b/src/workflows/modals/EditWorkflowModal.test.tsx
@@ -66,10 +66,10 @@ describe('EditWorkflowModal', () => {
 
     // Assert
     expect(screen.getByText('Edit'));
-    expect(screen.getByRole('textbox', { name: 'Namespace' })).toHaveAttribute('placeholder', 'my-namespace');
-    expect(screen.getByRole('textbox', { name: 'Namespace' })).toHaveAttribute('disabled');
-    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveAttribute('placeholder', 'my-workflow');
-    expect(screen.getByRole('textbox', { name: 'Name' })).toHaveAttribute('disabled');
+    expect(screen.getByRole('textbox', { name: 'Collection name' })).toHaveAttribute('placeholder', 'my-namespace');
+    expect(screen.getByRole('textbox', { name: 'Collection name' })).toHaveAttribute('disabled');
+    expect(screen.getByRole('textbox', { name: 'Workflow name' })).toHaveAttribute('placeholder', 'my-workflow');
+    expect(screen.getByRole('textbox', { name: 'Workflow name' })).toHaveAttribute('disabled');
     expect(screen.getByTestId('wdl editor')).toHaveDisplayValue('workflow doStuff {}');
     expect(screen.getByRole('textbox', { name: 'Documentation' })).toHaveDisplayValue('documentation');
     expect(screen.getByRole('textbox', { name: 'Synopsis (80 characters max)' })).toHaveDisplayValue('synopsis');

--- a/src/workflows/modals/EditWorkflowModal.tsx
+++ b/src/workflows/modals/EditWorkflowModal.tsx
@@ -109,13 +109,13 @@ export const EditWorkflowModal = (props: EditWorkflowModalProps) => {
         <div style={{ display: 'flex', alignItems: 'flex-end', flexWrap: 'wrap', gap: '16px' }}>
           <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
             <div style={{ marginBottom: '0.1667em' }}>
-              <FormLabel htmlFor={namespaceInputId}>Namespace</FormLabel>
+              <FormLabel htmlFor={namespaceInputId}>Collection name</FormLabel>
               <TextInput id={namespaceInputId} placeholder={namespace} disabled />
             </div>
           </div>
           <div style={{ flexWrap: 'wrap', flexGrow: 1, flexBasis: '400px' }}>
             <div style={{ marginBottom: '0.1667em' }}>
-              <FormLabel htmlFor={nameInputId}>Name</FormLabel>
+              <FormLabel htmlFor={nameInputId}>Workflow name</FormLabel>
               <TextInput id={nameInputId} placeholder={name} disabled />
             </div>
           </div>

--- a/src/workflows/modals/PermissionsModal.test.tsx
+++ b/src/workflows/modals/PermissionsModal.test.tsx
@@ -82,7 +82,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -109,7 +109,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='my-namespace'
-          versionOrNamespace='Namespace'
+          versionOrCollection='Collection'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -118,7 +118,7 @@ describe('PermissionsModal', () => {
     });
 
     // ASSERT
-    expect(screen.getByText('Edit permissions for namespace my-namespace'));
+    expect(screen.getByText('Edit permissions for collection my-namespace'));
     expect(screen.getByText('Note: Sharing with user groups is not supported.'));
     expect(screen.getByText('User'));
     expect(screen.getByRole('textbox', { name: 'User' }));
@@ -137,7 +137,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -172,7 +172,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -219,7 +219,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -257,7 +257,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -280,7 +280,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -309,7 +309,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -351,7 +351,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={mockProvider}
@@ -387,7 +387,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={jest.fn()}
           refresh={jest.fn()}
           permissionsProvider={permissionsProviderSuccess}
@@ -426,7 +426,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={mockSetPermissionsModalOpen}
           refresh={mockRefresh}
           permissionsProvider={permissionsProviderSuccess}
@@ -453,7 +453,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={mockSetPermissionsModalOpen}
           refresh={mockRefresh}
           permissionsProvider={permissionsProviderSuccess}
@@ -478,7 +478,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={mockSetPermissionsModalOpen}
           refresh={mockRefresh}
           permissionsProvider={permissionsProviderError}
@@ -501,7 +501,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Namespace'
+          versionOrCollection='Collection'
           setPermissionsModalOpen={mockSetPermissionsModalOpen}
           refresh={mockRefresh}
           permissionsProvider={permissionsProviderForbidden}
@@ -510,7 +510,7 @@ describe('PermissionsModal', () => {
     });
 
     // ASSERT
-    expect(screen.getByText('You do not have permissions to edit namespace settings.')).toBeInTheDocument();
+    expect(screen.getByText('You do not have permissions to edit collection settings.')).toBeInTheDocument();
   });
 
   it('displays an error popup and closes the modal if there is an error saving permissions', async () => {
@@ -524,7 +524,7 @@ describe('PermissionsModal', () => {
       renderWithAppContexts(
         <PermissionsModal
           namespace='namespace'
-          versionOrNamespace='Version'
+          versionOrCollection='Version'
           setPermissionsModalOpen={mockSetPermissionsModalOpen}
           refresh={mockRefresh}
           permissionsProvider={permissionsProviderError}

--- a/src/workflows/modals/PermissionsModal.tsx
+++ b/src/workflows/modals/PermissionsModal.tsx
@@ -165,6 +165,14 @@ const CurrentUsers = (props: CurrentUsersProps) => {
   );
 };
 
+/**
+ * Component for editing version or collection permissions.
+ * Note: During the migration and release of the new Terra Workflow Repository UI, some terminology changes were
+ *       introduced. As a result, certain terms in the UI may differ from those used in the code. Below are few
+ *       terms in this component that have been renamed (or is referred as) specifically for user-facing purposes:
+ *          namespace -> collection
+ *          snapshot  -> version
+ */
 export const PermissionsModal = (props: WorkflowPermissionsModalProps) => {
   const { versionOrCollection, namespace, setPermissionsModalOpen, refresh, permissionsProvider } = props;
   const signal: AbortSignal = useCancellation();

--- a/src/workflows/modals/PermissionsModal.tsx
+++ b/src/workflows/modals/PermissionsModal.tsx
@@ -31,7 +31,7 @@ import {
 import validate from 'validate.js';
 
 type WorkflowPermissionsModalProps = {
-  versionOrNamespace: 'Version' | 'Namespace';
+  versionOrCollection: 'Version' | 'Collection';
   namespace: string;
   setPermissionsModalOpen: (b: boolean) => void;
   refresh: () => void;
@@ -166,7 +166,7 @@ const CurrentUsers = (props: CurrentUsersProps) => {
 };
 
 export const PermissionsModal = (props: WorkflowPermissionsModalProps) => {
-  const { versionOrNamespace, namespace, setPermissionsModalOpen, refresh, permissionsProvider } = props;
+  const { versionOrCollection, namespace, setPermissionsModalOpen, refresh, permissionsProvider } = props;
   const signal: AbortSignal = useCancellation();
   const [searchValue, setSearchValue] = useState<string>('');
   const [permissions, setPermissions] = useState<WorkflowsPermissions>([]);
@@ -238,11 +238,11 @@ export const PermissionsModal = (props: WorkflowPermissionsModalProps) => {
   });
 
   const modalTitle =
-    versionOrNamespace === 'Version' ? 'Edit version permissions' : `Edit permissions for namespace ${namespace}`;
+    versionOrCollection === 'Version' ? 'Edit version permissions' : `Edit permissions for collection ${namespace}`;
   const noEditPermissionsMsg =
-    versionOrNamespace === 'Version'
+    versionOrCollection === 'Version'
       ? 'You do not have permissions to edit version settings.'
-      : 'You do not have permissions to edit namespace settings.';
+      : 'You do not have permissions to edit collection settings.';
 
   return (
     <Modal title={modalTitle} onDismiss={() => setPermissionsModalOpen(false)} width='600px' showButtons={false} showX>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-149
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- renames `namespace` to `collection`: I have updated only the component names and user-facing instances to `collection`
- updates the feature preview section to align with what is in Roadmap

### Why
- better terminology

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] manual testing
- [x] updated unit tests

### Visual Aids
Feature Preview change
![Screenshot 2025-01-07 at 1 56 43 PM](https://github.com/user-attachments/assets/befc340c-71ba-4c02-bb66-454a8190a49c)

Namespace -> Collection renaming
![Screenshot 2025-01-07 at 1 57 10 PM](https://github.com/user-attachments/assets/a910694e-d156-42ae-a59b-7cf02aba9702)

![Screenshot 2025-01-07 at 1 57 34 PM](https://github.com/user-attachments/assets/f915d3d0-2e74-40f6-9ed4-42a129dd5b9b)

![Screenshot 2025-01-07 at 1 57 55 PM](https://github.com/user-attachments/assets/109feb3a-1cbe-4e51-8a5a-899218d37a8c)

