### PR TITLE
[CORE-175] use getStorageCostEstimateV2 instead of v2 and getBucketUsage

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -10,7 +10,6 @@ import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
 import { FieldsArg } from 'src/libs/ajax/workspaces/providers/WorkspaceProvider';
 import {
   AttributeEntityReference,
-  BucketUsageResponse,
   EntityUpdateDefinition,
   MethodConfiguration,
   RawWorkspaceAcl,
@@ -606,9 +605,9 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return res.blob();
       },
 
-      storageCostEstimate: async (): Promise<StorageCostEstimate> => {
+      storageCostEstimateV2: async (): Promise<StorageCostEstimate> => {
         const res = await fetchOrchestration(
-          `api/workspaces/${namespace}/${name}/storageCostEstimate`,
+          `api/workspaces/v2/${namespace}/${name}/storageCostEstimate`,
           _.merge(authOpts(), { signal })
         );
         return res.json();
@@ -638,10 +637,10 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return res.json();
       },
 
-      bucketUsage: async (): Promise<BucketUsageResponse> => {
-        const res = await fetchRawls(`${root}/bucketUsage`, _.merge(authOpts(), { signal }));
-        return res.json();
-      },
+      // bucketUsage: async (): Promise<BucketUsageResponse> => {
+      //   const res = await fetchRawls(`${root}/bucketUsage`, _.merge(authOpts(), { signal }));
+      //   return res.json();
+      // },
 
       listActiveFileTransfers: async (): Promise<any[]> => {
         const res = await fetchRawls(`${root}/fileTransfers`, _.merge(authOpts(), { signal }));

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -637,11 +637,6 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return res.json();
       },
 
-      // bucketUsage: async (): Promise<BucketUsageResponse> => {
-      //   const res = await fetchRawls(`${root}/bucketUsage`, _.merge(authOpts(), { signal }));
-      //   return res.json();
-      // },
-
       listActiveFileTransfers: async (): Promise<any[]> => {
         const res = await fetchRawls(`${root}/fileTransfers`, _.merge(authOpts(), { signal }));
         return res.json();

--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -232,7 +232,7 @@ export interface AttributeEntityReference {
 }
 
 export interface StorageCostEstimate {
-  estimate: string;
+  estimate: number;
   usageInBytes: number;
   lastUpdated?: string;
 }

--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -233,10 +233,6 @@ export interface AttributeEntityReference {
 
 export interface StorageCostEstimate {
   estimate: string;
-  lastUpdated?: string;
-}
-
-export interface BucketUsageResponse {
   usageInBytes: number;
   lastUpdated?: string;
 }

--- a/src/pages/workspaces/workspace/Workflows.test.ts
+++ b/src/pages/workspaces/workspace/Workflows.test.ts
@@ -70,8 +70,7 @@ describe('Find Workflow modal in Workflows view', () => {
           partial<WorkspaceContract>({
             details: jest.fn().mockResolvedValue(mockGoogleWorkspace),
             checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: jest.fn(),
+            storageCostEstimateV2: jest.fn(),
             checkBucketLocation: jest.fn().mockResolvedValue(mockStorageDetails),
             listMethodConfigs: jest.fn(),
           }),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -270,8 +270,7 @@ describe('Workflow View (GCP)', () => {
           gcpDataRepoSnapshots: [],
         }),
         checkBucketReadAccess: jest.fn(),
-        storageCostEstimate: jest.fn(),
-        bucketUsage: jest.fn(),
+        storageCostEstimateV2: jest.fn(),
         checkBucketLocation: jest.fn().mockResolvedValue(mockStorageDetails),
         methodConfig: () => ({
           save: jest.fn().mockReturnValue(mockSave),

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -2,7 +2,7 @@ import { act } from '@testing-library/react';
 import { generateTestApp } from 'src/analysis/_testData/testData';
 import { Apps, AppsAjaxContract } from 'src/libs/ajax/leonardo/Apps';
 import { Runtimes, RuntimesAjaxContract } from 'src/libs/ajax/leonardo/Runtimes';
-import { BucketUsageResponse, RawAccessEntry } from 'src/libs/ajax/workspaces/workspace-models';
+import { RawAccessEntry, StorageCostEstimate } from 'src/libs/ajax/workspaces/workspace-models';
 import {
   WorkspaceContract,
   Workspaces,
@@ -73,12 +73,13 @@ describe('useDeleteWorkspaceState', () => {
 
     const getAcl: WorkspaceContract['getAcl'] = jest.fn();
     asMockedFn(getAcl).mockResolvedValue({ acl: { 'example1@example.com': partial<RawAccessEntry>({}) } });
-    const bucketUsage: WorkspaceContract['bucketUsage'] = jest.fn();
-    asMockedFn(bucketUsage).mockResolvedValue({ usageInBytes: 1234 });
+
+    const storageCostEstimateV2: WorkspaceContract['storageCostEstimateV2'] = jest.fn();
+    asMockedFn(storageCostEstimateV2).mockResolvedValue({ estimate: '$0.02', usageInBytes: 1234 });
 
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
-        workspace: () => partial<WorkspaceContract>({ getAcl, bucketUsage }),
+        workspace: () => partial<WorkspaceContract>({ getAcl, storageCostEstimateV2 }),
       })
     );
     asMockedFn(Apps).mockReturnValue(partial<AppsAjaxContract>({ listWithoutProject }));
@@ -99,7 +100,7 @@ describe('useDeleteWorkspaceState', () => {
       saturnWorkspaceName: googleWorkspace.workspace.name,
     });
     expect(getAcl).toHaveBeenCalledTimes(1);
-    expect(bucketUsage).toHaveBeenCalledTimes(1);
+    expect(storageCostEstimateV2).toHaveBeenCalledTimes(1);
   });
 
   it('can initialize state for an azure workspace', async () => {
@@ -191,7 +192,7 @@ describe('useDeleteWorkspaceState', () => {
         workspace: () =>
           partial<WorkspaceContract>({
             getAcl: async () => ({ acl: {} }),
-            bucketUsage: async () => partial<BucketUsageResponse>({}),
+            storageCostEstimateV2: async () => partial<StorageCostEstimate>({}),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({
@@ -227,7 +228,7 @@ describe('useDeleteWorkspaceState', () => {
         workspace: () =>
           partial<WorkspaceContract>({
             getAcl: async () => ({ acl: {} }),
-            bucketUsage: async () => partial<BucketUsageResponse>({}),
+            storageCostEstimateV2: async () => partial<StorageCostEstimate>({}),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({
@@ -263,7 +264,7 @@ describe('useDeleteWorkspaceState', () => {
         workspace: () =>
           partial<WorkspaceContract>({
             getAcl: async () => ({ acl: {} }),
-            bucketUsage: async () => {
+            storageCostEstimateV2: async () => {
               throw new Error('no project!');
             },
           }),

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -75,7 +75,7 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(getAcl).mockResolvedValue({ acl: { 'example1@example.com': partial<RawAccessEntry>({}) } });
 
     const storageCostEstimateV2: WorkspaceContract['storageCostEstimateV2'] = jest.fn();
-    asMockedFn(storageCostEstimateV2).mockResolvedValue({ estimate: '$0.02', usageInBytes: 1234 });
+    asMockedFn(storageCostEstimateV2).mockResolvedValue({ estimate: 0.02, usageInBytes: 1234 });
 
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.ts
@@ -91,7 +91,7 @@ export const useDeleteWorkspaceState = (hookArgs: DeleteWorkspaceHookArgs): Dele
           Workspaces(signal).workspace(workspaceInfo.namespace, workspaceInfo.name).getAcl(),
           Workspaces(signal)
             .workspace(workspaceInfo.namespace, workspaceInfo.name)
-            .bucketUsage()
+            .storageCostEstimateV2()
             .catch((_error) => undefined),
         ]);
         setCollaboratorEmails(_.without([getTerraUser().email!], _.keys(acl)));

--- a/src/workspaces/common/state/useWorkspace.test.ts
+++ b/src/workspaces/common/state/useWorkspace.test.ts
@@ -274,8 +274,7 @@ describe('useWorkspace', () => {
           partial<WorkspaceContract>({
             checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
             checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: jest.fn(),
+            storageCostEstimateV2: jest.fn(),
           }),
       })
     );
@@ -345,57 +344,6 @@ describe('useWorkspace', () => {
     expect(captureEventFn).toHaveBeenCalledTimes(1);
   });
 
-  it('can read workspace details from server, and poll until permissions synced (handling storageCostEstimate failure)', async () => {
-    // Arrange
-    // remove workspaceInitialized because the server response does not include this information
-    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
-
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () =>
-          partial<WorkspaceContract>({
-            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-            checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: () =>
-              Promise.reject(new Response('Mock storage cost estimate error', { status: 500 })),
-            bucketUsage: jest.fn(),
-          }),
-      })
-    );
-
-    // Verify initial failure based on error mock.
-    const { result } = await verifyGooglePermissionsFailure();
-
-    // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result);
-  });
-
-  it('can read workspace details from server, and poll until permissions synced (handling bucketUsage failure)', async () => {
-    // Arrange
-    // remove workspaceInitialized because the server response does not include this information
-    const { workspaceInitialized, ...serverWorkspaceResponse } = initializedGoogleWorkspace;
-
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () =>
-          partial<WorkspaceContract>({
-            details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
-            checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
-            checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: () => Promise.reject(new Response('Mock bucket usage error', { status: 500 })),
-          }),
-      })
-    );
-
-    // Verify initial failure based on error mock.
-    const { result } = await verifyGooglePermissionsFailure();
-
-    // Finally, change mock to pass all checks verify success.
-    await verifyGooglePermissionsSuccess(result);
-  });
-
   it('can read workspace details from server, and poll until permissions synced (handling checkBucketLocation failure)', async () => {
     // Arrange
     // remove workspaceInitialized because the server response does not include this information
@@ -408,8 +356,7 @@ describe('useWorkspace', () => {
             details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
             checkBucketLocation: () => Promise.reject(new Response('Mock check bucket location', { status: 500 })),
             checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: jest.fn(),
+            storageCostEstimateV2: jest.fn(),
           }),
       })
     );
@@ -437,8 +384,7 @@ describe('useWorkspace', () => {
             details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
             checkBucketLocation: jest.fn().mockResolvedValue(bucketLocationResponse),
             checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: () => Promise.reject(new Response('Should not call', { status: 500 })),
-            bucketUsage: () => Promise.reject(new Response('Should not call', { status: 500 })),
+            storageCostEstimateV2: () => Promise.reject(new Response('Should not call', { status: 500 })),
           }),
       })
     );
@@ -476,8 +422,7 @@ describe('useWorkspace', () => {
           partial<WorkspaceContract>({
             details: jest.fn().mockResolvedValue(serverWorkspaceResponse),
             checkBucketReadAccess: jest.fn(),
-            storageCostEstimate: jest.fn(),
-            bucketUsage: jest.fn(),
+            storageCostEstimateV2: jest.fn(),
             checkBucketLocation: checkBucketLocationMock,
           }),
       })

--- a/src/workspaces/common/state/useWorkspace.ts
+++ b/src/workspaces/common/state/useWorkspace.ts
@@ -99,13 +99,6 @@ export const useWorkspace = (namespace, name): WorkspaceDetails => {
       // to be done syncing until all the methods that we know will be called quickly in succession succeed.
       // This is not guaranteed to eliminate the issue, but it improves the odds.
       await Workspaces(signal).workspace(namespace, name).checkBucketReadAccess();
-      if (canWrite(workspace.accessLevel)) {
-        // Calls done on the Workspace Dashboard. We could store the results and pass them
-        // through, but then we would have to do it checkWorkspaceInitialization as well,
-        // and nobody else actually needs these values.
-        await Workspaces(signal).workspace(namespace, name).storageCostEstimate();
-        await Workspaces(signal).workspace(namespace, name).bucketUsage();
-      }
       await loadGoogleBucketLocation();
       updateWorkspaceInStore(workspace, true);
     } catch (error: any) {

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -61,14 +61,12 @@ describe('CloudInformation', () => {
 
   it('does not retrieve bucket and storage estimate when the workspace is not initialized', async () => {
     // Arrange
-    const mockBucketUsage = jest.fn();
-    const mockStorageCostEstimate = jest.fn();
+    const mockStorageCostEstimateV2 = jest.fn();
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimate: mockStorageCostEstimate,
-            bucketUsage: mockBucketUsage,
+            storageCostEstimateV2: mockStorageCostEstimateV2,
           }),
       })
     );
@@ -81,23 +79,21 @@ describe('CloudInformation', () => {
     // Assert
     expect(screen.getByTitle('Google Cloud Platform')).not.toBeNull;
 
-    expect(mockBucketUsage).not.toHaveBeenCalled();
-    expect(mockStorageCostEstimate).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
   });
 
   it('retrieves bucket and storage estimate when the workspace is initialized', async () => {
     // Arrange
-    const mockBucketUsage = jest.fn().mockResolvedValue({ usageInBytes: 100, lastUpdated: '2023-11-01' });
-    const mockStorageCostEstimate = jest.fn().mockResolvedValue({
+    const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
       estimate: '1 million dollars',
+      usageInBytes: 100,
       lastUpdated: '2023-12-01',
     });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimate: mockStorageCostEstimate,
-            bucketUsage: mockBucketUsage,
+            storageCostEstimateV2: mockStorageCostEstimateV2,
           }),
       })
     );
@@ -112,26 +108,22 @@ describe('CloudInformation', () => {
     // Assert
     expect(screen.getByTitle('Google Cloud Platform')).not.toBeNull;
     // Cost estimate
-    expect(screen.getByText('Updated on 12/1/2023')).not.toBeNull();
+    expect(screen.getAllByText('Updated on 12/1/2023')).not.toBeNull();
     expect(screen.getByText('1 million dollars')).not.toBeNull();
     // Bucket usage
-    expect(screen.getByText('Updated on 11/1/2023')).not.toBeNull();
     expect(screen.getByText('100 B')).not.toBeNull();
 
-    expect(mockBucketUsage).toHaveBeenCalled();
-    expect(mockStorageCostEstimate).toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
   });
 
   const copyButtonTestSetup = async () => {
     const captureEvent = jest.fn();
-    const mockBucketUsage = jest.fn();
-    const mockStorageCostEstimate = jest.fn();
+    const mockStorageCostEstimateV2 = jest.fn();
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimate: mockStorageCostEstimate,
-            bucketUsage: mockBucketUsage,
+            storageCostEstimateV2: mockStorageCostEstimateV2,
           }),
       })
     );
@@ -182,17 +174,16 @@ describe('CloudInformation', () => {
   it('can use the info button to display additional information about cost', async () => {
     // Arrange
     const user = userEvent.setup();
-    const mockBucketUsage = jest.fn().mockResolvedValue({ usageInBytes: 15, lastUpdated: '2024-07-15' });
-    const mockStorageCostEstimate = jest.fn().mockResolvedValue({
+    const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
       estimate: '2 dollars',
+      usageInBytes: 15,
       lastUpdated: '2024-07-15',
     });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimate: mockStorageCostEstimate,
-            bucketUsage: mockBucketUsage,
+            storageCostEstimateV2: mockStorageCostEstimateV2,
           }),
       })
     );
@@ -204,17 +195,17 @@ describe('CloudInformation', () => {
     await user.click(screen.getByLabelText('More info'));
 
     // Assert
-    expect(
-      screen.getAllByText('Based on list price. Does not include savings from Autoclass or other discounts.')
-    ).not.toBeNull();
+    expect(screen.getAllByText('Based on list price. Does not include discounts.')).not.toBeNull();
   });
 
   it('displays bucket size for users with reader access', async () => {
     // Arrange
-    const mockBucketUsage = jest.fn().mockResolvedValue({ usageInBytes: 50, lastUpdated: '2024-07-26' });
+    const mockStorageCostEstimateV2 = jest
+      .fn()
+      .mockResolvedValue({ estimate: '$1.23', usageInBytes: 50, lastUpdated: '2024-07-26' });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
-        workspace: () => partial<WorkspaceContract>({ bucketUsage: mockBucketUsage }),
+        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
       })
     );
 
