### PR TITLE
CORE-310: add 'Estimated' or 'Final cost' to workflow costs

### DIFF
--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -154,7 +154,7 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
                 headerRenderer: () => h(Sortable, { sort, field: 'status', onSort: setSort }, ['Status']),
                 cellRenderer: ({ rowIndex }) => {
                   const { status } = filteredWorkflows[rowIndex];
-                  return div({ style: { display: 'flex' } }, [collapseStatus(status).icon({ marginRight: '0.5rem' }), status]);
+                  return div({ style: { display: 'flex', alignItems: 'center' } }, [collapseStatus(status).icon({ marginRight: '0.5rem' }), status]);
                 },
               },
               {
@@ -172,7 +172,7 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
                           filteredWorkflows[rowIndex].costType === 'Estimated' ? 'Estimated' : 'Final cost',
                         ]);
 
-                  return div({ style: { verticalAlign: 'middle', height: '16px' } }, [costElement, costTypeElement]);
+                  return div({ style: { alignItems: 'center', height: '16px' } }, [costElement, costTypeElement]);
                 },
               },
               {

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -163,7 +163,16 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
                 headerRenderer: () => h(Sortable, { sort, field: 'cost', onSort: setSort }, ['Run Cost']),
                 cellRenderer: ({ rowIndex }) => {
                   const cost = filteredWorkflows[rowIndex].cost;
-                  return typeof cost === 'number' ? h(TextCell, [Utils.formatUSD(cost || 0)]) : cost;
+                  const costElement = typeof cost === 'number' ? h(TextCell, [Utils.formatUSD(cost || 0)]) : cost;
+
+                  const costTypeElement =
+                    cost === 'n/a' || cost === 'N/A'
+                      ? undefined
+                      : div({ style: { fontSize: 10, display: 'block', marginTop: '2px' } }, [
+                          filteredWorkflows[rowIndex].costType === 'Estimated' ? 'Estimated' : 'Final cost',
+                        ]);
+
+                  return div({ style: { verticalAlign: 'middle', height: '18px' } }, [costElement, costTypeElement]);
                 },
               },
               {

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -172,7 +172,7 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
                           filteredWorkflows[rowIndex].costType === 'Estimated' ? 'Estimated' : 'Final cost',
                         ]);
 
-                  return div({ style: { verticalAlign: 'middle', height: '18px' } }, [costElement, costTypeElement]);
+                  return div({ style: { verticalAlign: 'middle', height: '16px' } }, [costElement, costTypeElement]);
                 },
               },
               {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-310

### Dependencies
This requires https://github.com/broadinstitute/rawls/pull/3172 for full functionality. Without that Rawls PR, this terra-ui PR will always show either "Final cost" or nothing; we'll never show "Estimated". I think it's good to get this PR out first, then follow up with the Rawls PR later; that way, we'll ensure we have the proper annotation for costs before we start showing esimated costs.

## Summary of changes:
Adds a "Final cost" or "Estimated" annotation to the Run Cost column when displaying workflows. 

Bonus fix: vertically aligns the "Status" column to be consistent with the rest of the table.

_before:_
![Screenshot 19-02-2025 at 15 34 (2)](https://github.com/user-attachments/assets/5fc0853f-92a5-4d75-91b9-20969eaf980c)

_after:_

when a workflow has a cost, we give it a final/estimated annotation:
![Screenshot 19-02-2025 at 15 34](https://github.com/user-attachments/assets/6a2bf4a7-09da-4845-beed-8043321cbce9)

when a workflow has "n/a" for cost, we omit the annotation:
![Screenshot 19-02-2025 at 15 34 (1)](https://github.com/user-attachments/assets/afd61703-827d-4687-ac60-ee68f750af4e)


### Testing strategy
Tested by running locally. I could not find an existing test suite for the `SubmissionWorkflowsTable` component or the SubmissionDetails.js file, and this felt small enough that I didn't want to blow up scope to create a new one.


