### PR TITLE
UIE-204 Narrow Ajax Usage pt24 (final)

### DIFF
--- a/src/appLoader.js
+++ b/src/appLoader.js
@@ -12,6 +12,7 @@ import { initAuthTesting } from 'src/auth/app-load/init-auth-test';
 import { initializeAuthMetrics } from 'src/auth/app-load/init-metrics';
 import { initializeClientId } from 'src/auth/app-load/initializeClientId';
 import { initializeSystemProperties } from 'src/auth/system-loader';
+import { setupAjaxTestUtil } from 'src/libs/ajax';
 import { isAxeEnabled } from 'src/libs/config';
 import Main from 'src/pages/Main';
 
@@ -20,6 +21,8 @@ const rootElement = document.getElementById('root');
 RModal.defaultStyles = { overlay: {}, content: {} };
 
 window._ = _;
+
+setupAjaxTestUtil();
 
 initializeAuthListeners();
 initializeAuthMetrics();

--- a/src/libs/ajax.test.ts
+++ b/src/libs/ajax.test.ts
@@ -1,0 +1,44 @@
+import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
+
+import { AjaxTestingContract, setupAjaxTestUtil } from './ajax';
+import { Apps, AppsAjaxContract } from './ajax/leonardo/Apps';
+import { Runtimes, RuntimesAjaxContract } from './ajax/leonardo/Runtimes';
+import { Workspaces, WorkspacesAjaxContract } from './ajax/workspaces/Workspaces';
+
+jest.mock('src/libs/ajax/leonardo/Apps');
+jest.mock('src/libs/ajax/leonardo/Runtimes');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
+
+describe('setupAjaxTestUtil', () => {
+  beforeEach(() => {
+    asMockedFn(Apps).mockReturnValue(partial<AppsAjaxContract>({}));
+    asMockedFn(Runtimes).mockReturnValue(partial<RuntimesAjaxContract>({}));
+    asMockedFn(Workspaces).mockReturnValue(partial<WorkspacesAjaxContract>({}));
+  });
+
+  it('sets up Ajax data-call testing root', () => {
+    // Act
+    setupAjaxTestUtil();
+    const ajaxTestingContract = (window as any).Ajax() as AjaxTestingContract;
+
+    // Assert
+    expect(ajaxTestingContract).toBeDefined();
+    expect(ajaxTestingContract.Apps).toBeDefined();
+    expect(ajaxTestingContract.Runtimes).toBeDefined();
+    expect(ajaxTestingContract.Workspaces).toBeDefined();
+  });
+  it('passes along signal arg to sub-areas', () => {
+    // Arrange
+    const signal = new AbortController().signal;
+
+    // Act
+    setupAjaxTestUtil();
+    const ajaxTestingContract = (window as any).Ajax(signal) as AjaxTestingContract;
+
+    // Assert
+    expect(ajaxTestingContract).toBeDefined();
+    expect(Apps).toBeCalledWith(signal);
+    expect(Runtimes).toBeCalledWith(signal);
+    expect(Workspaces).toBeCalledWith(signal);
+  });
+});

--- a/src/libs/ajax.ts
+++ b/src/libs/ajax.ts
@@ -1,66 +1,18 @@
-import { AzureStorage } from 'src/libs/ajax/AzureStorage';
-import { Billing } from 'src/libs/ajax/billing/Billing';
-import { Catalog } from 'src/libs/ajax/Catalog';
-import { DataRepo } from 'src/libs/ajax/DataRepo';
-import { Dockstore } from 'src/libs/ajax/Dockstore';
-import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
-import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
-import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
-import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
-import { Groups } from 'src/libs/ajax/Groups';
 import { Apps } from 'src/libs/ajax/leonardo/Apps';
-import { Disks } from 'src/libs/ajax/leonardo/Disks';
 import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
