### PR TITLE
UIE-204 Narrow Ajax Usage pt21

### DIFF
--- a/src/billing/ConsolidatedSpendReport.tsx
+++ b/src/billing/ConsolidatedSpendReport.tsx
@@ -9,13 +9,13 @@ import { parseCurrencyIfNeeded } from 'src/billing/utils';
 import { BillingProject } from 'src/billing-core/models';
 import { ButtonOutline, fixedSpinnerOverlay } from 'src/components/common';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
-import { Ajax } from 'src/libs/ajax';
 import { Billing } from 'src/libs/ajax/billing/Billing';
 import {
   AggregatedWorkspaceSpendData,
   SpendReport as SpendReportServerResponse,
 } from 'src/libs/ajax/billing/billing-models';
 import { Metrics } from 'src/libs/ajax/Metrics';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import Events, { extractBillingDetails } from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { memoWithName, useCancellation } from 'src/libs/react-utils';
@@ -203,7 +203,7 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
     const startDate = subDays(spendReportLengthInDays, new Date()).toISOString().slice(0, 10);
 
     const fetchWorkspaces = async (signal: AbortSignal): Promise<WorkspaceWrapper[]> => {
-      const fetchedWorkspaces = await Ajax(signal).Workspaces.list(
+      const fetchedWorkspaces = await Workspaces(signal).list(
         [
           'workspace.billingAccount',
           'workspace.bucketName',

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -1,6 +1,5 @@
 import { delay } from '@terra-ui-packages/core-utils';
 import { useEffect, useState } from 'react';
-import { Ajax } from 'src/libs/ajax';
 import { DataRepo, Snapshot } from 'src/libs/ajax/DataRepo';
 import { SamResources } from 'src/libs/ajax/SamResources';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
@@ -77,7 +76,7 @@ const getFileImportRequest = (queryParams: QueryParams, type: FileImportRequest[
  */
 const generateSnapshotManifest = async (snapshotId: string): Promise<URL> => {
   const { id } = await DataRepo().snapshot(snapshotId).exportSnapshot();
-  const jobApi = Ajax().DataRepo.job(id);
+  const jobApi = DataRepo().job(id);
   let jobInfo = await jobApi.details();
   while (jobInfo.job_status === 'running') {
     await delay(1000);

--- a/src/libs/ajax/DataRepo.ts
+++ b/src/libs/ajax/DataRepo.ts
@@ -290,3 +290,5 @@ export const DataRepo = (signal?: AbortSignal): DataRepoContract => ({
     result: async () => callDataRepo(`repository/v1/jobs/${jobId}/result`, signal),
   }),
 });
+
+export type DataRepoSnapshotContract = ReturnType<DataRepoContract['snapshot']>;

--- a/src/libs/ajax/WorkspaceDataService.test.ts
+++ b/src/libs/ajax/WorkspaceDataService.test.ts
@@ -1,5 +1,5 @@
 import { asMockedFn } from '@terra-ui-packages/test-utils';
-import { Ajax } from 'src/libs/ajax';
+import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 
 import { fetchWDS } from './ajax-common';
 
@@ -49,7 +49,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const capabilities = await WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
@@ -63,7 +63,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const capabilities = await WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
@@ -77,7 +77,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const capabilities = await WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
@@ -91,7 +91,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const capabilities = await WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
@@ -105,7 +105,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const capabilities = await Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const capabilities = await WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       expect(fetchWDS).toHaveBeenCalledWith(wdsProxyUrl);
@@ -121,7 +121,7 @@ describe('WorkspaceData', () => {
       });
 
       // Act
-      const act = async () => Ajax().WorkspaceData.getCapabilities(wdsProxyUrl);
+      const act = async () => WorkspaceData().getCapabilities(wdsProxyUrl);
 
       // Assert
       await expect(act()).rejects.toEqual(

--- a/src/libs/analysis.js
+++ b/src/libs/analysis.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import * as Utils from 'src/libs/utils';
 
 export const launch = async ({
@@ -26,8 +26,8 @@ export const launch = async ({
 }) => {
   const createSet = () => {
     onProgress('createSet');
-    return Ajax()
-      .Workspaces.workspace(namespace, name)
+    return Workspaces()
+      .workspace(namespace, name)
       .createEntity({
         name: newSetName,
         entityType: `${selectedEntityType}_set`,
@@ -41,7 +41,7 @@ export const launch = async ({
   };
   onProgress('checkBucketAccess');
   try {
-    await Ajax().Workspaces.workspace(namespace, name).checkBucketAccess(googleProject, bucketName, accessLevel);
+    await Workspaces().workspace(namespace, name).checkBucketAccess(googleProject, bucketName, accessLevel);
   } catch (error) {
     throw new Error(
       'Error confirming workspace bucket access. This may be a transient problem. Please try again in a few minutes. If the problem persists, please contact support.'
@@ -77,8 +77,8 @@ export const launch = async ({
     ]
   );
   onProgress('launch');
-  return Ajax()
-    .Workspaces.workspace(namespace, name)
+  return Workspaces()
+    .workspace(namespace, name)
     .methodConfig(configNamespace, configName)
     .launch({
       entityType: Utils.cond([entityName === undefined, () => undefined], [processSet, () => `${rootEntityType}_set`], () => rootEntityType),

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { useState } from 'react';
-import { Ajax } from 'src/libs/ajax';
+import { Groups } from 'src/libs/ajax/Groups';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { getConfig } from 'src/libs/config';
 import Events from 'src/libs/events';
 import featurePreviewsConfig from 'src/libs/feature-previews-config';
@@ -14,11 +15,11 @@ export const isFeaturePreviewEnabled = (id) => !!getLocalPref(featurePreviewPref
 
 export const toggleFeaturePreview = (id, enabled) => {
   setLocalPref(featurePreviewPreferenceKey(id), enabled);
-  Ajax().Metrics.captureEvent(Events.featurePreviewToggle, { featureId: id, enabled });
+  Metrics().captureEvent(Events.featurePreviewToggle, { featureId: id, enabled });
 };
 
 const getGroups = async ({ signal } = {}) => {
-  const rawGroups = await Ajax(signal).Groups.list();
+  const rawGroups = await Groups(signal).list();
   return _.flow(_.map('groupName'), _.uniq)(rawGroups);
 };
 

--- a/src/libs/feature-previews.js
+++ b/src/libs/feature-previews.js
@@ -15,7 +15,7 @@ export const isFeaturePreviewEnabled = (id) => !!getLocalPref(featurePreviewPref
 
 export const toggleFeaturePreview = (id, enabled) => {
   setLocalPref(featurePreviewPreferenceKey(id), enabled);
-  Metrics().captureEvent(Events.featurePreviewToggle, { featureId: id, enabled });
+  void Metrics().captureEvent(Events.featurePreviewToggle, { featureId: id, enabled });
 };
 
 const getGroups = async ({ signal } = {}) => {


### PR DESCRIPTION
- narrowed Ajax() usage within most of the smaller remaining code areas (outside of src/libs/ajax) to call Ajax().SubAreaX directly.
- picked up src/libs/ajax/DataRepo as part of this sweep.
- improved mock types where possible.
- light Typescript conversions to assist in safer code udpates.

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
