### PR TITLE
Msilva/UIE-204 narrow ajax usage pt23

### DIFF
--- a/src/libs/ajax/analysis-providers/AnalysisProvider.test.ts
+++ b/src/libs/ajax/analysis-providers/AnalysisProvider.test.ts
@@ -59,23 +59,12 @@ describe('AnalysisProvider - listAnalyses', () => {
 describe('AnalysisProvider - copyAnalysis', () => {
   it('handles GCP workspace', async () => {
     // Arrange
-    const mockBuckets: Partial<AjaxBucketsContract> = {
-      analysis: jest.fn(),
-    };
-    const watchCopy = jest.fn();
-    asMockedFn((mockBuckets as AjaxBucketsContract).analysis).mockImplementation(() => {
-      const mockAnalysisContract: Partial<AjaxBucketsAnalysisContract> = {
-        copy: watchCopy,
-      };
-      const analysisContract = mockAnalysisContract as AjaxBucketsAnalysisContract;
-      asMockedFn(analysisContract.copy).mockResolvedValue(undefined);
-      return analysisContract;
-    });
+    const analysis: MockedFn<GoogleStorageContract['analysis']> = jest.fn();
+    const watchCopy: MockedFn<AjaxBucketsAnalysisContract['copy']> = jest.fn();
+    watchCopy.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      Buckets: mockBuckets as AjaxBucketsContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    analysis.mockReturnValue(partial<AjaxBucketsAnalysisContract>({ copy: watchCopy }));
+    asMockedFn(GoogleStorage).mockReturnValue(partial<GoogleStorageContract>({ analysis }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       googleProject: 'GoogleProject123',
@@ -97,36 +86,20 @@ describe('AnalysisProvider - copyAnalysis', () => {
 
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockBuckets.analysis).toBeCalledTimes(1);
-    expect(mockBuckets.analysis).toBeCalledWith(
-      'GoogleProject123',
-      'Bucket123',
-      'PrintName123.jpt',
-      runtimeToolLabels.Jupyter
-    );
+    expect(analysis).toBeCalledTimes(1);
+    expect(analysis).toBeCalledWith('GoogleProject123', 'Bucket123', 'PrintName123.jpt', runtimeToolLabels.Jupyter);
     expect(watchCopy).toBeCalledTimes(1);
     expect(watchCopy).toBeCalledWith('NewName123.jpt', 'TargetBucket456', false);
   });
 
   it('handles Azure workspace', async () => {
     // Arrange
-    const mockAzureStorage: Partial<AjaxAzureStorageContract> = {
-      blob: jest.fn(),
-    };
-    const watchCopy = jest.fn();
-    asMockedFn((mockAzureStorage as AjaxAzureStorageContract).blob).mockImplementation(() => {
-      const mockBlobContract: Partial<AjaxAzureStorageBlobContract> = {
-        copy: watchCopy,
-      };
-      const blobContract = mockBlobContract as AjaxAzureStorageBlobContract;
-      asMockedFn(blobContract.copy).mockResolvedValue(undefined);
-      return blobContract;
-    });
+    const blob: MockedFn<AzureStorageContract['blob']> = jest.fn();
+    const watchCopy: MockedFn<AjaxAzureStorageBlobContract['copy']> = jest.fn();
+    watchCopy.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      AzureStorage: mockAzureStorage as AjaxAzureStorageContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    blob.mockReturnValue(partial<AjaxAzureStorageBlobContract>({ copy: watchCopy }));
+    asMockedFn(AzureStorage).mockReturnValue(partial<AzureStorageContract>({ blob }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       workspaceId: 'Workspace123',
@@ -147,8 +120,8 @@ describe('AnalysisProvider - copyAnalysis', () => {
 
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockAzureStorage.blob).toBeCalledTimes(1);
-    expect(mockAzureStorage.blob).toBeCalledWith('Workspace123', 'PrintName123.jpt');
+    expect(blob).toBeCalledTimes(1);
+    expect(blob).toBeCalledWith('Workspace123', 'PrintName123.jpt');
     expect(watchCopy).toBeCalledTimes(1);
     expect(watchCopy).toBeCalledWith('NewName123', 'Workspace456');
   });
@@ -157,23 +130,12 @@ describe('AnalysisProvider - copyAnalysis', () => {
 describe('AnalysisProvider - createAnalysis', () => {
   it('handles GCP workspace', async () => {
     // Arrange
-    const mockBuckets: Partial<AjaxBucketsContract> = {
-      analysis: jest.fn(),
-    };
-    const watchCreate = jest.fn();
-    asMockedFn((mockBuckets as AjaxBucketsContract).analysis).mockImplementation(() => {
-      const mockAnalysisContract: Partial<AjaxBucketsAnalysisContract> = {
-        create: watchCreate,
-      };
-      const analysisContract = mockAnalysisContract as AjaxBucketsAnalysisContract;
-      asMockedFn(analysisContract.create).mockResolvedValue(undefined);
-      return analysisContract;
-    });
+    const analysis: MockedFn<GoogleStorageContract['analysis']> = jest.fn();
+    const watchCreate: MockedFn<AjaxBucketsAnalysisContract['create']> = jest.fn();
+    watchCreate.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      Buckets: mockBuckets as AjaxBucketsContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    analysis.mockReturnValue(partial<AjaxBucketsAnalysisContract>({ create: watchCreate }));
+    asMockedFn(GoogleStorage).mockReturnValue(partial<GoogleStorageContract>({ analysis }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       googleProject: 'GoogleProject123',
@@ -194,36 +156,20 @@ describe('AnalysisProvider - createAnalysis', () => {
     // contents: any, signal?: AbortSignal) => Promise<void>
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockBuckets.analysis).toBeCalledTimes(1);
-    expect(mockBuckets.analysis).toBeCalledWith(
-      'GoogleProject123',
-      'Bucket123',
-      'PrintName123.ipynb',
-      runtimeToolLabels.Jupyter
-    );
+    expect(analysis).toBeCalledTimes(1);
+    expect(analysis).toBeCalledWith('GoogleProject123', 'Bucket123', 'PrintName123.ipynb', runtimeToolLabels.Jupyter);
     expect(watchCreate).toBeCalledTimes(1);
     expect(watchCreate).toBeCalledWith('MyIpynbContents');
   });
 
   it('handles Azure workspace', async () => {
     // Arrange
-    const mockAzureStorage: Partial<AjaxAzureStorageContract> = {
-      blob: jest.fn(),
-    };
-    const watchCreate = jest.fn();
-    asMockedFn((mockAzureStorage as AjaxAzureStorageContract).blob).mockImplementation(() => {
-      const mockBlobContract: Partial<AjaxAzureStorageBlobContract> = {
-        create: watchCreate,
-      };
-      const blobContract = mockBlobContract as AjaxAzureStorageBlobContract;
-      asMockedFn(blobContract.create).mockResolvedValue(undefined);
-      return blobContract;
-    });
+    const blob: MockedFn<AzureStorageContract['blob']> = jest.fn();
+    const watchCreate: MockedFn<AjaxAzureStorageBlobContract['create']> = jest.fn();
+    watchCreate.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      AzureStorage: mockAzureStorage as AjaxAzureStorageContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    blob.mockReturnValue(partial<AjaxAzureStorageBlobContract>({ create: watchCreate }));
+    asMockedFn(AzureStorage).mockReturnValue(partial<AzureStorageContract>({ blob }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       workspaceId: 'Workspace123',
@@ -240,8 +186,8 @@ describe('AnalysisProvider - createAnalysis', () => {
 
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockAzureStorage.blob).toBeCalledTimes(1);
-    expect(mockAzureStorage.blob).toBeCalledWith('Workspace123', 'PrintName123.ipynb');
+    expect(blob).toBeCalledTimes(1);
+    expect(blob).toBeCalledWith('Workspace123', 'PrintName123.ipynb');
     expect(watchCreate).toBeCalledTimes(1);
     expect(watchCreate).toBeCalledWith('MyIpynbContents');
   });
@@ -250,23 +196,12 @@ describe('AnalysisProvider - createAnalysis', () => {
 describe('AnalysisProvider - deleteAnalysis', () => {
   it('handles GCP workspace', async () => {
     // Arrange
-    const mockBuckets: Partial<AjaxBucketsContract> = {
-      analysis: jest.fn(),
-    };
-    const watchDelete = jest.fn();
-    asMockedFn((mockBuckets as AjaxBucketsContract).analysis).mockImplementation(() => {
-      const mockAnalysisContract: Partial<AjaxBucketsAnalysisContract> = {
-        delete: watchDelete,
-      };
-      const analysisContract = mockAnalysisContract as AjaxBucketsAnalysisContract;
-      asMockedFn(analysisContract.delete).mockResolvedValue(undefined);
-      return analysisContract;
-    });
+    const analysis: MockedFn<GoogleStorageContract['analysis']> = jest.fn();
+    const watchDelete: MockedFn<AjaxBucketsAnalysisContract['delete']> = jest.fn();
+    watchDelete.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      Buckets: mockBuckets as AjaxBucketsContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    analysis.mockReturnValue(partial<AjaxBucketsAnalysisContract>({ delete: watchDelete }));
+    asMockedFn(GoogleStorage).mockReturnValue(partial<GoogleStorageContract>({ analysis }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       googleProject: 'GoogleProject123',
@@ -285,35 +220,19 @@ describe('AnalysisProvider - deleteAnalysis', () => {
     // contents: any, signal?: AbortSignal) => Promise<void>
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockBuckets.analysis).toBeCalledTimes(1);
-    expect(mockBuckets.analysis).toBeCalledWith(
-      'GoogleProject123',
-      'Bucket123',
-      'PrintName123.ipynb',
-      runtimeToolLabels.Jupyter
-    );
+    expect(analysis).toBeCalledTimes(1);
+    expect(analysis).toBeCalledWith('GoogleProject123', 'Bucket123', 'PrintName123.ipynb', runtimeToolLabels.Jupyter);
     expect(watchDelete).toBeCalledTimes(1);
   });
 
   it('handles Azure workspace', async () => {
     // Arrange
-    const mockAzureStorage: Partial<AjaxAzureStorageContract> = {
-      blob: jest.fn(),
-    };
-    const watchDelete = jest.fn();
-    asMockedFn((mockAzureStorage as AjaxAzureStorageContract).blob).mockImplementation(() => {
-      const mockBlobContract: Partial<AjaxAzureStorageBlobContract> = {
-        delete: watchDelete,
-      };
-      const blobContract = mockBlobContract as AjaxAzureStorageBlobContract;
-      asMockedFn(blobContract.delete).mockResolvedValue(undefined);
-      return blobContract;
-    });
+    const blob: MockedFn<AzureStorageContract['blob']> = jest.fn();
+    const watchDelete: MockedFn<AjaxAzureStorageBlobContract['delete']> = jest.fn();
+    watchDelete.mockResolvedValue(undefined);
 
-    const mockAjax: Partial<AjaxContract> = {
-      AzureStorage: mockAzureStorage as AjaxAzureStorageContract,
-    };
-    asMockedFn(Ajax).mockImplementation(() => mockAjax as AjaxContract);
+    blob.mockReturnValue(partial<AjaxAzureStorageBlobContract>({ delete: watchDelete }));
+    asMockedFn(AzureStorage).mockReturnValue(partial<AzureStorageContract>({ blob }));
 
     const workspaceInfo: Partial<WorkspaceInfo> = {
       workspaceId: 'Workspace123',
@@ -328,8 +247,8 @@ describe('AnalysisProvider - deleteAnalysis', () => {
 
     // Assert
     expect(result).toEqual(undefined);
-    expect(mockAzureStorage.blob).toBeCalledTimes(1);
-    expect(mockAzureStorage.blob).toBeCalledWith('Workspace123', 'PrintName123.ipynb');
+    expect(blob).toBeCalledTimes(1);
+    expect(blob).toBeCalledWith('Workspace123', 'PrintName123.ipynb');
     expect(watchDelete).toBeCalledTimes(1);
   });
 });

--- a/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoAppProvider.ts
@@ -1,6 +1,6 @@
 import { AbortOption } from '@terra-ui-packages/data-client-core';
 import { AppWithWorkspace } from 'src/analysis/Environments/Environments.models';
-import { Ajax } from 'src/libs/ajax';
+import { Apps } from 'src/libs/ajax/leonardo/Apps';
 import { GetAppItem, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
 
 export type AppBasics = Pick<ListAppItem, 'appName' | 'workspaceId'> & {
@@ -22,7 +22,7 @@ export const leoAppProvider: LeoAppProvider = {
   listWithoutProject: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListAppItem[]> => {
     const { signal } = options;
 
-    return Ajax(signal).Apps.listWithoutProject(listArgs);
+    return Apps(signal).listWithoutProject(listArgs);
   },
   delete: (app: AppBasics, options: DeleteAppOptions = {}): Promise<void> => {
     const { cloudProvider, cloudResource } = app.cloudContext;
@@ -30,10 +30,10 @@ export const leoAppProvider: LeoAppProvider = {
 
     const { appName, workspaceId } = app;
     if (cloudProvider === 'GCP') {
-      return Ajax(signal).Apps.app(cloudResource, appName).delete(!!deleteDisk);
+      return Apps(signal).app(cloudResource, appName).delete(!!deleteDisk);
     }
     if (cloudProvider === 'AZURE' && !!workspaceId) {
-      return Ajax(signal).Apps.deleteAppV2(appName, workspaceId);
+      return Apps(signal).deleteAppV2(appName, workspaceId);
     }
     throw new Error(
       `Deleting apps is currently only supported for azure or google apps. Azure apps must have a workspace id. App: ${app.appName} workspaceId: ${workspaceId}`
@@ -47,7 +47,7 @@ export const leoAppProvider: LeoAppProvider = {
       throw new Error('Pausing apps is not supported for azure');
     }
 
-    return Ajax(signal).Apps.app(cloudResource, app.appName).pause();
+    return Apps(signal).app(cloudResource, app.appName).pause();
   },
   get: (app: AppBasics, options: AbortOption = {}): Promise<GetAppItem> => {
     const { cloudResource, cloudProvider } = app.cloudContext;
@@ -55,10 +55,10 @@ export const leoAppProvider: LeoAppProvider = {
     const { workspaceId } = app;
 
     if (cloudProvider === 'GCP') {
-      return Ajax(signal).Apps.app(cloudResource, app.appName).details();
+      return Apps(signal).app(cloudResource, app.appName).details();
     }
     if (cloudProvider === 'AZURE' && !!workspaceId) {
-      return Ajax(signal).Apps.getAppV2(app.appName, workspaceId);
+      return Apps(signal).getAppV2(app.appName, workspaceId);
     }
 
     throw new Error(

--- a/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
+++ b/src/libs/ajax/leonardo/providers/LeoDiskProvider.test.ts
@@ -24,10 +24,9 @@ interface DiskMockNeeds {
 }
 
 /**
- * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
- * returns with as much type-saftely as possible.
+ * local test utility - sets up mocks for needed ajax data-calls with as much type-saftely as possible.
  *
- * @return collection of key contract sub-objects for easy
+ * @return collection of key data-call fns for easy
  * mock overrides and/or method spying/assertions
  */
 const mockDiskNeeds = (): DiskMockNeeds => {

--- a/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
+++ b/src/libs/ajax/leonardo/providers/LeoRuntimeProvider.ts
@@ -1,8 +1,8 @@
 import { AbortOption } from '@terra-ui-packages/data-client-core';
 import { isGcpContext } from 'src/analysis/utils/runtime-utils';
-import { Ajax } from 'src/libs/ajax';
+import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { ListRuntimeItem, Runtime, RuntimeError } from 'src/libs/ajax/leonardo/models/runtime-models';
-import { AzureRuntimeWrapper, GoogleRuntimeWrapper, RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
+import { AzureRuntimeWrapper, GoogleRuntimeWrapper, Runtimes, RuntimeWrapper } from 'src/libs/ajax/leonardo/Runtimes';
 
 export type RuntimeBasics = RuntimeWrapper & Pick<Runtime, 'cloudContext'>;
 
@@ -42,21 +42,23 @@ export const leoRuntimeProvider: LeoRuntimeProvider = {
   list: (listArgs: Record<string, string>, options: AbortOption = {}): Promise<ListRuntimeItem[]> => {
     const { signal } = options;
 
-    return Ajax(signal).Runtimes.listV2(listArgs);
+    return Runtimes(signal).listV2(listArgs);
   },
   errorInfo: async (runtime: RuntimeBasics, options?: AbortOption): Promise<RuntimeErrorInfo> => {
-    const ajax = Ajax(options?.signal);
+    const runtimes = Runtimes(options?.signal);
     const isGcp = isGcpContext(runtime.cloudContext);
     const { errors: runtimeErrors, asyncRuntimeFields } = isGcp
-      ? await ajax.Runtimes.runtime((runtime as GoogleRuntimeWrapper).googleProject, runtime.runtimeName).details()
-      : await ajax.Runtimes.runtimeV2((runtime as AzureRuntimeWrapper).workspaceId, runtime.runtimeName).details();
+      ? await runtimes.runtime((runtime as GoogleRuntimeWrapper).googleProject, runtime.runtimeName).details()
+      : await runtimes.runtimeV2((runtime as AzureRuntimeWrapper).workspaceId, runtime.runtimeName).details();
     if (isGcp && runtimeErrors.some(({ errorMessage }) => errorMessage.includes('Userscript failed'))) {
-      const scriptErrorDetail = await ajax.Buckets.getObjectPreview(
-        (runtime as GoogleRuntimeWrapper).googleProject,
-        asyncRuntimeFields?.stagingBucket,
-        'userscript_output.txt',
-        true
-      ).then((res) => res.text());
+      const scriptErrorDetail = await GoogleStorage(options?.signal)
+        .getObjectPreview(
+          (runtime as GoogleRuntimeWrapper).googleProject,
+          asyncRuntimeFields?.stagingBucket,
+          'userscript_output.txt',
+          true
+        )
+        .then((res) => res.text());
       return { errorType: 'UserScriptError', detail: scriptErrorDetail };
     } // else
     return { errorType: 'ErrorList', errors: runtimeErrors };
@@ -66,10 +68,10 @@ export const leoRuntimeProvider: LeoRuntimeProvider = {
 
     // TODO: refactor runtimeWrapper and related v1/v2 mechanics into this provider.
     // This provider largely does the same abstraction pattern that runtimeWrapper is going for.
-    // We should follow-up and see about removing runtimeWrapper from Ajax.Runtimes and point all current
+    // We should follow-up and see about removing runtimeWrapper from ajax Runtimes and point all current
     // consumers to this leoRuntimeProvider instead.  Any v1/v2 (GCP/Azure) conditional logic should happen
     // here, and the Ajax layer should just be mirrors of backend endpoints.
-    return Ajax(signal).Runtimes.runtimeWrapper(runtime).stop();
+    return Runtimes(signal).runtimeWrapper(runtime).stop();
   },
   delete: (runtime: RuntimeBasics, options: DeleteRuntimeOptions = {}): Promise<void> => {
     const { cloudContext, runtimeName } = runtime;
@@ -77,9 +79,9 @@ export const leoRuntimeProvider: LeoRuntimeProvider = {
 
     if (isGcpContext(cloudContext)) {
       const googleProject = (runtime as GoogleRuntimeWrapper).googleProject;
-      return Ajax(signal).Runtimes.runtime(googleProject, runtimeName).delete(!!deleteDisk);
+      return Runtimes(signal).runtime(googleProject, runtimeName).delete(!!deleteDisk);
     }
     const workspaceId = (runtime as AzureRuntimeWrapper).workspaceId;
-    return Ajax(signal).Runtimes.runtimeV2(workspaceId, runtimeName).delete(!!deleteDisk);
+    return Runtimes(signal).runtimeV2(workspaceId, runtimeName).delete(!!deleteDisk);
   },
 };

--- a/src/libs/ajax/workspaces/providers/ExportWorkflowToWorkspaceProvider.ts
+++ b/src/libs/ajax/workspaces/providers/ExportWorkflowToWorkspaceProvider.ts
@@ -1,7 +1,8 @@
 import { AbortOption } from '@terra-ui-packages/data-client-core';
-import { Ajax } from 'src/libs/ajax';
+import { Methods } from 'src/libs/ajax/methods/Methods';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { MethodConfiguration, MethodRepoMethod } from 'src/libs/ajax/workspaces/workspace-models';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { WorkspaceInfo } from 'src/workspaces/utils';
 
@@ -28,8 +29,8 @@ export const makeExportWorkflowFromWorkspaceProvider = (
     export: (destWorkspace: WorkspaceInfo, destWorkflowName: string, options: AbortOption = {}) => {
       const { signal } = options;
 
-      return Ajax(signal)
-        .Workspaces.workspace(currentWorkspace.namespace, currentWorkspace.name)
+      return Workspaces(signal)
+        .workspace(currentWorkspace.namespace, currentWorkspace.name)
         .methodConfig(methodConfig.namespace, methodConfig.name)
         .copyTo({
           destConfigNamespace: destWorkspace.namespace,
@@ -60,10 +61,10 @@ export const makeExportWorkflowFromMethodsRepoProvider = (
 
       // Remove placeholder root entity type from template before importing -
       // the user can select their own on the workflow configuration page
-      const { rootEntityType, ...template } = await Ajax(signal).Methods.template(sourceMethod);
+      const { rootEntityType, ...template } = await Methods(signal).template(sourceMethod);
 
-      await Ajax(signal)
-        .Workspaces.workspace(destWorkspace.namespace, destWorkspace.name)
+      await Workspaces(signal)
+        .workspace(destWorkspace.namespace, destWorkspace.name)
         .importMethodConfig({
           ...template,
           name: destWorkflowName,

--- a/src/libs/ajax/workspaces/providers/WorkspaceProvider.test.ts
+++ b/src/libs/ajax/workspaces/providers/WorkspaceProvider.test.ts
@@ -1,12 +1,10 @@
-import { Ajax } from 'src/libs/ajax';
-import { asMockedFn } from 'src/testing/test-utils';
+import { Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
+import { asMockedFn, partial } from 'src/testing/test-utils';
 
 import { workspaceProvider } from './WorkspaceProvider';
 
-jest.mock('src/libs/ajax');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
-type AjaxContract = ReturnType<typeof Ajax>;
-type WorkspacesAjaxContract = Pick<AjaxContract, 'Workspaces'>['Workspaces'];
 type WorkspacesAjaxNeeds = Pick<WorkspacesAjaxContract, 'list'>;
 
 interface AjaxMockNeeds {
@@ -14,23 +12,18 @@ interface AjaxMockNeeds {
 }
 
 /**
- * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
- * returns with as much type-safety as possible.
+ * local test utility - sets up mocks for needed ajax data-calls with as much type-saftely as possible.
  *
- * @return collection of key contract sub-objects for easy
+ * @return collection of key data-call fns for easy
  * mock overrides and/or method spying/assertions
  */
 const mockAjaxNeeds = (): AjaxMockNeeds => {
   const partialWorkspaces: WorkspacesAjaxNeeds = {
     list: jest.fn(),
   };
-  const mockWorkspaces = partialWorkspaces as WorkspacesAjaxContract;
+  asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>(partialWorkspaces));
 
-  asMockedFn(Ajax).mockReturnValue({ Workspaces: mockWorkspaces } as AjaxContract);
-
-  return {
-    workspaces: partialWorkspaces,
-  };
+  return { workspaces: partialWorkspaces };
 };
 describe('workspacesProvider', () => {
   it('handles list call', async () => {
@@ -43,8 +36,8 @@ describe('workspacesProvider', () => {
     const result = await workspaceProvider.list(['field1', 'field2'], { stringAttributeMaxLength: 50, signal });
 
     // Assert;
-    expect(Ajax).toBeCalledTimes(1);
-    expect(Ajax).toBeCalledWith(signal);
+    expect(Workspaces).toBeCalledTimes(1);
+    expect(Workspaces).toBeCalledWith(signal);
     expect(ajaxMock.workspaces.list).toBeCalledTimes(1);
     expect(ajaxMock.workspaces.list).toBeCalledWith(['field1', 'field2'], 50);
     expect(result).toEqual([]);

--- a/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
+++ b/src/libs/ajax/workspaces/providers/WorkspaceProvider.ts
@@ -1,5 +1,5 @@
 import { AbortOption } from '@terra-ui-packages/data-client-core';
-import { Ajax } from 'src/libs/ajax';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { WorkspaceWrapper } from 'src/workspaces/utils';
 
 export type FieldsArg = string[];
@@ -16,7 +16,7 @@ export const workspaceProvider: WorkspaceDataProvider = {
   list: async (fieldsArgs: FieldsArg, options: WorkspaceListOptions): Promise<WorkspaceWrapper[]> => {
     const { signal, stringAttributeMaxLength } = options;
 
-    const ws = await Ajax(signal).Workspaces.list(fieldsArgs, stringAttributeMaxLength);
+    const ws = await Workspaces(signal).list(fieldsArgs, stringAttributeMaxLength);
     return ws;
   },
 };

--- a/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
+++ b/src/workspaces/common/state/useCloudEnvironmentPolling.test.ts
@@ -18,10 +18,9 @@ interface AjaxMockNeeds {
   Runtimes: RuntimeMockNeeds;
 }
 /**
- * local test utility - mocks the Ajax super-object and the subset of needed multi-contracts it
- * returns with as much type-safety as possible.
+ * local test utility - sets up mocks for needed ajax data-calls with as much type-saftely as possible.
  *
- * @return collection of key contract sub-objects for easy
+ * @return collection of key data-call fns for easy
  * mock overrides and/or method spying/assertions
  */
 const mockAjaxNeeds = (): AjaxMockNeeds => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
- narrow Ajax() usage within some of src/libs/ajax area to call Ajax().SubAreaX directly.
- improve mock types where possible

### What
-

### Why
- improve code maintainability

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
