### PR TITLE
[CORE-283] Disable user suggestions in sharing modals

### DIFF
--- a/src/groups/Members/EmailSelect.tsx
+++ b/src/groups/Members/EmailSelect.tsx
@@ -74,6 +74,7 @@ export const EmailSelect: React.FC<EmailSelectProps> = ({
         onBlur={handleOnBlur}
         onChange={handleOnChange}
         height={200}
+        noOptionsMessage={() => null}
       />
     </>
   );

--- a/src/groups/Members/NewMemberModal.tsx
+++ b/src/groups/Members/NewMemberModal.tsx
@@ -44,6 +44,8 @@ export const NewMemberModal = (props: NewMemberModalProps) => {
 
   const signal = useCancellation();
 
+  const enableShareLog = false; // Set "true" to enable suggestions
+
   useOnMount(() => {
     const loadData = withErrorReporting('Error looking up collaborators')(async () => {
       const [shareSuggestions, groups] = await Promise.all([Workspaces(signal).getShareLog(), Groups(signal).list()]);
@@ -52,7 +54,7 @@ export const NewMemberModal = (props: NewMemberModalProps) => {
 
       setSuggestions(suggestions);
     });
-    loadData();
+    enableShareLog && loadData();
   });
 
   const submit = async () => {

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.tsx
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.tsx
@@ -59,6 +59,8 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
 
   const signal = useCancellation();
 
+  const enableShareLog = false; // Set "true" to enable suggestions
+
   // Lifecycle
   useOnMount(() => {
     const load = async () => {
@@ -100,7 +102,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
     _.uniq
   )(groups);
 
-  const remainingSuggestions = _.difference(suggestions, _.map('email', acl));
+  const remainingSuggestions = enableShareLog ? _.difference(suggestions, _.map('email', acl)) : [];
   const addUserReminder =
     'Did you mean to add collaborators? Add them or clear the "User emails" field to save changes.';
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-283

### What
- This PR disables user suggestions in the groups, billing project, and workspace sharing modals while keeping the backend code intact for quick reversion if needed.

### Why
- We’re removing Elasticsearch dependencies from Orchestration. This is a scream test to see if we can remove the “sharelog” feature without issues before fully deleting it.

### Testing strategy
- Manual Testing: Checked that the groups, billing project, and workspace sharing modals no longer show suggestions.

**Share Workspace Modal**
<img width="1792" alt="Share Workspaces" src="https://github.com/user-attachments/assets/69077ee7-5b2e-4532-a337-3700e4ef1878" />

**Share Group Modal**
<img width="1792" alt="Share Billing Projects" src="https://github.com/user-attachments/assets/a725eb14-f09d-4e02-9f15-d56f13322bd2" />

**Share Billing Project Modal**
<img width="1792" alt="Share Groups" src="https://github.com/user-attachments/assets/18651cf5-b6b5-4d87-8db9-4c047518c2b8" />

