### PR TITLE
[CORE-323] Fix cost cap message in submission modal

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1146,7 +1146,7 @@ export const WorkflowView = _.flow(
                         min: 0.01,
                         max: 9999999999.99,
                         placeholder: 'Example: 1.00',
-                        onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : undefined }),
+                        onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : '' }),
                         style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                       }),
                     ]),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -694,4 +694,32 @@ describe('Workflow View (GCP)', () => {
     // check that workflow cost capping is shown
     expect(screen.queryByText('Set cost limit per workflow (BETA)')).not.toBeNull();
   });
+
+  it('updates perWorkflowCostCap state on input change', async () => {
+    // Arrange
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
+
+    const user = userEvent.setup();
+    const namespace = 'gatk';
+    const name = 'echo_to_file-configured';
+
+    mockDefaultAjax();
+
+    // Act
+    await act(async () => {
+      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
+    });
+
+    const costCapInput = screen.getByPlaceholderText('Example: 1.00');
+    expect(costCapInput).toBeInTheDocument();
+
+    // Assert initial state
+    expect(costCapInput).toHaveValue(null);
+
+    // Act
+    await user.type(costCapInput, '123.456');
+
+    // Assert updated state
+    expect(Number(costCapInput.value)).toBeCloseTo(123.456, 2);
+  });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-323

### What
- Fixed the submission confirmation modal to correctly show when no cost limit is set.

### Why
- The modal was confusing when cost capping was enabled but no cap was set. This fix ensures clear messaging.

### Testing strategy
- Unit Testing: Added tests for cases with and without a cost cap.
- Manual Testing: Manually verified correct modal messages in different scenarios.

**Before**
<img width="1794" alt="Before" src="https://github.com/user-attachments/assets/ddc7cbee-3933-4d95-acee-f2dc0caba32c" />

**After**
<img width="1794" alt="CostCapMessage" src="https://github.com/user-attachments/assets/d62902cb-c216-4697-8219-36307c4dd7be" />
