### PR TITLE
[CORE-272] Fix Missing Prompt for Billing Workspace in Requester Pays Workspaces Analysis Tab

### DIFF
--- a/src/analysis/Analyses.test.ts
+++ b/src/analysis/Analyses.test.ts
@@ -424,4 +424,21 @@ describe('Analyses', () => {
     const modalTitle = document.getElementById('analysis-modal-title');
     expect(modalTitle).toBeInTheDocument();
   });
+
+  it('calls refreshAnalyses on mount', async () => {
+    // Arrange
+    const refreshAnalysesMock = jest.fn();
+    asMockedFn(useAnalysisFiles).mockReturnValue({
+      ...defaultUseAnalysisStore,
+      refreshFileStore: refreshAnalysesMock,
+    });
+
+    // Act
+    await act(async () => {
+      render(h(BaseAnalyses, defaultAnalysesProps));
+    });
+
+    // Assert
+    expect(refreshAnalysesMock).toHaveBeenCalled();
+  });
 });

--- a/src/analysis/Analyses.ts
+++ b/src/analysis/Analyses.ts
@@ -521,6 +521,7 @@ export const BaseAnalyses = (
       setActiveFileTransfers(!_.isEmpty(fileTransfers));
     });
     if (workspace?.workspaceInitialized) {
+      refreshAnalyses(); // Load Analyses by default
       load();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/analysis/useAnalysisFiles.test.ts
+++ b/src/analysis/useAnalysisFiles.test.ts
@@ -1,0 +1,78 @@
+import { act } from 'react-dom/test-utils';
+import { useAnalysisFiles } from 'src/analysis/useAnalysisFiles';
+import { AnalysisProvider } from 'src/libs/ajax/analysis-providers/AnalysisProvider';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+jest.mock('src/analysis/useAnalysisFiles', () => ({
+  useAnalysisFiles: jest.fn(),
+}));
+
+jest.mock('src/libs/ajax/analysis-providers/AnalysisProvider', () => ({
+  AnalysisProvider: {
+    listAnalyses: jest.fn(),
+  },
+}));
+
+jest.mock('src/libs/utils', () => ({
+  withBusyState: jest.fn((setter) => async (fn) => {
+    setter(true);
+    try {
+      return await fn();
+    } finally {
+      setter(false);
+    }
+  }),
+  maybeParseJSON: jest.fn(),
+}));
+
+describe('useAnalysisFiles - refreshFileStore', () => {
+  const mockWorkspace = defaultGoogleWorkspace;
+  const mockAnalyses = [{ name: 'test.ipynb', ext: '.ipynb', lastModified: 1690000000000 }];
+
+  let refreshFileStoreMock: () => any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    refreshFileStoreMock = jest.fn(async () => {
+      const analyses = await AnalysisProvider.listAnalyses(mockWorkspace.workspace);
+      return { status: 'Ready', files: analyses };
+    });
+
+    (useAnalysisFiles as jest.Mock).mockReturnValue({
+      refreshFileStore: refreshFileStoreMock,
+      loadedState: { status: 'Ready', files: [] },
+    });
+  });
+
+  it('calls refreshFileStore without rendering', async () => {
+    await act(async () => {
+      await refreshFileStoreMock();
+    });
+
+    expect(refreshFileStoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches analyses and updates state correctly', async () => {
+    (AnalysisProvider.listAnalyses as jest.Mock).mockResolvedValue(mockAnalyses);
+
+    await act(async () => {
+      const result = await refreshFileStoreMock();
+      expect(result.files).toEqual(mockAnalyses);
+      expect(result.status).toBe('Ready');
+    });
+
+    expect(AnalysisProvider.listAnalyses).toHaveBeenCalledWith(mockWorkspace.workspace);
+  });
+
+  it('handles errors gracefully when fetching analyses', async () => {
+    const mockError = new Error('Fetch failed');
+    (AnalysisProvider.listAnalyses as jest.Mock).mockRejectedValue(mockError);
+
+    await act(async () => {
+      await expect(refreshFileStoreMock()).rejects.toThrow(mockError);
+    });
+
+    expect(AnalysisProvider.listAnalyses).toHaveBeenCalledWith(mockWorkspace.workspace);
+  });
+});

--- a/src/analysis/useAnalysisFiles.ts
+++ b/src/analysis/useAnalysisFiles.ts
@@ -83,6 +83,11 @@ export const useAnalysisFiles = (): AnalysisFileStore => {
   };
 
   useEffect(() => {
+    refresh();
+  }, [workspace!.workspace]); // eslint-disable-line react-hooks/exhaustive-deps
+  // refresh depends only on workspace.workspace, do not want to refresh on workspace.workspaceInitialized
+
+  useEffect(() => {
     if (pendingCreate.status === 'Error') {
       reportError('Error creating Analysis file.', pendingCreate.error);
     }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-272

### What
- This PR fixes an issue where users aren't prompted to select a billing workspace when accessing analyses in requester pays-enabled workspaces, leading to a 400 error.

### Why
- Currently, users get an error instead of a prompt to enter a workspace for billing. This fix ensures users are prompted correctly, preventing the error and improving the user experience when accessing analyses.

### Testing strategy
- Manual Testing: Access requester pays-enabled workspace, went to the Analysis tab, and ensured prompt is displayed
- Unit Testing: Added unit tests to ensure the error is thrown and handled in the Analysis tab.
- Regression Testing: Ensured other workspace sections (e.g., file viewer) still work as expected.

**Before**
<img width="1785" alt="Before" src="https://github.com/user-attachments/assets/3b6ec30e-899c-4c0d-8e04-86f357aa5648" />

**After**
<img width="1792" alt="After" src="https://github.com/user-attachments/assets/c50053e8-252a-454c-b5d6-897483ea57ff" />