-import { Methods } from 'src/libs/ajax/methods/Methods';
-import { Metrics } from 'src/libs/ajax/Metrics';
-import { OAuth2 } from 'src/libs/ajax/OAuth2';
-import { SamResources } from 'src/libs/ajax/SamResources';
-import { Support } from 'src/libs/ajax/Support';
-import { Surveys } from 'src/libs/ajax/surveys/Surveys';
-import { TermsOfService } from 'src/libs/ajax/TermsOfService';
-import { User } from 'src/libs/ajax/User';
-import { Cbas } from 'src/libs/ajax/workflows-app/Cbas';
-import { CromIAM } from 'src/libs/ajax/workflows-app/CromIAM';
-import { CromwellApp } from 'src/libs/ajax/workflows-app/CromwellApp';
-import { WorkflowScript } from 'src/libs/ajax/workflows-app/WorkflowScript';
-import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
-import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 
-export const Ajax = (signal?: AbortSignal) => {
+const AjaxTestingRoot = (signal?: AbortSignal) => {
   return {
     Apps: Apps(signal), // used for e2e testing
-    AzureStorage: AzureStorage(signal),
-    Billing: Billing(signal),
-    Buckets: GoogleStorage(signal), // used for e2e testing
-    Catalog: Catalog(signal),
-    Cbas: Cbas(signal),
-    CromIAM: CromIAM(signal),
-    CromwellApp: CromwellApp(signal),
-    DataRepo: DataRepo(signal),
-    Disks: Disks(signal),
-    Dockstore: Dockstore(signal),
-    DrsUriResolver: DrsUriResolver(signal),
-    ExternalCredentials: ExternalCredentials(signal),
-    FirecloudBucket: FirecloudBucket(signal),
-    Groups: Groups(signal),
-    Methods: Methods(signal),
-    Metrics: Metrics(signal),
-    OAuth2: OAuth2(signal),
     Runtimes: Runtimes(signal), // used for e2e testing
-    SamResources: SamResources(signal),
-    Support: Support(signal),
-    Surveys: Surveys(signal),
-    TermsOfService: TermsOfService(signal),
-    User: User(signal),
-    WorkflowScript: WorkflowScript(signal),
-    WorkspaceData: WorkspaceData(signal),
-    WorkspaceManagerResources: WorkspaceManagerResources(signal),
     Workspaces: Workspaces(signal), // used for e2e testing
   };
 };
 
-export type AjaxContract = ReturnType<typeof Ajax>;
+export type AjaxTestingContract = ReturnType<typeof AjaxTestingRoot>;
 
-// Exposing Ajax for use by integration tests (and debugging, or whatever)
-(window as any).Ajax = Ajax;
+export const setupAjaxTestUtil = () => {
+  // Exposing Ajax for use by integration tests (and debugging, or whatever)
+  (window as any).Ajax = AjaxTestingRoot;
+};

--- a/src/libs/ajax/AzureStorage.ts
+++ b/src/libs/ajax/AzureStorage.ts
@@ -3,9 +3,9 @@ import { AnalysisFile, AnalysisFileMetadata } from 'src/analysis/useAnalysisFile
 import { AbsolutePath, getDisplayName, getExtension, getFileName } from 'src/analysis/utils/file-utils';
 import { runtimeToolLabels } from 'src/analysis/utils/tool-utils';
 import { authOpts } from 'src/auth/auth-session';
-import { Ajax } from 'src/libs/ajax';
 import { fetchWorkspaceManager } from 'src/libs/ajax/ajax-common';
 import { fetchOk } from 'src/libs/ajax/fetch/fetch-core';
+import { WorkspaceManagerResources } from 'src/libs/ajax/WorkspaceManagerResources';
 import { getConfig } from 'src/libs/config';
 import * as Utils from 'src/libs/utils';
 import { cloudProviderTypes } from 'src/workspaces/utils';
@@ -78,7 +78,7 @@ export const AzureStorage = (signal?: AbortSignal) => ({
    * (which is an expected transient state while a workspace is being cloned).
    */
   containerInfo: async (workspaceId: string): Promise<StorageContainerInfo> => {
-    const data = await Ajax(signal).WorkspaceManagerResources.controlledResources(workspaceId);
+    const data = await WorkspaceManagerResources(signal).controlledResources(workspaceId);
     const container = _.find(
       {
         metadata: {

--- a/src/libs/ajax/SamResources.ts
+++ b/src/libs/ajax/SamResources.ts
@@ -1,7 +1,6 @@
 import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import { authOpts } from 'src/auth/auth-session';
-import { Ajax } from 'src/libs/ajax';
 import { fetchSam } from 'src/libs/ajax/ajax-common';
 import { appIdentifier } from 'src/libs/ajax/fetch/fetch-core';
 
@@ -34,7 +33,7 @@ export const SamResources = (signal?: AbortSignal) => ({
     object: string,
     requesterPaysProject: RequesterPaysProject = undefined
   ): Promise<string> => {
-    return Ajax(signal).SamResources.getRequesterPaysSignedUrl(`gs://${bucket}/${object}`, requesterPaysProject);
+    return SamResources(signal).getRequesterPaysSignedUrl(`gs://${bucket}/${object}`, requesterPaysProject);
   },
 
   getResourcePolicies: async (fqResourceId: FullyQualifiedResourceId): Promise<object> => {

--- a/src/libs/ajax/compute-image-providers/ComputeImageProvider.ts
+++ b/src/libs/ajax/compute-image-providers/ComputeImageProvider.ts
@@ -5,7 +5,7 @@ import {
   runtimeToolLabels,
   terraSupportedRuntimeImageIds,
 } from 'src/analysis/utils/tool-utils';
-import { Ajax } from 'src/libs/ajax';
+import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { getConfig } from 'src/libs/config';
 
 export interface ComputeImageProviderContract {
@@ -72,8 +72,8 @@ const normalizeImage: (rawImage: ComputeImageRaw) => ComputeImage = (rawImage) =
 
 export const ComputeImageProvider: ComputeImageProviderContract = {
   listImages: async (googleProject: string, signal?: AbortSignal): Promise<ComputeImage[]> => {
-    const fetchedImages: ComputeImageRaw[] = await Ajax(signal)
-      .Buckets.getObjectPreview(
+    const fetchedImages: ComputeImageRaw[] = await GoogleStorage(signal)
+      .getObjectPreview(
         googleProject,
         getConfig().terraDockerImageBucket,
         getConfig().terraDockerVersionsFile,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash/fp';
-import { Ajax } from 'src/libs/ajax';
 import {
   AttributeArray,
   DataTableFeatures,
@@ -15,6 +14,7 @@ import {
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
+import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { Capabilities, Capability } from 'src/libs/ajax/WorkspaceDataService';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
@@ -283,7 +283,7 @@ export class WdsDataTableProvider implements DataTableProvider {
     metadata: EntityMetadata
   ): Promise<EntityQueryResponse> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    const wdsPage: RecordQueryResponse = await Ajax(signal).WorkspaceData.getRecords(
+    const wdsPage: RecordQueryResponse = await WorkspaceData(signal).getRecords(
       this.proxyUrl,
       this.workspaceId,
       entityType,
@@ -301,17 +301,17 @@ export class WdsDataTableProvider implements DataTableProvider {
 
   deleteTable = (entityType: string): Promise<Response> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    return Ajax().WorkspaceData.deleteTable(this.proxyUrl, this.workspaceId, entityType);
+    return WorkspaceData().deleteTable(this.proxyUrl, this.workspaceId, entityType);
   };
 
   deleteColumn = (signal: AbortSignal, entityType: string, attributeName: string): Promise<Response> => {
     if (!this.proxyUrl) return Promise.reject('Proxy URL not loaded');
-    return Ajax(signal).WorkspaceData.deleteColumn(this.proxyUrl, this.workspaceId, entityType, attributeName);
+    return WorkspaceData(signal).deleteColumn(this.proxyUrl, this.workspaceId, entityType, attributeName);
   };
 
   downloadTsv = (signal: AbortSignal, entityType: string): Promise<Blob> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    return Ajax(signal).WorkspaceData.downloadTsv(this.proxyUrl, this.workspaceId, entityType);
+    return WorkspaceData(signal).downloadTsv(this.proxyUrl, this.workspaceId, entityType);
   };
 
   uploadTsv = (uploadParams: UploadParameters): Promise<TsvUploadResponse> => {
@@ -331,7 +331,7 @@ export class WdsDataTableProvider implements DataTableProvider {
         );
       }
     }, 1000);
-    return Ajax().WorkspaceData.uploadTsv(
+    return WorkspaceData().uploadTsv(
       this.proxyUrl,
       uploadParams.workspaceId,
       uploadParams.recordType,
@@ -342,7 +342,7 @@ export class WdsDataTableProvider implements DataTableProvider {
   updateRecord = (recordEditParams: RecordEditParameters): Promise<RecordResponseBody> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
 
-    return Ajax().WorkspaceData.updateRecord(
+    return WorkspaceData().updateRecord(
       this.proxyUrl,
       recordEditParams.instance,
       recordEditParams.recordName,
@@ -353,7 +353,7 @@ export class WdsDataTableProvider implements DataTableProvider {
 
   updateAttribute = (params: UpdateAttributeParameters): Promise<Blob> => {
     if (!this.proxyUrl) return Promise.reject('Proxy Url not loaded');
-    return Ajax().WorkspaceData.updateAttribute(
+    return WorkspaceData().updateAttribute(
       this.proxyUrl,
       this.workspaceId,
       params.entityType,

--- a/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/WdsDataTableProvider.ts
@@ -14,8 +14,7 @@ import {
   UploadParameters,
 } from 'src/libs/ajax/data-table-providers/DataTableProvider';
 import { LeoAppStatus, ListAppItem } from 'src/libs/ajax/leonardo/models/app-models';
-import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
-import { Capabilities, Capability } from 'src/libs/ajax/WorkspaceDataService';
+import { Capabilities, Capability, WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { notificationStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import { notifyDataImportProgress } from 'src/workspace-data/import-jobs';

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -1,7 +1,8 @@
-import { Ajax } from 'src/libs/ajax';
 import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
+import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { GCSItem } from 'src/libs/ajax/GoogleStorage';
 import IncrementalResponse from 'src/libs/ajax/incremental-response/IncrementalResponse';
+import { SamResources } from 'src/libs/ajax/SamResources';
 
 export interface GCSFileBrowserProviderParams {
   bucket: string;
@@ -67,7 +68,7 @@ const GCSFileBrowserProvider = ({
           requestOptions.matchGlob = matchGlob;
         }
 
-        const response = await Ajax(signal).Buckets.list(project, bucket, prefix, requestOptions);
+        const response = await GoogleStorage(signal).list(project, bucket, prefix, requestOptions);
         const responseItems = (response[itemsOrPrefixes] || []).map((itemOrPrefix) => mapItemOrPrefix(itemOrPrefix));
 
         // Exclude folder placeholder objects.
@@ -141,20 +142,20 @@ const GCSFileBrowserProvider = ({
         signal,
       }),
     getDownloadUrlForFile: async (path, { signal } = {}) => {
-      return await Ajax(signal).SamResources.getSignedUrl(bucket, path);
+      return await SamResources(signal).getSignedUrl(bucket, path);
     },
     getDownloadCommandForFile: (path) => {
       return Promise.resolve(`gcloud storage cp 'gs://${bucket}/${path}' .`);
     },
     uploadFileToDirectory: (directoryPath, file) => {
-      return Ajax().Buckets.upload(project, bucket, directoryPath, file);
+      return GoogleStorage().upload(project, bucket, directoryPath, file);
     },
     deleteFile: async (path: string): Promise<void> => {
-      await Ajax().Buckets.delete(project, bucket, path);
+      await GoogleStorage().delete(project, bucket, path);
     },
     moveFile: async (sourcePath: string, destinationPath: string): Promise<void> => {
-      await Ajax().Buckets.copyWithinBucket(project, bucket, sourcePath, destinationPath);
-      await Ajax().Buckets.delete(project, bucket, sourcePath);
+      await GoogleStorage().copyWithinBucket(project, bucket, sourcePath, destinationPath);
+      await GoogleStorage().delete(project, bucket, sourcePath);
     },
     createEmptyDirectory: async (directoryPath: string) => {
       // Create a placeholder object for the new folder.
@@ -164,7 +165,7 @@ const GCSFileBrowserProvider = ({
       const prefix = prefixSegments.length === 0 ? '' : `${prefixSegments.join('/')}/`;
       const directoryName = directoryPath.split('/').slice(-2, -1)[0];
       const placeholderObject = new File([''], `${directoryName}/`, { type: 'text/plain' });
-      await Ajax().Buckets.upload(project, bucket, prefix, placeholderObject);
+      await GoogleStorage().upload(project, bucket, prefix, placeholderObject);
       return {
         path: directoryPath,
       };
@@ -175,7 +176,7 @@ const GCSFileBrowserProvider = ({
       // A placeholder object may not exist for the prefix being viewed, so do not an report error for 404 responses.
       // See https://cloud.google.com/storage/docs/folders for more information on placeholder objects.
       try {
-        await Ajax().Buckets.delete(project, bucket, directoryPath);
+        await GoogleStorage().delete(project, bucket, directoryPath);
       } catch (error) {
         if (!(error instanceof Response && error.status === 404)) {
           throw error;

--- a/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
+++ b/src/libs/ajax/file-browser-providers/GCSFileBrowserProvider.ts
@@ -1,6 +1,5 @@
 import FileBrowserProvider from 'src/libs/ajax/file-browser-providers/FileBrowserProvider';
-import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
-import { GCSItem } from 'src/libs/ajax/GoogleStorage';
+import { GCSItem, GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import IncrementalResponse from 'src/libs/ajax/incremental-response/IncrementalResponse';
 import { SamResources } from 'src/libs/ajax/SamResources';
 

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -337,7 +337,7 @@ export const Workspaces = (signal?: AbortSignal) => ({
           },
 
           // NB: This could one day perhaps redirect to CromIAM's 'workflow' like:
-          // workflow: workflowId => Ajax(signal).CromIAM.workflow(workflowId)
+          // workflow: workflowId => CromIAM(signal).workflow(workflowId)
           // But: Because of the slowness of asking via CromIAM, that's probably a non-starter for right now.
           workflow: (workflowId: string) => {
             return {

--- a/src/support/ResourcePolicies.test.tsx
+++ b/src/support/ResourcePolicies.test.tsx
@@ -24,7 +24,7 @@ describe('ResourcePolicies', () => {
     asMockedFn(SamResources).mockReturnValue(partial<SamResourcesContract>({ getResourcePolicies }));
   }
 
-  it('calls Ajax().SamResources.getResourcePolicies and displays the result', async () => {
+  it('calls SamResources().getResourcePolicies and displays the result', async () => {
     // Arrange
     const testValue = uuidv4();
     const getResourcePolicies = jest.fn(() => Promise.resolve({ policy: testValue }));

--- a/src/workflows-app/RunDetails.test.ts
+++ b/src/workflows-app/RunDetails.test.ts
@@ -2,7 +2,6 @@ import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import _ from 'lodash/fp';
 import { h } from 'react-hyperscript-helpers';
-import { AjaxContract } from 'src/libs/ajax';
 import {
   AzureBlobByUriContract,
   AzureBlobResult,
@@ -95,7 +94,7 @@ const runDetailsProps = {
 
 const captureEvent = jest.fn();
 
-const mockObj: Pick<AjaxContract, 'CromwellApp' | 'AzureStorage' | 'Metrics'> = {
+const mockObj = {
   CromwellApp: partial<CromwellAppAjaxContract>({
     workflows: () =>
       partial<WorkflowsContract>({

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -14,13 +14,6 @@ import { asMockedFn, partial, renderHookInAct } from 'src/testing/test-utils';
 import { useDeleteWorkspaceState } from 'src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState';
 import { AzureWorkspaceInfo, BaseWorkspace, GoogleWorkspaceInfo } from 'src/workspaces/utils';
 
-type AjaxExports = typeof import('src/libs/ajax');
-jest.mock('src/libs/ajax', (): AjaxExports => {
-  return {
-    ...jest.requireActual('src/libs/ajax'),
-    Ajax: jest.fn(),
-  };
-});
 jest.mock('src/libs/ajax/leonardo/Apps');
 jest.mock('src/libs/ajax/leonardo/Runtimes');
 jest.mock('src/libs/ajax/workspaces/Workspaces');


### PR DESCRIPTION
- narrow Ajax() usage within last of src/libs/ajax area modules to call Ajax().SubAreaX directly.
- demoted Ajax() to no longer be exported from ajax.ts.  It is now called AjaxTestingRoot and only a setupAjaxTestUtil method is exposed.
- setupAjaxTestUtil is called from appLoader.js since it is no longer incedentally initalized through ajax.ts module load.
- unit tests added for setupAjaxTestUtil.
- improve mock types where possible

### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Ajax() super-object has been an anti-pattern of sorts, that has been pervasive and problematic in our code base.  It's caused many lost hours to circular dependency trouble-shooting, and overly-entwined dependency footprint in general.   Previous investments carefully unraveled the circular dependencies, but with Ajax() super-object still kicking around, they could easily be re-introduced. 
- The Ajax() super-object facilitated data-call unification and bespoke data-call override mechanics that facilitated script-like test setup convenience for some of our end2end tests to perform workspace, runitme, etc preconditions through direct data calls before the main test scenario.  This seemed more valuable when end2end tests were the only real automated testing footprint for Terra UI.  But we have now invested in a growing set of unit tests, which provide great coverage, speed, and other benefits over end2end tests.  So we have been reducing the number and complexity of end2end tests, making the Ajax() testing root pattern something we should probably discourage.  It is kept for current compatibility, but would be nice to one day simplify out it's need in the remaining end2end tests that still use it.
- This series of PRs has also taken the opportunity to optimize type safety in many of our unit tests.  Lack of type safety on mock signatures is a nasty gap, since it would leave us blind to contract drift.  Tests would continue to pass even though their mocks no longer reflect reality.  This has been addressed in all tests that were mocking Ajax() subareas.
- Ajax mocking was also clunky since tests has to mock the outer and inner function/contract layers. This has also been cleaned up.  

### Why
- improve code maintainability, improve modularity and potential code sharing by simplifying dependency graph.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
