### PR TITLE
[AN-293] Add https://cdn.jsdelivr.net to BEE CSP allowlist

### DIFF
--- a/nginx-bees.conf
+++ b/nginx-bees.conf
@@ -23,7 +23,7 @@ server {
     }
 
     location / {
-        add_header Content-Security-Policy "base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' https://fast.appcues.com https://cdnjs.cloudflare.com; style-src * 'unsafe-inline'";
+        add_header Content-Security-Policy "base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' https://fast.appcues.com https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src * 'unsafe-inline'";
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
         add_header X-Content-Type-Options "nosniff";
         add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-293

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds the url `https://cdn.jsdelivr.net` to BEE CSP allowlist

### Why
- Will allow the WDL editor in the new port of the firecloud UI to function correctly, Currently it stalls with the following error:

> appLoader-DKcx3lwg.js:980 Refused to load the script 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js' because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' https://fast.appcues.com https://cdnjs.cloudflare.com". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
