### PR TITLE
[AN-369] Show "Terra Workflow Repository" behind feature flag

### DIFF
--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -152,13 +152,13 @@ export const WorkflowsLibrary = () => {
                     logoFilePath={dockstoreLogo}
                   />
                 </div>
-                {
-                  // TODO: Change over to Terra workflow repo
-                  // Update `title` to 'Terra Workflow Repository'
-                }
                 <div style={{ marginLeft: 20 }}>
                   <WorkflowSourceBox
-                    title='Broad Methods Repository'
+                    title={
+                      isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION)
+                        ? 'Terra Workflow Repository'
+                        : 'Broad Methods Repository'
+                    }
                     description='A repository of WDL workflows that offers quick hosting of public and private workflows.'
                     url={workflowsRepoUrl}
                     logoFilePath={terraLogo}

--- a/src/pages/workspaces/workspace/Workflows.test.ts
+++ b/src/pages/workspaces/workspace/Workflows.test.ts
@@ -130,7 +130,7 @@ describe('Find Workflow modal in Workflows view', () => {
     expect(within(findWorkflowModal).getByText('Find a workflow')).toBeInTheDocument();
     // Dockstore and Broad Methods Repo cards
     expect(within(findWorkflowModal).getByText('Dockstore.org')).toBeInTheDocument();
-    expect(within(findWorkflowModal).getByText('Terra Workflow Repository')).toBeInTheDocument();
+    expect(within(findWorkflowModal).getByText('Broad Methods Repository')).toBeInTheDocument();
     // curated workflows section
     expect(within(findWorkflowModal).getByText('GATK Best Practices')).toBeInTheDocument();
     expect(within(findWorkflowModal).getByText('Long Read Pipelines')).toBeInTheDocument();

--- a/src/pages/workspaces/workspace/modals/FindWorkflowModal.test.tsx
+++ b/src/pages/workspaces/workspace/modals/FindWorkflowModal.test.tsx
@@ -17,7 +17,7 @@ describe('FindWorkflowModal', () => {
     expect(screen.getByLabelText('Close modal')).toBeInTheDocument();
     // Dockstore and Broad Methods Repo cards
     expect(screen.getByText('Dockstore.org')).toBeInTheDocument();
-    expect(screen.getByText('Terra Workflow Repository')).toBeInTheDocument();
+    expect(screen.getByText('Broad Methods Repository')).toBeInTheDocument();
     // curated workflows section
     expect(screen.getByText('GATK Best Practices')).toBeInTheDocument();
     expect(screen.getByText('Long Read Pipelines')).toBeInTheDocument();

--- a/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
+++ b/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
@@ -87,7 +87,9 @@ export const FindWorkflowModal = (props: FindWorkflowModalProps) => {
         </div>
         <div style={{ flex: 1, marginLeft: 20 }}>
           <WorkflowSourceCard
-            title='Terra Workflow Repository'
+            title={
+              isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION) ? 'Terra Workflow Repository' : 'Broad Methods Repository'
+            }
             description='A repository of WDL workflows that offers private workflows hosted in the platform.'
             url={workflowsRepoUrl}
             openInNewTab={false}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-369

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- The name "Terra Workflow Repository" should only be shown if feature flag is enabled 

### Why
- for consistency

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] manual testing

### Visual Aids
Feature flag "Terra Workflow Repository Improvements" turned **OFF**

Workflows Library
![Screenshot 2025-01-16 at 3 57 52 PM](https://github.com/user-attachments/assets/3abb1e54-5ddd-43f7-85e8-fb7dc465360a)

Find Workflow modal
![Screenshot 2025-01-16 at 3 57 32 PM](https://github.com/user-attachments/assets/5ab4c8f5-567c-49f0-900d-3a6c4dfc3779)

------

Feature flag "Terra Workflow Repository Improvements" turned **ON**

Workflows Library
![Screenshot 2025-01-16 at 3 58 24 PM](https://github.com/user-attachments/assets/eafac93c-a5a7-4efb-9bbb-be64823525eb)

Find Workflow modal
![Screenshot 2025-01-16 at 3 58 54 PM](https://github.com/user-attachments/assets/99217b0a-fbe6-40f1-ad0d-04896bebc801)
