### PR TITLE
CORE-277 post_logout_redirect_uri can't be a fragment

### DIFF
--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -94,7 +94,7 @@ describe('sign-out', () => {
       userManager: { signoutRedirect: signOutRedirectFn },
     } as unknown as OidcState);
     asMockedFn(leoCookieProvider.unsetCookies).mockImplementation(unsetCookiesFn);
-    asMockedFn(Nav.getLink).mockReturnValue(link);
+    asMockedFn(Nav.getPath).mockReturnValue(`/${link}`);
     asMockedFn(Nav.getWindowOrigin).mockReturnValue(hostname);
     asMockedFn(Nav.getCurrentRoute).mockReturnValue(currentRoute);
     // Act

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -35,7 +35,7 @@ type NavExports = typeof import('src/libs/nav');
 jest.mock('src/libs/nav', (): NavExports => {
   return {
     ...jest.requireActual<NavExports>('src/libs/nav'),
-    getLink: jest.fn().mockReturnValue({ name: 'signout-callback', query: {} }),
+    getPath: jest.fn().mockReturnValue('/signout'),
     goToPath: jest.fn(),
     getWindowOrigin: jest.fn(),
     getCurrentRoute: jest.fn().mockReturnValue(currentRoute),

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -88,13 +88,13 @@ describe('sign-out', () => {
     const unsetCookiesFn = jest.fn();
     const signOutRedirectFn = jest.fn();
     const hostname = 'https://mycoolhost.horse';
-    const link = 'signout';
+    const link = '/signout';
     const expectedState = btoa(JSON.stringify({ signOutRedirect: currentRoute, signOutCause: 'unspecified' }));
     asMockedFn(oidcStore.get).mockReturnValue({
       userManager: { signoutRedirect: signOutRedirectFn },
     } as unknown as OidcState);
     asMockedFn(leoCookieProvider.unsetCookies).mockImplementation(unsetCookiesFn);
-    asMockedFn(Nav.getPath).mockReturnValue(`/${link}`);
+    asMockedFn(Nav.getPath).mockReturnValue(link);
     asMockedFn(Nav.getWindowOrigin).mockReturnValue(hostname);
     asMockedFn(Nav.getCurrentRoute).mockReturnValue(currentRoute);
     // Act
@@ -102,7 +102,7 @@ describe('sign-out', () => {
     // Assert
     expect(unsetCookiesFn).toHaveBeenCalled();
     expect(signOutRedirectFn).toHaveBeenCalledWith({
-      post_logout_redirect_uri: `${hostname}/${link}`,
+      post_logout_redirect_uri: `${hostname}${link}`,
       extraQueryParams: { state: expectedState },
     });
   });

--- a/src/auth/signout/sign-out.ts
+++ b/src/auth/signout/sign-out.ts
@@ -42,7 +42,7 @@ export const doSignOut = async (signOutCause: SignOutCause = 'unspecified'): Pro
   await leoCookieProvider.unsetCookies();
   try {
     const userManager = oidcStore.get().userManager;
-    const redirectUrl = `${Nav.getWindowOrigin()}/${Nav.getLink(signOutCallbackLinkName)}`;
+    const redirectUrl = `${Nav.getWindowOrigin()}${Nav.getPath(signOutCallbackLinkName)}`;
     // This will redirect to the logout callback page, which calls `userSignedOut` and then redirects to the homepage.
     const { name, query, params }: SignOutRedirect = Nav.getCurrentRoute();
     const signOutState: SignOutState = { signOutRedirect: { name, query, params }, signOutCause };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-277

I am updating azure b2c to validate `post_logout_redirect_uri` and azure b2c won't allow fragments in redirect uris. `getLink` prepends a hash but `getPath` does not (and also includes a leading slash).

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
