### PR TITLE
CORE-311 no redirect after calling userSignedOut

### DIFF
--- a/src/auth/signout/sign-out.test.ts
+++ b/src/auth/signout/sign-out.test.ts
@@ -4,7 +4,6 @@ import { leoCookieProvider } from 'src/libs/ajax/leonardo/providers/LeoCookiePro
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
-import { goToPath } from 'src/libs/nav';
 import { OidcState, oidcStore } from 'src/libs/state';
 import { asMockedFn } from 'src/testing/test-utils';
 
@@ -36,7 +35,6 @@ jest.mock('src/libs/nav', (): NavExports => {
   return {
     ...jest.requireActual<NavExports>('src/libs/nav'),
     getPath: jest.fn().mockReturnValue('/signout'),
-    goToPath: jest.fn(),
     getWindowOrigin: jest.fn(),
     getCurrentRoute: jest.fn().mockReturnValue(currentRoute),
   };
@@ -113,7 +111,6 @@ describe('sign-out', () => {
       throw new Error('test error');
     });
     const removeUserFromLocalStateFn = jest.fn();
-    const goToRootFn = jest.fn();
     asMockedFn(oidcStore.get).mockReturnValue({
       userManager: {
         signoutRedirect: signOutRedirectFn,
@@ -121,7 +118,6 @@ describe('sign-out', () => {
       },
     } as unknown as OidcState);
     asMockedFn(removeUserFromLocalState).mockImplementation(removeUserFromLocalStateFn);
-    asMockedFn(goToPath).mockImplementation(goToRootFn);
     const consoleErrorFn = jest.spyOn(console, 'error').mockImplementation(() => {});
     // Act
     await doSignOut();
@@ -131,23 +127,19 @@ describe('sign-out', () => {
       expect.any(Error)
     );
     expect(removeUserFromLocalStateFn).toHaveBeenCalled();
-    expect(goToRootFn).toHaveBeenCalledWith('root');
   });
   it('calls userSignedOut if getUser returns null', async () => {
     // Arrange
     const removeUserFromLocalStateFn = jest.fn();
-    const goToRootFn = jest.fn();
     asMockedFn(oidcStore.get).mockReturnValue({
       userManager: {
         getUser: jest.fn().mockReturnValue(null),
       },
     } as unknown as OidcState);
     asMockedFn(removeUserFromLocalState).mockImplementation(removeUserFromLocalStateFn);
-    asMockedFn(goToPath).mockImplementation(goToRootFn);
     // Act
     await doSignOut();
     // Assert
     expect(removeUserFromLocalStateFn).toHaveBeenCalled();
-    expect(goToRootFn).toHaveBeenCalledWith('root');
   });
 });

--- a/src/auth/signout/sign-out.ts
+++ b/src/auth/signout/sign-out.ts
@@ -55,12 +55,10 @@ export const doSignOut = async (signOutCause: SignOutCause = 'unspecified'): Pro
       });
     } else {
       userSignedOut(signOutCause, true);
-      Nav.goToPath('root');
     }
   } catch (e: unknown) {
     console.error('Signing out with B2C failed. Falling back on local signout', e);
     userSignedOut(signOutCause, true);
-    Nav.goToPath('root');
   }
 };
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-311

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- when a user's session expires we no longer redirect to b2c to log the user out because b2c has already done so. Recently introduced code instead calls `userSignedOut` directly to clear local state. The new code also redirects to root just like it did in the error condition. It turns out that clearing the local state puts up the sign in page all by itself and redirecting to root is not a good UX.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
