### PR TITLE
CORE-299 don't do b2c signout when there is no user

### DIFF
--- a/src/auth/oidc-broker.ts
+++ b/src/auth/oidc-broker.ts
@@ -40,6 +40,7 @@ export const getOidcConfig = () => {
     // Leo's setCookie interval is currently 5 min, set refresh auth then 5 min 30 seconds to guarantee that setCookie's token won't expire between 2 setCookie api calls
     accessTokenExpiringNotificationTimeInSeconds: 330,
     includeIdTokenInSilentRenew: true,
+    includeIdTokenInSilentSignout: true,
     extraQueryParams: { access_type: 'offline' },
     redirect_uri: '', // this field is not being used currently, but is expected from UserManager
   };

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -65,6 +65,9 @@ describe('sign-out', () => {
     asMockedFn(Metrics).mockReturnValue({
       captureEvent: captureEventFn,
     } as Partial<MetricsContract> as MetricsContract);
+    asMockedFn(oidcStore.get).mockReturnValue({
+      userManager: { getUser: jest.fn().mockReturnValue('not null') },
+    } as unknown as OidcState);
 
     // Act
     signOut();
@@ -77,6 +80,9 @@ describe('sign-out', () => {
     asMockedFn(Metrics).mockReturnValue({
       captureEvent: captureEventFn,
     } as Partial<MetricsContract> as MetricsContract);
+    asMockedFn(oidcStore.get).mockReturnValue({
+      userManager: { getUser: jest.fn().mockReturnValue('not null') },
+    } as unknown as OidcState);
 
     // Act
     signOut('idleStatusMonitor');

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -91,7 +91,7 @@ describe('sign-out', () => {
     const link = '/signout';
     const expectedState = btoa(JSON.stringify({ signOutRedirect: currentRoute, signOutCause: 'unspecified' }));
     asMockedFn(oidcStore.get).mockReturnValue({
-      userManager: { signoutRedirect: signOutRedirectFn },
+      userManager: { signoutRedirect: signOutRedirectFn, getUser: jest.fn().mockReturnValue('not null') },
     } as unknown as OidcState);
     asMockedFn(leoCookieProvider.unsetCookies).mockImplementation(unsetCookiesFn);
     asMockedFn(Nav.getPath).mockReturnValue(link);
@@ -116,6 +116,7 @@ describe('sign-out', () => {
     asMockedFn(oidcStore.get).mockReturnValue({
       userManager: {
         signoutRedirect: signOutRedirectFn,
+        getUser: jest.fn().mockReturnValue('not null'),
       },
     } as unknown as OidcState);
     asMockedFn(removeUserFromLocalState).mockImplementation(removeUserFromLocalStateFn);
@@ -128,6 +129,23 @@ describe('sign-out', () => {
       'Signing out with B2C failed. Falling back on local signout',
       expect.any(Error)
     );
+    expect(removeUserFromLocalStateFn).toHaveBeenCalled();
+    expect(goToRootFn).toHaveBeenCalledWith('root');
+  });
+  it('calls userSignedOut if getUser returns null', async () => {
+    // Arrange
+    const removeUserFromLocalStateFn = jest.fn();
+    const goToRootFn = jest.fn();
+    asMockedFn(oidcStore.get).mockReturnValue({
+      userManager: {
+        getUser: jest.fn().mockReturnValue(null),
+      },
+    } as unknown as OidcState);
+    asMockedFn(removeUserFromLocalState).mockImplementation(removeUserFromLocalStateFn);
+    asMockedFn(goToPath).mockImplementation(goToRootFn);
+    // Act
+    await doSignOut();
+    // Assert
     expect(removeUserFromLocalStateFn).toHaveBeenCalled();
     expect(goToRootFn).toHaveBeenCalledWith('root');
   });

--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -52,6 +52,7 @@ jest.mock('src/libs/state', (): StateExports => {
       get: jest.fn().mockReturnValue({
         userManager: {
           signoutRedirect: jest.fn(() => 'Default signOutRedirectFn'),
+          getUser: jest.fn().mockReturnValue('not null'),
         },
       }),
     },
@@ -65,9 +66,6 @@ describe('sign-out', () => {
     asMockedFn(Metrics).mockReturnValue({
       captureEvent: captureEventFn,
     } as Partial<MetricsContract> as MetricsContract);
-    asMockedFn(oidcStore.get).mockReturnValue({
-      userManager: { getUser: jest.fn().mockReturnValue('not null') },
-    } as unknown as OidcState);
 
     // Act
     signOut();
@@ -80,9 +78,6 @@ describe('sign-out', () => {
     asMockedFn(Metrics).mockReturnValue({
       captureEvent: captureEventFn,
     } as Partial<MetricsContract> as MetricsContract);
-    asMockedFn(oidcStore.get).mockReturnValue({
-      userManager: { getUser: jest.fn().mockReturnValue('not null') },
-    } as unknown as OidcState);
 
     // Act
     signOut('idleStatusMonitor');

--- a/src/auth/signout/sign-out.ts
+++ b/src/auth/signout/sign-out.ts
@@ -47,10 +47,16 @@ export const doSignOut = async (signOutCause: SignOutCause = 'unspecified'): Pro
     const { name, query, params }: SignOutRedirect = Nav.getCurrentRoute();
     const signOutState: SignOutState = { signOutRedirect: { name, query, params }, signOutCause };
     const encodedState = btoa(JSON.stringify(signOutState));
-    userManager!.signoutRedirect({
-      post_logout_redirect_uri: redirectUrl,
-      extraQueryParams: { state: encodedState },
-    });
+    const user = await userManager!.getUser();
+    if (user) {
+      userManager!.signoutRedirect({
+        post_logout_redirect_uri: redirectUrl,
+        extraQueryParams: { state: encodedState },
+      });
+    } else {
+      userSignedOut(signOutCause, true);
+      Nav.goToPath('root');
+    }
   } catch (e: unknown) {
     console.error('Signing out with B2C failed. Falling back on local signout', e);
     userSignedOut(signOutCause, true);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-299

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Recent changes to azure b2c require an id token to be passed to the sign out call. But Terra UI does not have a valid user after a session has expired. The prior code called the b2c sign out flow regardless which triggered the error when there is no user. The new code only calls b2c if there is a user. This is fine because the azure b2c session is already expired so b2c sign out is meaningless.

### What
- 

### Why
-

### Testing strategy
Open Terra, sign in, close browser, wait 24 hours, open Terra again.
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
