### PR TITLE
[AN-408] Prevent TWR url from popping out in workflows library

### DIFF
--- a/src/pages/library/WorkflowsLibrary.tsx
+++ b/src/pages/library/WorkflowsLibrary.tsx
@@ -52,6 +52,7 @@ interface WorkflowSourceBoxProps {
   title: string;
   description: string;
   url: string;
+  openInNewTab: boolean;
   logoFilePath: string;
   metricsEventName: MetricsEventName;
 }
@@ -62,7 +63,7 @@ const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
   };
 
   return (
-    <Clickable href={props.url} {...Utils.newTabLinkProps} onClick={() => sendMetrics()}>
+    <Clickable href={props.url} {...(props.openInNewTab ? Utils.newTabLinkProps : {})} onClick={() => sendMetrics()}>
       <div
         style={{
           width: 400,
@@ -81,10 +82,11 @@ const WorkflowSourceBox = (props: WorkflowSourceBoxProps) => {
           </div>
           <p style={{ height: '55px' }}>{props.description}</p>
           <div style={{ bottom: 0 }}>
-            {icon('pop-out', {
-              size: 18,
-              style: { color: colors.accent(1) },
-            })}
+            {props.openInNewTab &&
+              icon('pop-out', {
+                size: 18,
+                style: { color: colors.accent(1) },
+              })}
           </div>
         </div>
       </div>
@@ -153,6 +155,7 @@ export const WorkflowsLibrary = () => {
                     title='Dockstore.org'
                     description='A community repository of public workflows that offers publishing features and automatic integration with GitHub.'
                     url={dockstoreUrl}
+                    openInNewTab
                     logoFilePath={dockstoreLogo}
                     metricsEventName={Events.libraryWorkflowsDockstore}
                   />
@@ -162,6 +165,7 @@ export const WorkflowsLibrary = () => {
                     title='Terra Workflow Repository'
                     description='A repository of WDL workflows that offers quick hosting of public and private workflows.'
                     url={workflowsRepoUrl}
+                    openInNewTab={false}
                     logoFilePath={workflowsRepoLogo}
                     metricsEventName={Events.libraryWorkflowsTerraRepo}
                   />


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-408

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Prevents the Terra Workflow Repository link from popping out like the dockstore URL

### Why
- Now that TWR is embedded in Terra-UI, we do not need to open it in a new tab

![Screenshot 2025-02-19 at 10 39 52 AM](https://github.com/user-attachments/assets/0fc040c8-fc5a-42ac-9a5b-b8c467e8c97f)


### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
