### PR TITLE
CORE-237: submission-level cost should show Estimated vs. Actual

### DIFF
--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -465,6 +465,14 @@ const SubmissionDetails = _.flow(
    */
   const firstLine = _.flow(_.split('\n'), (lines) => (lines.length > 1 ? `${lines[0]} ...` : lines[0]));
 
+  /**
+   *
+   */
+  const hasWorkflowCostEstimates = _.includes(
+    'Estimated',
+    _.map((w) => w.costType, workflows)
+  );
+
   /*
    * Page render
    */
@@ -547,7 +555,7 @@ const SubmissionDetails = _.flow(
                 ),
               ]),
               makeSection('Submitted by', [div([submitter]), Utils.makeCompleteDate(submissionDate)]),
-              makeSection('Total Run Cost', [cost ? `${Utils.formatUSD(cost)} Actual cost` : 'N/A']),
+              makeSection('Total Run Cost', [cost ? `${Utils.formatUSD(cost)} ${hasWorkflowCostEstimates ? 'Estimated ' : 'Actual'} cost` : 'N/A']),
               makeSection('Data Entity', [div([entityName]), div([entityType])]),
               makeSection('Submission ID', [
                 h(Link, { href: bucketBrowserUrl(submissionRoot.replace('gs://', '')), ...Utils.newTabLinkProps }, submissionId),

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -466,7 +466,7 @@ const SubmissionDetails = _.flow(
   const firstLine = _.flow(_.split('\n'), (lines) => (lines.length > 1 ? `${lines[0]} ...` : lines[0]));
 
   /**
-   *
+   * Does any workflow in this submission use an estimated cost?
    */
   const hasWorkflowCostEstimates = _.includes(
     'Estimated',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-237

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
The "Total Run Cost" display on the submission-detail page now shows "Estimated" or "Actual" next to its dollar value.

If all workflows in the submission are actual-cost, Total Run Cost will be actual. If any workflow is estimated-cost, Total Run Cost will be estimated.
