### PR TITLE
[CORE-249] Add Copy Functionality for Folders in File Browser

### DIFF
--- a/src/components/file-browser/DirectoryTree.test.ts
+++ b/src/components/file-browser/DirectoryTree.test.ts
@@ -26,6 +26,7 @@ describe('Directory', () => {
         level: 0,
         id: 'node-0',
         path: 'path/to/directory/',
+        url: 'gs://path/to/directory/',
         provider: mockFileBrowserProvider,
         reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
@@ -45,12 +46,15 @@ describe('Directory', () => {
     const directories = [
       {
         path: 'directory1',
+        url: 'gs://directory1/',
       },
       {
         path: 'directory2',
+        url: 'gs://directory3/',
       },
       {
         path: 'directory3',
+        url: 'gs://directory3/',
       },
     ];
 
@@ -72,6 +76,7 @@ describe('Directory', () => {
           id: 'node-0',
           level: 0,
           path: '',
+          url: 'gs://',
           provider: mockFileBrowserProvider,
           reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
@@ -99,18 +104,22 @@ describe('Directory', () => {
           return [
             {
               path: 'directory1/test1',
+              url: 'gs://directory1/test1/',
             },
             {
               path: 'directory1/test2',
+              url: 'gs://directory1/test2/',
             },
           ];
         case 'directory1/test1/':
           return [
             {
               path: 'directory1/test1/abc/',
+              url: 'gs://directory1/test1/abc/',
             },
             {
               path: 'directory1/test1/xyz/',
+              url: 'gs://directory1/test1/xyz/',
             },
           ];
         default:
@@ -135,6 +144,7 @@ describe('Directory', () => {
           id: 'node-0',
           level: 0,
           path: 'directory1/',
+          url: 'gs://directory1/',
           provider: mockFileBrowserProvider,
           reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
@@ -162,12 +172,15 @@ describe('Directory', () => {
       const directories = [
         {
           path: 'path/to/directory/subdirectory1',
+          url: 'gs://path/to/directory/subdirectory1/',
         },
         {
           path: 'path/to/directory/subdirectory2',
+          url: 'gs://path/to/directory/subdirectory2/',
         },
         {
           path: 'path/to/directory/subdirectory3',
+          url: 'gs://path/to/directory/subdirectory3/',
         },
       ];
 
@@ -188,6 +201,7 @@ describe('Directory', () => {
           id: 'node-0',
           level: 0,
           path: 'path/to/directory/',
+          url: 'gs://path/to/directory/',
           provider: mockFileBrowserProvider,
           reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
@@ -226,12 +240,15 @@ describe('Directory', () => {
     const directories = [
       {
         path: 'path/to/directory/subdirectory1',
+        url: 'gs://path/to/directory/subdirectory1/',
       },
       {
         path: 'path/to/directory/subdirectory2',
+        url: 'gs://path/to/directory/subdirectory2/',
       },
       {
         path: 'path/to/directory/subdirectory3',
+        url: 'gs://path/to/directory/subdirectory3/',
       },
     ];
 
@@ -252,6 +269,7 @@ describe('Directory', () => {
           id: 'node-0',
           level: 0,
           path: 'path/to/directory/',
+          url: 'gs://path/to/directory/',
           provider: mockFileBrowserProvider,
           reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',
@@ -303,6 +321,7 @@ describe('Directory', () => {
         id: 'node-0',
         level: 0,
         path: 'path/to/directory/',
+        url: 'gs://path/to/directory/',
         provider: mockFileBrowserProvider,
         reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
@@ -348,6 +367,7 @@ describe('Directory', () => {
         id: 'node-0',
         level: 0,
         path: 'path/to/directory/',
+        url: 'gs://path/to/directory/',
         provider: mockFileBrowserProvider,
         reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
@@ -394,6 +414,7 @@ describe('Directory', () => {
         id: 'node-0',
         level: 0,
         path: 'path/to/directory/',
+        url: 'gs://path/to/directory/',
         provider: mockFileBrowserProvider,
         reloadRequests: subscribable(),
         rootLabel: 'Workspace bucket',
@@ -420,6 +441,7 @@ describe('Directory', () => {
     const directories = [
       {
         path: 'path/to/directory/subdirectory1',
+        url: 'gs://path/to/directory/subdirectory1/',
       },
     ];
 
@@ -445,6 +467,7 @@ describe('Directory', () => {
           id: 'node-0',
           level: 0,
           path: 'path/to/directory/',
+          url: 'gs://path/to/directory/',
           provider: mockFileBrowserProvider,
           reloadRequests: subscribable(),
           rootLabel: 'Workspace bucket',

--- a/src/components/file-browser/DirectoryTree.ts
+++ b/src/components/file-browser/DirectoryTree.ts
@@ -131,6 +131,7 @@ export const Subdirectories = (props: SubdirectoriesProps) => {
               id: `${parentId}-${index}`,
               level: level + 1,
               path: directory.path,
+              url: directory.url,
               provider,
               reloadRequests,
               rootLabel,
@@ -194,6 +195,7 @@ interface DirectoryProps {
   provider: FileBrowserProvider;
   level: number;
   path: string;
+  url?: string;
   reloadRequests: ReloadRequestSubscribable;
   rootLabel: string;
   selectedDirectory: string;
@@ -208,6 +210,7 @@ export const Directory = (props: DirectoryProps) => {
     id,
     level,
     path,
+    url,
     provider,
     reloadRequests,
     rootLabel,
@@ -289,8 +292,9 @@ export const Directory = (props: DirectoryProps) => {
         Link,
         {
           id: `${id}-link`,
-          role: 'presentation',
+          role: 'link',
           tabIndex: -1,
+          href: url,
           style: {
             display: 'inline-block',
             overflow: 'hidden',
@@ -308,7 +312,8 @@ export const Directory = (props: DirectoryProps) => {
           ...(isSelected && {
             hover: { color: selectedDirectoryColor },
           }),
-          onClick: () => {
+          onClick: (e) => {
+            e.preventDefault();
             onSelectDirectory(path);
             setIsExpanded(true);
           },

--- a/src/components/file-browser/FileBrowser.test.ts
+++ b/src/components/file-browser/FileBrowser.test.ts
@@ -44,6 +44,7 @@ describe('FileBrowser', () => {
     const directories: FileBrowserDirectory[] = [
       {
         path: 'path/to/folder/',
+        url: 'gs://test-bucket/path/to/folder/',
       },
     ];
 

--- a/src/components/file-browser/FilesTable.test.ts
+++ b/src/components/file-browser/FilesTable.test.ts
@@ -28,9 +28,11 @@ describe('FilesTable', () => {
   const directories: FileBrowserDirectory[] = [
     {
       path: 'path/to/folder1/',
+      url: 'gs://test-bucket/path/to/folder1/',
     },
     {
       path: 'path/to/folder2/',
+      url: 'gs://test-bucket/path/to/folder2/',
     },
   ];
 
@@ -154,7 +156,7 @@ describe('FilesTable', () => {
 
     const tableRows = screen.getAllByRole('row').slice(1, 3); // skip header row and files
     const nameCells = tableRows.map((row) => getAllByRole(row, 'cell')[1]);
-    const links = nameCells.map((cell) => getByRole(cell, 'button'));
+    const links = nameCells.map((cell) => getByRole(cell, 'link'));
 
     // Act
     await user.click(links[0]);
@@ -165,9 +167,11 @@ describe('FilesTable', () => {
     expect(onClickDirectory.mock.calls.map((call) => call[0])).toEqual([
       {
         path: 'path/to/folder1/',
+        url: 'gs://test-bucket/path/to/folder1/',
       },
       {
         path: 'path/to/folder2/',
+        url: 'gs://test-bucket/path/to/folder2/',
       },
     ]);
   });

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -113,7 +113,7 @@ const FilesTable = (props: FilesTableProps) => {
                     h(
                       Link,
                       {
-                        href: directory.url || directory.path,
+                        href: directory.url ?? directory.path,
                         style: {
                           ...(Style.noWrapEllipsis as React.CSSProperties),
                           textDecoration: 'underline',
@@ -129,7 +129,7 @@ const FilesTable = (props: FilesTableProps) => {
                       'aria-label': 'Copy folder URL to clipboard',
                       className: 'cell-hover-only',
                       iconSize: 14,
-                      text: directory.url || directory.path,
+                      text: directory.url ?? directory.path,
                       tooltip: 'Copy folder URL to clipboard',
                       style: { marginLeft: '1ch' },
                     }),

--- a/src/components/file-browser/FilesTable.ts
+++ b/src/components/file-browser/FilesTable.ts
@@ -109,20 +109,31 @@ const FilesTable = (props: FilesTableProps) => {
               cellRenderer: ({ rowIndex }) => {
                 if (rowIndex < directories.length) {
                   const directory = directories[rowIndex];
-                  return h(
-                    Link,
-                    {
-                      style: {
-                        ...(Style.noWrapEllipsis as React.CSSProperties),
-                        textDecoration: 'underline',
+                  return h(Fragment, [
+                    h(
+                      Link,
+                      {
+                        href: directory.url || directory.path,
+                        style: {
+                          ...(Style.noWrapEllipsis as React.CSSProperties),
+                          textDecoration: 'underline',
+                        },
+                        onClick: (e) => {
+                          e.preventDefault();
+                          onClickDirectory(directory);
+                        },
                       },
-                      onClick: (e) => {
-                        e.preventDefault();
-                        onClickDirectory(directory);
-                      },
-                    },
-                    [basename(directory.path)]
-                  );
+                      [basename(directory.path)]
+                    ),
+                    h(ClipboardButton, {
+                      'aria-label': 'Copy folder URL to clipboard',
+                      className: 'cell-hover-only',
+                      iconSize: 14,
+                      text: directory.url || directory.path,
+                      tooltip: 'Copy folder URL to clipboard',
+                      style: { marginLeft: '1ch' },
+                    }),
+                  ]);
                 }
                 const file = files[rowIndex - directories.length];
                 return h(Fragment, [

--- a/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/FileBrowserProvider.ts
@@ -11,6 +11,7 @@ export interface FileBrowserFile {
 
 export interface FileBrowserDirectory {
   path: string;
+  url?: string;
 }
 
 interface FileBrowserProvider {

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -281,4 +281,23 @@ describe('GCSFileBrowserProvider', () => {
     // Assert
     expect(del).toHaveBeenCalledWith('test-project', 'test-bucket', 'foo/bar/baz/');
   });
+
+  it('retrieves directories in a directory', async () => {
+    // Arrange
+    const provider = GCSFileBrowserProvider({ bucket: 'test-bucket', project: 'test-project', pageSize: 3 });
+
+    // Act
+    const response = await provider.getDirectoriesInDirectory('some/path/');
+    const numGCSRequests = list.mock.calls.length;
+
+    // Assert
+    const expectedDirectories: FileBrowserDirectory[] = [
+      { path: 'a-prefix/', url: 'gs://test-bucket/a-prefix/' },
+      { path: 'b-prefix/', url: 'gs://test-bucket/b-prefix/' },
+      { path: 'c-prefix/', url: 'gs://test-bucket/c-prefix/' },
+    ];
+    expect(response.items).toEqual(expectedDirectories);
+    expect(response.hasNextPage).toBe(true);
+    expect(numGCSRequests).toBe(1);
+  });
 });

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.test.ts
@@ -119,19 +119,19 @@ describe('GCSFileBrowserProvider', () => {
 
     // Assert
     const expectedFirstPageDirectories: FileBrowserDirectory[] = [
-      { path: 'a-prefix/' },
-      { path: 'b-prefix/' },
-      { path: 'c-prefix/' },
+      { path: 'a-prefix/', url: 'gs://test-bucket/a-prefix/' },
+      { path: 'b-prefix/', url: 'gs://test-bucket/b-prefix/' },
+      { path: 'c-prefix/', url: 'gs://test-bucket/c-prefix/' },
     ];
     expect(firstResponse.items).toEqual(expectedFirstPageDirectories);
     expect(firstResponse.hasNextPage).toBe(true);
     expect(numGCSRequestsAfterFirstResponse).toBe(1);
 
     const expectedSecondPageDirectories: FileBrowserDirectory[] = [
-      { path: 'a-prefix/' },
-      { path: 'b-prefix/' },
-      { path: 'c-prefix/' },
-      { path: 'd-prefix/' },
+      { path: 'a-prefix/', url: 'gs://test-bucket/a-prefix/' },
+      { path: 'b-prefix/', url: 'gs://test-bucket/b-prefix/' },
+      { path: 'c-prefix/', url: 'gs://test-bucket/c-prefix/' },
+      { path: 'd-prefix/', url: 'gs://test-bucket/d-prefix/' },
     ];
     expect(secondResponse.items).toEqual(expectedSecondPageDirectories);
     expect(secondResponse.hasNextPage).toBe(false);

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -133,6 +133,7 @@ const GCSFileBrowserProvider = ({
         itemsOrPrefixes: 'prefixes',
         mapItemOrPrefix: (prefix) => ({
           path: `${prefix}`,
+          url: `gs://${bucket}/${prefix}`,
         }),
         // This glob pattern matches prefixes (directories) excluding the given path
         matchGlob: `${path}**?/`,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-249

### What
- This PR enables users to copy the Google Storage (gs) path for folders in the file browser UI, adding parity with files.
  - Users can right-click on folders in the main pane and the left-hand navigation tree to copy the gs path.
  - A clipboard icon appears on hover in the main pane, allowing users to copy the gs path with one click.

### Why
- Previously, folders were not linkable or copyable in the UI, making it harder for users to work with their paths. This update improves usability and ensures consistency between file and folder behavior.

### Testing strategy
- Unit Testing: Validate that users access gs urls for folders.
- Manual Testing: Confirm right-click and hover-copy work for folders in the main pane and navigation tree.


https://github.com/user-attachments/assets/d622be25-e479-49b6-b789-092a26528c47