### PR TITLE
UIE-204 Narrow Ajax Usage pt20

### DIFF
--- a/src/libs/ajax/workflows-app/Cbas.ts
+++ b/src/libs/ajax/workflows-app/Cbas.ts
@@ -106,4 +106,5 @@ export const Cbas = (signal?: AbortSignal) => ({
 });
 
 export type CbasAjaxContract = ReturnType<typeof Cbas>;
+export type CbasRunSetsContract = CbasAjaxContract['runSets'];
 export type CbasMethodsContract = CbasAjaxContract['methods'];

--- a/src/workflows-app/SubmissionConfig.js
+++ b/src/workflows-app/SubmissionConfig.js
@@ -6,7 +6,9 @@ import { ButtonPrimary, Link, Select } from 'src/components/common';
 import { centeredSpinner, icon } from 'src/components/icons';
 import { InfoBox } from 'src/components/InfoBox';
 import StepButtons from 'src/components/StepButtons';
-import { Ajax } from 'src/libs/ajax';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
+import { WorkflowScript } from 'src/libs/ajax/workflows-app/WorkflowScript';
+import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
@@ -72,7 +74,7 @@ export const BaseSubmissionConfig = (
   const loadRecordsData = useCallback(
     async (recordType, wdsUrlRoot, searchLimit) => {
       try {
-        const searchResult = await Ajax(signal).WorkspaceData.queryRecords(wdsUrlRoot, workspaceId, recordType, searchLimit);
+        const searchResult = await WorkspaceData(signal).queryRecords(wdsUrlRoot, workspaceId, recordType, searchLimit);
         setRecords(searchResult.records);
         setTotalRecordsInActualDataTable(searchResult.totalRecords);
       } catch (error) {
@@ -89,7 +91,7 @@ export const BaseSubmissionConfig = (
   const loadMethodsData = useCallback(
     async (cbasUrlRoot, methodId, methodVersionId) => {
       try {
-        const methodsResponse = await Ajax(signal).Cbas.methods.getById(cbasUrlRoot, methodId);
+        const methodsResponse = await Cbas(signal).methods.getById(cbasUrlRoot, methodId);
         const method = methodsResponse.methods[0];
         if (method) {
           const selectedVersion = _.filter((mv) => mv.method_version_id === methodVersionId, method.method_versions)[0];
@@ -109,7 +111,7 @@ export const BaseSubmissionConfig = (
   const loadRunSet = useCallback(
     async (cbasUrlRoot) => {
       try {
-        const runSet = await Ajax(signal).Cbas.runSets.getForMethod(cbasUrlRoot, methodId, 1);
+        const runSet = await Cbas(signal).runSets.getForMethod(cbasUrlRoot, methodId, 1);
         const newRunSetData = runSet.run_sets[0];
 
         setConfiguredInputDefinition(maybeParseJSON(newRunSetData.input_definition));
@@ -132,7 +134,7 @@ export const BaseSubmissionConfig = (
   const loadCbasSubmissionLimits = useCallback(
     async (cbasUrlRoot) => {
       try {
-        const capabilities = await Ajax(signal).Cbas.capabilities(cbasUrlRoot);
+        const capabilities = await Cbas(signal).capabilities(cbasUrlRoot);
         if (capabilities) {
           const newCapabilities = {
             maxWorkflows: capabilities['submission.limits.maxWorkflows']
@@ -158,7 +160,7 @@ export const BaseSubmissionConfig = (
   const loadRecordTypes = useCallback(
     async (wdsUrlRoot) => {
       try {
-        setRecordTypes(await Ajax(signal).WorkspaceData.describeAllRecordTypes(wdsUrlRoot, workspaceId));
+        setRecordTypes(await WorkspaceData(signal).describeAllRecordTypes(wdsUrlRoot, workspaceId));
       } catch (error) {
         notify('error', 'Error loading data types', { detail: error instanceof Response ? await error.text() : error });
       }
@@ -304,7 +306,7 @@ export const BaseSubmissionConfig = (
       try {
         if (!method.isPrivate) {
           const workflowUrlRaw = await convertToRawUrl(selectedMethodVersion.url, selectedMethodVersion.name, method.source);
-          const script = await Ajax(signal).WorkflowScript.get(workflowUrlRaw);
+          const script = await WorkflowScript(signal).get(workflowUrlRaw);
           setWorkflowScript(script);
         }
       } catch (error) {

--- a/src/workflows-app/SubmissionHistory.js
+++ b/src/workflows-app/SubmissionHistory.js
@@ -7,7 +7,8 @@ import { centeredSpinner, icon } from 'src/components/icons';
 import { MenuButton } from 'src/components/MenuButton';
 import { MenuTrigger } from 'src/components/PopupTrigger';
 import { FlexTable, Paginator, Sortable, tableHeight, TextCell } from 'src/components/table';
-import { Ajax } from 'src/libs/ajax';
+import { User } from 'src/libs/ajax/User';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
@@ -45,7 +46,7 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
   const loadRunSets = useCallback(
     async (cbasUrlRoot) => {
       try {
-        const runSets = await Ajax(signal).Cbas.runSets.get(cbasUrlRoot);
+        const runSets = await Cbas(signal).runSets.get(cbasUrlRoot);
         const durationEnhancedRunSets = _.map(
           (r) => _.merge(r, { duration: getDuration(r.state, r.submission_timestamp, r.last_modified_timestamp, isRunSetInTerminalState) }),
           runSets.run_sets
@@ -112,7 +113,7 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
 
   const cancelRunSet = async (submissionId) => {
     try {
-      await Ajax(signal).Cbas.runSets.cancel(workflowsAppStore.get().cbasProxyUrlState.state, submissionId);
+      await Cbas(signal).runSets.cancel(workflowsAppStore.get().cbasProxyUrlState.state, submissionId);
       notify('success', 'Abort submission request submitted successfully', {
         message: 'You may refresh the page to get most recent status changes.',
         timeout: 5000,
@@ -148,8 +149,8 @@ export const BaseSubmissionHistory = ({ namespace, workspace }, _ref) => {
       }
     };
     loadWorkflowsApp();
-    Ajax()
-      .User.getStatus()
+    User()
+      .getStatus()
       .then((res) => setUserId(res.userSubjectId));
     refresh();
 

--- a/src/workflows-app/SubmitWorkflow.js
+++ b/src/workflows-app/SubmitWorkflow.js
@@ -3,7 +3,8 @@ import { div, h } from 'react-hyperscript-helpers';
 import { doesWorkspaceSupportCromwellAppForUser, generateAppName, getCurrentApp, getIsAppBusy } from 'src/analysis/utils/app-utils';
 import { appAccessScopes, appToolLabels, appTools } from 'src/analysis/utils/tool-utils';
 import { centeredSpinner } from 'src/components/icons';
-import { Ajax } from 'src/libs/ajax';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { reportError } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation, usePollingEffect } from 'src/libs/react-utils';
@@ -95,14 +96,9 @@ export const SubmitWorkflow = wrapWorkflowsPage({ name: 'SubmitWorkflow' })(
     const createWorkflowsApp = Utils.withBusyState(setCreating, async () => {
       try {
         setCreating(true);
-        await Ajax().Apps.createAppV2(
-          generateAppName(),
-          workspace.workspace.workspaceId,
-          appToolLabels.WORKFLOWS_APP,
-          appAccessScopes.WORKSPACE_SHARED
-        );
+        await Apps().createAppV2(generateAppName(), workspace.workspace.workspaceId, appToolLabels.WORKFLOWS_APP, appAccessScopes.WORKSPACE_SHARED);
 
-        await Ajax(signal).Metrics.captureEvent(Events.applicationCreate, {
+        await Metrics(signal).captureEvent(Events.applicationCreate, {
           app: appTools.CROMWELL.label,
           ...extractWorkspaceDetails(workspace),
         });

--- a/src/workflows-app/status/workflows-status.ts
+++ b/src/workflows-app/status/workflows-status.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { getCurrentApp } from 'src/analysis/utils/app-utils';
-import { Ajax } from 'src/libs/ajax';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
+import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
 import { useCallback } from 'use-memo-one';
 
 type UseWorkflowsStatusArgs = {
@@ -111,8 +113,8 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
     }
 
     await Promise.allSettled([
-      Ajax(signal)
-        .Cbas.status(cbasProxyUrl)
+      Cbas(signal)
+        .status(cbasProxyUrl)
         .then((statusResponse) => {
           setStatus((previouStatus) => ({
             ...previouStatus,
@@ -134,8 +136,8 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
           }));
         }),
 
-      Ajax(signal)
-        .CromwellApp.engineStatus(cromwellReaderProxyUrl)
+      CromwellApp(signal)
+        .engineStatus(cromwellReaderProxyUrl)
         .then((statusResponse) => {
           setStatus((previousStatus) => ({
             ...previousStatus,
@@ -187,8 +189,8 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
     }
 
     await Promise.allSettled([
-      Ajax(signal)
-        .CromwellApp.engineStatus(cromwellRunnerProxyUrl)
+      CromwellApp(signal)
+        .engineStatus(cromwellRunnerProxyUrl)
         .then((statusResponse) => {
           setStatus((previousStatus) => ({
             ...previousStatus,
@@ -215,7 +217,7 @@ export const useWorkflowsStatus = ({ workspaceId }: UseWorkflowsStatusArgs) => {
 
     let listAppsResponse: ListAppItem[];
     try {
-      listAppsResponse = await Ajax(signal).Apps.listAppsV2(workspaceId);
+      listAppsResponse = await Apps(signal).listAppsV2(workspaceId);
     } catch (err) {
       setStatus({
         totalVisibleApps: 'unknown',

--- a/src/workflows-app/utils/app-utils.js
+++ b/src/workflows-app/utils/app-utils.js
@@ -1,8 +1,8 @@
 import { icon } from '@terra-ui-packages/components';
 import { div } from 'react-hyperscript-helpers';
 import { appToolLabels } from 'src/analysis/utils/tool-utils';
-import { Ajax } from 'src/libs/ajax';
 import { resolveWdsUrl } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { getConfig } from 'src/libs/config';
 import * as Nav from 'src/libs/nav';
 import { AppProxyUrlStatus, getTerraUser, workflowsAppStore } from 'src/libs/state';
@@ -80,7 +80,7 @@ const fetchAppUrlsFromLeo = async (workspaceId, wdsUrlRoot, cbasUrlRoot, cromwel
   let cromwellProxyUrlState;
 
   try {
-    const appsList = await Ajax().Apps.listAppsV2(workspaceId);
+    const appsList = await Apps().listAppsV2(workspaceId);
     wdsProxyUrlState = resolveProxyUrl(wdsUrlRoot, appsList, (appsList) => resolveWdsUrl(appsList));
     cbasProxyUrlState = resolveProxyUrl(cbasUrlRoot, appsList, (appsList) => resolveRunningCromwellAppUrl(appsList, getTerraUser()?.email).cbasUrl);
     cromwellProxyUrlState = resolveProxyUrl(

--- a/src/workflows-app/utils/cromwell-metadata-utils.ts
+++ b/src/workflows-app/utils/cromwell-metadata-utils.ts
@@ -1,4 +1,4 @@
-import { Ajax } from 'src/libs/ajax';
+import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
 
 export interface WorkflowMetadata {
   actualWorkflowLanguage?: string;
@@ -39,7 +39,7 @@ export type MetadataOptions = {
 };
 
 export const fetchMetadata = async (options: MetadataOptions): Promise<WorkflowMetadata> =>
-  Ajax(options.signal).CromwellApp.workflows(options.workflowId).metadata(options.cromwellProxyUrl, {
+  CromwellApp(options.signal).workflows(options.workflowId).metadata(options.cromwellProxyUrl, {
     includeKey: options.includeKeys,
     excludeKey: options.excludeKeys,
     expandSubWorkflows: options.expandSubWorkflows,

--- a/src/workflows-app/utils/method-common.js
+++ b/src/workflows-app/utils/method-common.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp';
-import { Ajax } from 'src/libs/ajax';
+import { Dockstore } from 'src/libs/ajax/Dockstore';
+import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
 import { notify } from 'src/libs/notifications';
 import { workflowsAppStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -27,7 +28,7 @@ export const submitMethod = async (signal, method, workspace, onSuccess, onError
         method_version: method.method_version,
         method_url: method.method_url,
       };
-      const methodObject = await Ajax(signal).Cbas.methods.post(workflowsAppStore.get().cbasProxyUrlState.state, methodPayload);
+      const methodObject = await Cbas(signal).methods.post(workflowsAppStore.get().cbasProxyUrlState.state, methodPayload);
 
       onSuccess(methodObject);
     } catch (error) {
@@ -60,7 +61,7 @@ export const convertToRawUrl = (methodPath, methodVersion, methodSource) => {
     ],
     [
       methodSource.toLowerCase() === MethodSource.Dockstore.toLowerCase(),
-      async () => await Ajax().Dockstore.getWorkflowSourceUrl(methodPath, methodVersion),
+      async () => await Dockstore().getWorkflowSourceUrl(methodPath, methodVersion),
     ],
     () => {
       throw new Error(

--- a/src/workflows-app/utils/task-log-utils.ts
+++ b/src/workflows-app/utils/task-log-utils.ts
@@ -1,4 +1,4 @@
-import { Ajax } from 'src/libs/ajax';
+import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { LogInfo } from 'src/workflows-app/components/LogViewer';
 
 export const LogTooltips = {
@@ -113,7 +113,7 @@ export const discoverTesLogs = async (signal, workspaceId: string, tesLogBlobPat
   }
 
   // we're not entirely sure which logs will exist in blob storage, so we fetch all files in the directory of the template TES log and search for the files we want.
-  const allFilesInTesDirectory = await Ajax(signal).AzureStorage.listFiles(
+  const allFilesInTesDirectory = await AzureStorage(signal).listFiles(
     workspaceId,
     parseFullFilepathToContainerDirectory(workspaceId, tesLogBlobPath)
   );


### PR DESCRIPTION
- narrowed Ajax() usage within last of src/workflows-app area to call Ajax().SubAreaX directly.
- improved mock types where possible.
- light Typescript conversions to assist in safer code udpates.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
