### PR TITLE
[CORE-175] Remove call to storage apis during permission check

### DIFF
--- a/src/workspaces/common/state/useWorkspace.test.ts
+++ b/src/workspaces/common/state/useWorkspace.test.ts
@@ -345,57 +345,6 @@ describe('useWorkspace', () => {
     expect(captureEventFn).toHaveBeenCalledTimes(1);
   });
 
-  it('can read workspace details from server, and poll until permissions synced (handling storageCostEstimate failure)', async () => {
-    // Arrange
-    // remove workspaceInitialized because the server response does not include this information
-    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
-
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () =>
-          partial<WorkspaceContract>({
-            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-            checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: () =>
-              Promise.reject(new Response('Mock storage cost estimate error', { status: 500 })),
-            bucketUsage: jest.fn(),
-          }),
-      })
-    );
-
-    // Verify initial failure based on error mock.
-    const { result } = await verifyGooglePermissionsFailure();
-
-    // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result);
-  });
-
-  it('can read workspace details from server, and poll until permissions synced (handling bucketUsage failure)', async () => {
-    // Arrange
-    // remove workspaceInitialized because the server response does not include this information
-    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
-
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () =>
-          partial<WorkspaceContract>({
-            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-            checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: () => Promise.reject(new Response('Mock bucket usage error', { status: 500 })),
-          }),
-      })
-    );
-
-    // Verify initial failure based on error mock.
-    const { result } = await verifyGooglePermissionsFailure();
-
-    // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result);
-  });
-
   it('can read workspace details from server, and poll until permissions synced (handling checkBucketLocation failure)', async () => {
     // Arrange
     // remove workspaceInitialized because the server response does not include this information

--- a/src/workspaces/common/state/useWorkspace.ts
+++ b/src/workspaces/common/state/useWorkspace.ts
@@ -99,13 +99,6 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
       // to be done syncing until all the methods that we know will be called quickly in succession succeed.
       // This is not guaranteed to eliminate the issue, but it improves the odds.
       await Workspaces(signal).workspace(namespace, name).checkBucketReadAccess();
-      if (canWrite(workspace.accessLevel)) {
-        // Calls done on the Workspace Dashboard. We could store the results and pass them
-        // through, but then we would have to do it checkWorkspaceInitialization as well,
-        // and nobody else actually needs these values.
-        await Workspaces(signal).workspace(namespace, name).storageCostEstimate();
-        await Workspaces(signal).workspace(namespace, name).bucketUsage();
-      }
       await loadGoogleBucketLocation();
       updateWorkspaceInStore(workspace, true);
     } catch (error: any) {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-175

This PR removes an extra call to the `storageEstimate` and `bucketUsage` APIs during google permissions check.  These calls disregard the response, and the APIs are called again later when their values are needed.  Both APIs use the rawls SA, so they shouldn't affect the result of a user's google permissions check.  This has the bonus of allowing these APIs to potentially throw errors without sending the page into forever checking permissions. 

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
