### PR TITLE
[AN-230] MixPanel metrics for Terra Workflows Repository

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -85,8 +85,8 @@ const eventsList = {
   featurePreviewToggle: 'featurePreview:toggle',
   // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp
   jobManagerOpenExternal: 'job-manager:open-external',
-  libraryWorkflowsDockstore: 'library:workflows:dockstore-click',
-  libraryWorkflowsTerraRepo: 'library:workflows:terraWorkflowRepo-click',
+  libraryWorkflowsDockstore: 'library:workflows:dockstoreClick',
+  libraryWorkflowsTerraRepo: 'library:workflows:terraWorkflowRepoClick',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',
   notificationToggle: 'notification:toggle',

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -85,6 +85,8 @@ const eventsList = {
   featurePreviewToggle: 'featurePreview:toggle',
   // Note: "external" refers to the common Job Manager deployment, not a Job Manager bundled in CromwellApp
   jobManagerOpenExternal: 'job-manager:open-external',
+  libraryWorkflowsDockstore: 'library:workflows:dockstore-click',
+  libraryWorkflowsTerraRepo: 'library:workflows:terraWorkflowRepo-click',
   notebookRename: 'notebook:rename',
   notebookCopy: 'notebook:copy',
   notificationToggle: 'notification:toggle',
@@ -233,7 +235,7 @@ export interface EventWorkspaceDetails {
 /**
  * Extracts name, namespace, cloudPlatform, and policies (if present) from an object.
  *
- * @param workspace - Workspace attributes. These can be provided with a WorkspaceWrapper object, a WorkspaceInfo object, or a plain { namespace, name } object.
+ * @param workspaceObject - Workspace attributes. These can be provided with a WorkspaceWrapper object, a WorkspaceInfo object, or a plain { namespace, name } object.
  */
 export const extractWorkspaceDetails = (workspaceObject: EventWorkspaceAttributes): EventWorkspaceDetails => {
   // If a WorkspaceWrapper is provided, get the inner WorkspaceInfo. Otherwise, use the provided object directly.

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -131,6 +131,10 @@ const eventsList = {
   workflowImport: 'workflow:import',
   workflowLaunch: 'workflow:launch',
   workflowRerun: 'workflow:rerun',
+  workflowRepoCreateVersion: 'workflow:repository:createVersion',
+  workflowRepoCreateWorkflow: 'workflow:repository:createWorkflow',
+  workflowRepoEditCollection: 'workflow:repository:editCollection',
+  workflowRepoExportWorkflow: 'workflow:repository:exportWorkflow',
   workflowUploadIO: 'workflow:uploadIO',
   workflowUseDefaultOutputs: 'workflow:useDefaultOutputs',
   workflowSetCostCap: 'workflow:setCostCap',
@@ -195,6 +199,8 @@ const eventsList = {
   workspaceStar: 'workspace:star',
   workspaceListFilter: 'workspace:list:filter',
   workspacesListSelectTab: 'workspace:list:tab',
+  workspaceFindWorkflowDockstore: 'workspace:find-workflow:dockstoreClick',
+  workspaceFindWorkflowTerraRepo: 'workspace:find-workflow:terraWorkflowRepoClick',
 } as const;
 
 // Helper type to create BaseMetricsEventName.

--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -53,13 +53,14 @@ interface WorkflowSourceBoxProps {
   description: string;
   url: string;
   logoFilePath: string;
-  metricEvent: MetricsEventName;
+  metricsEventName: MetricsEventName;
 }
 
 const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
   const sendMetrics = () => {
-    void Metrics().captureEvent(props.metricEvent);
+    void Metrics().captureEvent(props.metricsEventName);
   };
+
   return (
     <Clickable href={props.url} {...Utils.newTabLinkProps} onClick={() => sendMetrics()}>
       <div
@@ -135,7 +136,6 @@ const CuratedWorkflowsSection = () => {
 export const WorkflowsLibrary = () => {
   const dockstoreUrl = `${getConfig().dockstoreUrlRoot}/search?_type=workflow&descriptorType=WDL&searchMode=files`;
 
-  // TODO: Change over to Terra workflow repo
   // Set to static `workflows` and remove feature flag
   const workflowsRepoUrl: string = isFeaturePreviewEnabled(FIRECLOUD_UI_MIGRATION)
     ? Nav.getLink('workflows')
@@ -156,7 +156,7 @@ export const WorkflowsLibrary = () => {
                     description='A community repository of public workflows that offers publishing features and automatic integration with GitHub.'
                     url={dockstoreUrl}
                     logoFilePath={dockstoreLogo}
-                    metricEvent={Events.libraryWorkflowsDockstore}
+                    metricsEventName={Events.libraryWorkflowsDockstore}
                   />
                 </div>
                 <div style={{ marginLeft: 20 }}>
@@ -169,7 +169,7 @@ export const WorkflowsLibrary = () => {
                     description='A repository of WDL workflows that offers quick hosting of public and private workflows.'
                     url={workflowsRepoUrl}
                     logoFilePath={terraLogo}
-                    metricEvent={Events.libraryWorkflowsTerraRepo}
+                    metricsEventName={Events.libraryWorkflowsTerraRepo}
                   />
                 </div>
               </div>

--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -59,7 +59,8 @@ interface WorkflowSourceBoxProps {
 const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
   const sendMetrics = () => {
     // don't send metrics if Broad Methods Repo card and links are shown in UI
-    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed
+    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed.
+    //       https://broadworkbench.atlassian.net/browse/AN-373
     if (props.title !== 'Broad Methods Repository') {
       void Metrics().captureEvent(props.metricsEventName);
     }

--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -58,7 +58,11 @@ interface WorkflowSourceBoxProps {
 
 const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
   const sendMetrics = () => {
-    void Metrics().captureEvent(props.metricsEventName);
+    // don't send metrics if Broad Methods Repo card and links are shown in UI
+    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed
+    if (props.title !== 'Broad Methods Repository') {
+      void Metrics().captureEvent(props.metricsEventName);
+    }
   };
 
   return (

--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -5,9 +5,11 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { libraryTopMatter } from 'src/components/library-common';
 import terraLogo from 'src/images/brands/terra/logo.svg';
 import dockstoreLogo from 'src/images/library/workflows/dockstore.svg';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
+import Events, { MetricsEventName } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { FIRECLOUD_UI_MIGRATION } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
@@ -51,11 +53,15 @@ interface WorkflowSourceBoxProps {
   description: string;
   url: string;
   logoFilePath: string;
+  metricEvent: MetricsEventName;
 }
 
 const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
+  const sendMetrics = () => {
+    void Metrics().captureEvent(props.metricEvent);
+  };
   return (
-    <Clickable href={props.url} {...Utils.newTabLinkProps}>
+    <Clickable href={props.url} {...Utils.newTabLinkProps} onClick={() => sendMetrics()}>
       <div
         style={{
           width: 400,
@@ -150,6 +156,7 @@ export const WorkflowsLibrary = () => {
                     description='A community repository of public workflows that offers publishing features and automatic integration with GitHub.'
                     url={dockstoreUrl}
                     logoFilePath={dockstoreLogo}
+                    metricEvent={Events.libraryWorkflowsDockstore}
                   />
                 </div>
                 {
@@ -162,6 +169,7 @@ export const WorkflowsLibrary = () => {
                     description='A repository of WDL workflows that offers quick hosting of public and private workflows.'
                     url={workflowsRepoUrl}
                     logoFilePath={terraLogo}
+                    metricEvent={Events.libraryWorkflowsTerraRepo}
                   />
                 </div>
               </div>

--- a/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
+++ b/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
@@ -23,7 +23,8 @@ interface WorkflowSourceCardProps {
 const WorkflowSourceCard = (props: WorkflowSourceCardProps) => {
   const sendMetrics = () => {
     // don't send metrics if Broad Methods Repo card and links are shown in UI
-    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed
+    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed.
+    //       https://broadworkbench.atlassian.net/browse/AN-373
     if (props.title !== 'Broad Methods Repository') {
       void Metrics().captureEvent(props.metricsEventName);
     }

--- a/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
+++ b/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
@@ -1,9 +1,11 @@
 import { icon, Link, Modal } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React from 'react';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { getEnabledBrand } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
+import Events, { MetricsEventName } from 'src/libs/events';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { FIRECLOUD_UI_MIGRATION } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
@@ -15,9 +17,14 @@ interface WorkflowSourceCardProps {
   description: string;
   url: string;
   openInNewTab: boolean;
+  metricsEventName: MetricsEventName;
 }
 
 const WorkflowSourceCard = (props: WorkflowSourceCardProps) => {
+  const sendMetrics = () => {
+    void Metrics().captureEvent(props.metricsEventName);
+  };
+
   return (
     <div
       style={{
@@ -29,7 +36,7 @@ const WorkflowSourceCard = (props: WorkflowSourceCardProps) => {
     >
       <div style={{ marginLeft: '10px' }}>
         <h4>
-          <Link href={props.url} {...(props.openInNewTab ? Utils.newTabLinkProps : {})}>
+          <Link href={props.url} {...(props.openInNewTab ? Utils.newTabLinkProps : {})} onClick={() => sendMetrics()}>
             {props.title}
             {props.openInNewTab && icon('pop-out', { size: 12, style: { marginLeft: '0.25rem', marginBottom: '1px' } })}
           </Link>
@@ -83,6 +90,7 @@ export const FindWorkflowModal = (props: FindWorkflowModalProps) => {
             description=' A community repository of best practice workflows that offers integration with GitHub.'
             url={dockstoreUrl}
             openInNewTab
+            metricsEventName={Events.workspaceFindWorkflowDockstore}
           />
         </div>
         <div style={{ flex: 1, marginLeft: 20 }}>
@@ -93,6 +101,7 @@ export const FindWorkflowModal = (props: FindWorkflowModalProps) => {
             description='A repository of WDL workflows that offers private workflows hosted in the platform.'
             url={workflowsRepoUrl}
             openInNewTab={false}
+            metricsEventName={Events.workspaceFindWorkflowTerraRepo}
           />
         </div>
       </div>

--- a/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
+++ b/src/pages/workspaces/workspace/modals/FindWorkflowModal.tsx
@@ -22,7 +22,11 @@ interface WorkflowSourceCardProps {
 
 const WorkflowSourceCard = (props: WorkflowSourceCardProps) => {
   const sendMetrics = () => {
-    void Metrics().captureEvent(props.metricsEventName);
+    // don't send metrics if Broad Methods Repo card and links are shown in UI
+    // TODO: remove this if condition when feature flag FIRECLOUD_UI_MIGRATION is removed
+    if (props.title !== 'Broad Methods Repository') {
+      void Metrics().captureEvent(props.metricsEventName);
+    }
   };
 
   return (

--- a/src/workflows/modals/CreateWorkflowModal.tsx
+++ b/src/workflows/modals/CreateWorkflowModal.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import ErrorView from 'src/components/ErrorView';
 import { ValidatedInput } from 'src/components/input';
 import { PostMethodProvider } from 'src/libs/ajax/methods/providers/PostMethodProvider';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import Events from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import * as Utils from 'src/libs/utils';
 import { withBusyState } from 'src/libs/utils';
@@ -183,6 +185,12 @@ export const CreateWorkflowModal = (props: CreateWorkflowModalProps) => {
         name: createdWorkflowName,
         snapshotId: createdWorkflowSnapshotId,
       } = await postMethodProvider.postMethod(namespace, name, wdl, documentation, synopsis, snapshotComment);
+
+      void Metrics().captureEvent(Events.workflowRepoCreateWorkflow, {
+        collectionName: createdWorkflowNamespace,
+        workflowName: createdWorkflowName,
+      });
+
       onSuccess(createdWorkflowNamespace, createdWorkflowName, createdWorkflowSnapshotId);
     } catch (error) {
       setSubmissionError(error instanceof Response ? await error.text() : error);

--- a/src/workflows/modals/EditWorkflowModal.tsx
+++ b/src/workflows/modals/EditWorkflowModal.tsx
@@ -4,6 +4,8 @@ import { LabeledCheckbox } from 'src/components/common';
 import ErrorView from 'src/components/ErrorView';
 import { TextInput } from 'src/components/input';
 import { EditMethodProvider } from 'src/libs/ajax/methods/providers/EditMethodProvider';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import Events from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import { withBusyState } from 'src/libs/utils';
 import {
@@ -88,6 +90,12 @@ export const EditWorkflowModal = (props: EditWorkflowModalProps) => {
         wdl,
         snapshotComment
       );
+
+      void Metrics().captureEvent(Events.workflowRepoCreateVersion, {
+        collectionName: createdWorkflowNamespace,
+        workflowName: createdWorkflowName,
+      });
+
       onSuccess(createdWorkflowNamespace, createdWorkflowName, createdWorkflowSnapshotId);
     } catch (error) {
       setSubmissionError(error instanceof Response ? await error.text() : error);

--- a/src/workflows/modals/PermissionsModal.tsx
+++ b/src/workflows/modals/PermissionsModal.tsx
@@ -14,8 +14,10 @@ import { IdContainer, LabeledCheckbox } from 'src/components/common';
 import { ValidatedInput } from 'src/components/input';
 import { getPopupRoot } from 'src/components/popup-utils';
 import { PermissionsProvider } from 'src/libs/ajax/methods/providers/PermissionsProvider';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
 import { reportError } from 'src/libs/error';
+import Events from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { getTerraUser } from 'src/libs/state';
@@ -237,6 +239,12 @@ export const PermissionsModal = (props: WorkflowPermissionsModalProps) => {
 
     try {
       await permissionsProvider.updatePermissions(namespace, permissionUpdates, { signal });
+
+      // send a MixPanel event when user edits collection settings
+      if (versionOrCollection === 'Collection') {
+        void Metrics().captureEvent(Events.workflowRepoEditCollection, { collectionName: namespace });
+      }
+
       refresh();
       setPermissionsModalOpen(false);
     } catch (error) {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-230

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Adds below metrics that are sent to MixPanel:
- `library:workflows:dockstoreClick` - user clicks on Dockstore card in Library -> Workflows page
- `library:workflows:terraWorkflowRepoClick` - user clicks on Terra Workflow repo card in Library -> Workflows page
- `workflow:repository:createVersion` - user creates a new version of a workflow
- `workflow:repository:createWorkflow` - user creates a new workflow (cloning a workflow is also considered new workflow)
- `workflow:repository:editCollection` - user edits the collection settings (to track if collection settings is actually used or not)
- `workflow:repository:exportWorkflow` - user exports a workflow to a workspace
- `workspace:find-workflow:dockstoreClick` - user clicks on Dockstore card in Find Workflow modal in a workspace
- `workspace:find-workflow:terraWorkflowRepoClick` - user clicks on Terra Workflow repo card in Find Workflow modal in a workspace

### Why
- tracking usage

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] manual testing

###  Visual Aids
Example metric event in MixPanel (dev)
![Screenshot 2025-01-22 at 10 47 34 AM](https://github.com/user-attachments/assets/e3d237c9-56cd-41ec-b60d-4e46dad1eeaa)

Example graph of 'workflow:repository:exportWorkflow'
![Screenshot 2025-01-22 at 10 51 19 AM](https://github.com/user-attachments/assets/e4e1b9ed-330e-49e7-8520-9f7ada8e7279)