@@ -231,6 +222,6 @@ describe('CloudInformation', () => {
     // Assert
     expect(screen.getByText('Updated on 7/26/2024')).not.toBeNull();
     expect(screen.getByText('50 B')).not.toBeNull();
-    expect(mockBucketUsage).toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
   });
 });

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -85,7 +85,7 @@ describe('CloudInformation', () => {
   it('retrieves bucket and storage estimate when the workspace is initialized', async () => {
     // Arrange
     const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
-      estimate: '1 million dollars',
+      estimate: 1000000,
       usageInBytes: 100,
       lastUpdated: '2023-12-01',
     });
@@ -109,7 +109,7 @@ describe('CloudInformation', () => {
     expect(screen.getByTitle('Google Cloud Platform')).not.toBeNull;
     // Cost estimate
     expect(screen.getAllByText('Updated on 12/1/2023')).not.toBeNull();
-    expect(screen.getByText('1 million dollars')).not.toBeNull();
+    expect(screen.getByText('$1,000,000.00')).not.toBeNull();
     // Bucket usage
     expect(screen.getByText('100 B')).not.toBeNull();
 
@@ -175,7 +175,7 @@ describe('CloudInformation', () => {
     // Arrange
     const user = userEvent.setup();
     const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
-      estimate: '2 dollars',
+      estimate: 2.0,
       usageInBytes: 15,
       lastUpdated: '2024-07-15',
     });
@@ -202,7 +202,7 @@ describe('CloudInformation', () => {
     // Arrange
     const mockStorageCostEstimateV2 = jest
       .fn()
-      .mockResolvedValue({ estimate: '$1.23', usageInBytes: 50, lastUpdated: '2024-07-26' });
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, lastUpdated: '2024-07-26' });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -96,23 +96,14 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
 
     const loadStorageCost = withErrorReporting('Error loading storage cost data')(async () => {
       try {
-        const { estimate, lastUpdated } = await Workspaces(signal).workspace(namespace, name).storageCostEstimate();
+        const { estimate, usageInBytes, lastUpdated } = await Workspaces(signal)
+          .workspace(namespace, name)
+          .storageCostEstimateV2();
         setStorageCost({ isSuccess: true, estimate, lastUpdated });
-      } catch (error) {
-        if (error instanceof Response && error.status === 404) {
-          setStorageCost({ isSuccess: false, estimate: 'Not available' });
-        } else {
-          throw error;
-        }
-      }
-    });
-
-    const loadBucketSize = withErrorReporting('Error loading bucket size.')(async () => {
-      try {
-        const { usageInBytes, lastUpdated } = await Workspaces(signal).workspace(namespace, name).bucketUsage();
         setBucketSize({ isSuccess: true, usage: formatBytes(usageInBytes), lastUpdated });
       } catch (error) {
         if (error instanceof Response && error.status === 404) {
+          setStorageCost({ isSuccess: false, estimate: 'Not available' });
           setBucketSize({ isSuccess: false, usage: 'Not available' });
         } else {
           throw error;
@@ -122,9 +113,6 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
 
     if (workspace.workspaceInitialized) {
       if (canRead(accessLevel)) {
-        loadBucketSize();
-      }
-      if (canWrite(accessLevel)) {
         loadStorageCost();
       }
     }
@@ -183,7 +171,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           [
             storageCost?.estimate || '$ ...',
             h(InfoBox, { style: { marginLeft: '1ch' }, side: 'top' }, [
-              'Based on list price. Does not include savings from Autoclass or other discounts.',
+              'Based on list price. Does not include discounts.',
             ]),
           ]
         ),

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -1,5 +1,5 @@
 import { InfoBox, Link } from '@terra-ui-packages/components';
-import { cond } from '@terra-ui-packages/core-utils';
+import { cond, formatUSD } from '@terra-ui-packages/core-utils';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
 import { div, dl, h } from 'react-hyperscript-helpers';
 import { bucketBrowserUrl } from 'src/auth/auth';
@@ -99,7 +99,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
         const { estimate, usageInBytes, lastUpdated } = await Workspaces(signal)
           .workspace(namespace, name)
           .storageCostEstimateV2();
-        setStorageCost({ isSuccess: true, estimate, lastUpdated });
+        setStorageCost({ isSuccess: true, estimate: formatUSD(estimate), lastUpdated });
         setBucketSize({ isSuccess: true, usage: formatBytes(usageInBytes), lastUpdated });
       } catch (error) {
         if (error instanceof Response && error.status === 404) {

--- a/src/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/workspaces/migration/WorkspaceItem.test.ts
@@ -22,7 +22,7 @@ describe('WorkspaceItem', () => {
   };
   const migrateButtonText = `Migrate ${unscheduledWorkspace.name}`;
   const migrationScheduledTooltipText = 'Migration has been scheduled';
-  const mockGetBucketUsage: WorkspaceContract['bucketUsage'] = jest.fn();
+  const mockStorageCostEstimateV2: WorkspaceContract['storageCostEstimateV2'] = jest.fn();
   const mockMigrationStartedCallback = jest.fn();
 
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            bucketUsage: mockGetBucketUsage,
+            storageCostEstimateV2: mockStorageCostEstimateV2,
           }),
       })
     );
@@ -46,7 +46,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            bucketUsage: async () => ({ usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
           }),
       })
     );
@@ -72,7 +72,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            bucketUsage: async () => ({ usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({
@@ -112,7 +112,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            bucketUsage: async () => ({ usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({
@@ -152,7 +152,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            bucketUsage: async () => {
+            storageCostEstimateV2: async () => {
               throw new Error('testing');
             },
           }),
@@ -206,7 +206,7 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('april29');
     await screen.findByText('Migration Complete');
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
     expect(screen.queryByText(migrateButtonText)).toBeNull();
   });
 
@@ -238,7 +238,7 @@ describe('WorkspaceItem', () => {
     await screen.findByText('Migration Failed');
     await screen.findByText('Bucket migration failure reason');
     expect(screen.queryByText(migrateButtonText)).toBeNull();
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
     expect(await axe(container)).toHaveNoViolations();
   });
 
@@ -266,7 +266,7 @@ describe('WorkspaceItem', () => {
       // Assert
       await screen.findByText(expectedStatus);
       expect(screen.queryByText(migrateButtonText)).toBeNull();
-      expect(mockGetBucketUsage).not.toHaveBeenCalled();
+      expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
       expect(await axe(container)).toHaveNoViolations();
     }
   );
@@ -304,7 +304,7 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('Christina test');
     await screen.findByText('Initial Transfer in Progress (1000 B/1.95 KiB)');
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
   });
 
   it('shows transfer to temp bucket state with no files', async () => {
@@ -340,7 +340,7 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('Christina test');
     await screen.findByText('Initial Bucket Transfer');
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
   });
 
   it('shows transfer to temp bucket state with bytes', async () => {
@@ -376,7 +376,7 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('Christina test');
     await screen.findByText('Final Transfer in Progress (1000 B/1.95 KiB)');
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
   });
 
   it('shows transfer to temp bucket state with no files', async () => {
@@ -402,6 +402,6 @@ describe('WorkspaceItem', () => {
     // Assert
     await screen.findByText('Christina test');
     await screen.findByText('Final Bucket Transfer');
-    expect(mockGetBucketUsage).not.toHaveBeenCalled();
+    expect(mockStorageCostEstimateV2).not.toHaveBeenCalled();
   });
 });

--- a/src/workspaces/migration/WorkspaceItem.ts
+++ b/src/workspaces/migration/WorkspaceItem.ts
@@ -82,7 +82,7 @@ export const WorkspaceItem = (props: WorkspaceItemProps): ReactNode => {
       try {
         const { usageInBytes } = await Workspaces(signal)
           .workspace(workspaceInfo.namespace, workspaceInfo.name)
-          .bucketUsage();
+          .storageCostEstimateV2();
         setUnmigratedBucketSize(`Bucket Size: ${Utils.formatBytes(usageInBytes)}`);
       } catch (error) {
         // This is typically a 404 with no message to display


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-175

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Since the new `getStorageCostEstimateV2` API added in https://github.com/broadinstitute/firecloud-orchestration/pull/1554 includes bucket usage as well as cost estimate, this PR replaces both `getBucketUsage` and `getStorageCostEstimate` with this new API.  This API uses the Rawls service account and so is not affected by google permissions syncing, so calls to check it are removed.
### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
