### PR TITLE
[CORE-330] Resolve /job_history to /submission_history

### DIFF
--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -480,11 +480,19 @@ const SubmissionHistory = _.flow(
   ]);
 });
 
+const submissionHistoryRoute = {
+  name: 'workspace-submission-history',
+  component: SubmissionHistory,
+  title: ({ name }) => `${name} - Submission History`,
+};
+
 export const navPaths = [
   {
-    name: 'workspace-submission-history',
+    ...submissionHistoryRoute,
     path: '/workspaces/:namespace/:name/submission_history',
-    component: SubmissionHistory,
-    title: ({ name }) => `${name} - Submission History`,
+  },
+  {
+    ...submissionHistoryRoute,
+    path: '/workspaces/:namespace/:name/job_history',
   },
 ];

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -1,6 +1,6 @@
 import { Modal, TooltipTrigger } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
-import { Fragment, useImperativeHandle, useRef, useState } from 'react';
+import { Fragment, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { div, h, span, table, tbody, td, tr } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { bucketBrowserUrl } from 'src/auth/auth';
@@ -142,6 +142,11 @@ const SubmissionHistory = _.flow(
 
   const scheduledRefresh = useRef();
   const signal = useCancellation();
+
+  // Redirect to submission history url
+  useEffect(() => {
+    window.location.hash = window.location.hash.replace('job_history', 'submission_history');
+  }, []);
 
   // Helpers
   const refresh = Utils.withBusyState(setLoading, async () => {

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -1,0 +1,14 @@
+import { navPaths } from 'src/pages/workspaces/workspace/SubmissionHistory';
+
+describe('Route Accessibility', () => {
+  test('should contain valid paths for SubmissionHistory', () => {
+    const expectedPaths = [
+      '/workspaces/:namespace/:name/submission_history',
+      '/workspaces/:namespace/:name/job_history',
+    ];
+
+    const actualPaths = navPaths.map((route) => route.path);
+
+    expect(actualPaths).toEqual(expect.arrayContaining(expectedPaths));
+  });
+});

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -571,11 +571,19 @@ const SubmissionDetails = _.flow(
   ]);
 });
 
+const submissionDetailsRoute = {
+  name: 'workspace-submission-details',
+  component: SubmissionDetails,
+  title: ({ name }) => `${name} - Submission Details`,
+};
+
 export const navPaths = [
   {
-    name: 'workspace-submission-details',
+    ...submissionDetailsRoute,
     path: '/workspaces/:namespace/:name/submission_history/:submissionId',
-    component: SubmissionDetails,
-    title: ({ name }) => `${name} - Submission Details`,
+  },
+  {
+    ...submissionDetailsRoute,
+    path: '/workspaces/:namespace/:name/job_history/:submissionId',
   },
 ];

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -354,6 +354,11 @@ const SubmissionDetails = _.flow(
 
   const signal = useCancellation();
 
+  // Redirect to submission history url
+  useEffect(() => {
+    window.location.hash = window.location.hash.replace('job_history', 'submission_history');
+  }, []);
+
   /*
    * Data fetchers
    */

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
@@ -1,0 +1,14 @@
+import { navPaths } from 'src/pages/workspaces/workspace/submissionHistory/SubmissionDetails';
+
+describe('Route Accessibility', () => {
+  test('should contain valid paths for SubmissionDetails', () => {
+    const expectedPaths = [
+      '/workspaces/:namespace/:name/submission_history/:submissionId',
+      '/workspaces/:namespace/:name/job_history/:submissionId',
+    ];
+
+    const actualPaths = navPaths.map((route) => route.path);
+
+    expect(actualPaths).toEqual(expect.arrayContaining(expectedPaths));
+  });
+});

--- a/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.js
@@ -1,6 +1,6 @@
 import ReactJson from '@microlink/react-json-view';
 import _ from 'lodash/fp';
-import { Fragment, useCallback, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { bucketBrowserUrl } from 'src/auth/auth';
 import * as breadcrumbs from 'src/components/breadcrumbs';
@@ -92,6 +92,11 @@ const WorkflowDashboard = _.flow(
 
   const signal = useCancellation();
   const stateRefreshTimer = useRef();
+
+  // Redirect to submission history url
+  useEffect(() => {
+    window.location.hash = window.location.hash.replace('job_history', 'submission_history');
+  }, []);
 
   /*
    * Data fetchers

--- a/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.js
+++ b/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.js
@@ -322,11 +322,19 @@ const WorkflowDashboard = _.flow(
   ]);
 });
 
+const workflowDashboardRoute = {
+  name: 'workspace-workflow-dashboard',
+  component: WorkflowDashboard,
+  title: ({ name }) => `${name} - Workflow Dashboard`,
+};
+
 export const navPaths = [
   {
-    name: 'workspace-workflow-dashboard',
+    ...workflowDashboardRoute,
     path: '/workspaces/:namespace/:name/submission_history/:submissionId/:workflowId',
-    component: WorkflowDashboard,
-    title: ({ name }) => `${name} - Workflow Dashboard`,
+  },
+  {
+    ...workflowDashboardRoute,
+    path: '/workspaces/:namespace/:name/job_history/:submissionId/:workflowId',
   },
 ];

--- a/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.test.tsx
+++ b/src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard.test.tsx
@@ -1,0 +1,14 @@
+import { navPaths } from 'src/pages/workspaces/workspace/submissionHistory/WorkflowDashboard';
+
+describe('Route Accessibility', () => {
+  test('should contain valid paths for WorkflowDashboard', () => {
+    const expectedPaths = [
+      '/workspaces/:namespace/:name/submission_history/:submissionId/:workflowId',
+      '/workspaces/:namespace/:name/job_history/:submissionId/:workflowId',
+    ];
+
+    const actualPaths = navPaths.map((route) => route.path);
+
+    expect(actualPaths).toEqual(expect.arrayContaining(expectedPaths));
+  });
+});


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-330

### What
- This PR adds back paths for */job_history which resolves to */submission_history to prevent broken bookmarks.

### Why
- In [CORE-230](https://broadworkbench.atlassian.net/browse/CORE-230), we renamed "Job History" to "Submission History," changing the URL in the process. This broke user bookmarks, so we’re adding back the paths to ensure a smooth transition.

### Testing strategy
- Unit Testing: Added tests for paths
- Manual Testing: Open */job_history and confirm it resolves to */submission_history.


[CORE-230]: https://broadworkbench.atlassian.net/browse/CORE-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