### PR TITLE
CORE-259: better error message on support page

### DIFF
--- a/src/support/SupportSummary.tsx
+++ b/src/support/SupportSummary.tsx
@@ -39,7 +39,7 @@ export const SupportSummary = (props: ResourceTypeSummaryProps) => {
           } else if (e instanceof Response && e.status === 403) {
             setErrorMessage(`You do not have permission to view ${displayName} summary information or are not on VPN`);
           } else {
-            await reportError('Error loading group summary', e);
+            await reportError(`Error loading ${displayName} summary`, e);
           }
         }
       }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-259

## Summary of changes:

Fixes the error message on the support page. Previously, the error message always said "Error loading group summary", even if you weren't attempting to load a group. Now, the error message is type-specific.