### PR TITLE
[CORE-317] Rebrand Cost Limit to Threshold & Enable Cost Capping Public Preview

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -121,7 +121,7 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
     description:
       'Enabling this feature will show a new workflow configuration option to add a user-configurable cost threshold to the workflow. Workflows will be terminated once they exceed the configured value.',
     feedbackUrl: 'https://support.terra.bio/hc/en-us/articles/31269696049307',
-    lastUpdated: '12/6/2024',
+    lastUpdated: '2/28/2025',
   },
   {
     id: GCP_BATCH,

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -117,10 +117,9 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
   },
   {
     id: PREVIEW_COST_CAPPING,
-    title: 'Workflow Cost Capping',
+    title: 'Workflow Cost Thresholds',
     description:
-      'Enabling this feature will show a new workflow configuration option to add a user-configurable cost cap to the workflow. Workflows will be terminated once they exceed the configured value.',
-    groups: ['preview-cost-capping'],
+      'Enabling this feature will show a new workflow configuration option to add a user-configurable cost threshold to the workflow. Workflows will be terminated once they exceed the configured value.',
     feedbackUrl: 'https://support.terra.bio/hc/en-us/articles/31269696049307',
     lastUpdated: '12/6/2024',
   },

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -75,7 +75,7 @@ const deletedInfoIcon = ({ name, icon: iconName }) => {
 
 const tableRowHeight = flexTableDefaultRowHeight;
 
-const SubmissionWorkflowsTable = ({ workspace, submission }) => {
+export const SubmissionWorkflowsTable = ({ workspace, submission }) => {
   const {
     workspace: { namespace, name },
   } = workspace;
@@ -120,7 +120,7 @@ const SubmissionWorkflowsTable = ({ workspace, submission }) => {
       h(Link, { onClick: () => downloadWorkflows(filteredWorkflows, submissionId) }, ['Download TSV']),
       isFeaturePreviewEnabled(PREVIEW_COST_CAPPING) &&
         div({ style: { marginLeft: 'auto' } }, [
-          b({}, ['Per Workflow Cost Limit: ']),
+          b({}, ['Per Workflow Cost Threshold: ']),
           perWorkflowCostCap ? Utils.formatUSD(perWorkflowCostCap) : 'N/A',
         ]),
     ]),

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
@@ -1,4 +1,22 @@
-import { navPaths } from 'src/pages/workspaces/workspace/submissionHistory/SubmissionDetails';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { navPaths, SubmissionWorkflowsTable } from 'src/pages/workspaces/workspace/submissionHistory/SubmissionDetails';
+import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
+
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual('src/libs/nav'),
+    getLink: jest.fn(),
+  })
+);
+
+jest.mock('src/libs/feature-previews', () => ({
+  ...jest.requireActual('src/libs/feature-previews'),
+  isFeaturePreviewEnabled: jest.fn(),
+}));
 
 describe('Route Accessibility', () => {
   test('should contain valid paths for SubmissionDetails', () => {
@@ -10,5 +28,87 @@ describe('Route Accessibility', () => {
     const actualPaths = navPaths.map((route) => route.path);
 
     expect(actualPaths).toEqual(expect.arrayContaining(expectedPaths));
+  });
+});
+
+describe('Cost Capping', () => {
+  const testGoogleWorkspace = {
+    accessLevel: 'OWNER',
+    owners: ['groot@gmail.com'],
+    workspace: {
+      attributes: {
+        description: '',
+      },
+      authorizationDomain: [],
+      billingAccount: 'billingAccounts/google-billing-account',
+      bucketName: 'bucket-name',
+      cloudPlatform: 'Gcp',
+      completedCloneWorkspaceFileTransfer: '2024-11-27T22:29:04.319Z',
+      createdBy: 'groot@gmail.com',
+      createdDate: '2024-11-27T22:26:06.124Z',
+      googleProject: 'google-project-id',
+      isLocked: false,
+      lastModified: '2024-11-27T22:26:06.202Z',
+      name: 'groot-scientific-workflow',
+      namespace: 'groot-namespace',
+      workspaceId: 'google-workspace-id',
+      workspaceType: 'rawls',
+      workspaceVersion: 'v2',
+    },
+    canShare: true,
+    canCompute: true,
+    workspaceInitialized: true,
+  };
+
+  const testSubmission = {
+    extraInputs: [],
+    invalidInputs: {},
+    invalidOutputs: {},
+    methodConfiguration: {
+      deleted: false,
+      inputs: {
+        'echo_strings.echo_to_file.input1': 'this.newString',
+      },
+      methodConfigVersion: 2,
+      methodRepoMethod: {
+        methodName: 'echo_to_file',
+        methodVersion: 12,
+        methodNamespace: 'gatk',
+        methodUri: 'agora://gatk/echo_to_file/12',
+        sourceRepo: 'agora',
+      },
+      name: 'echo_to_file-configured',
+      namespace: 'gatk',
+      outputs: {
+        'echo_strings.echo_to_file.out': 'this.output',
+      },
+      prerequisites: {},
+      rootEntityType: 'sra',
+    },
+    missingInputs: [],
+    validInputs: ['echo_strings.echo_to_file.input1'],
+    validOutputs: ['echo_strings.echo_to_file.out'],
+  };
+
+  test('should render the Cost Capping feature when enabled', () => {
+    // Arrange
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
+
+    // Act
+    renderWithAppContexts(<SubmissionWorkflowsTable workspace={testGoogleWorkspace} submission={testSubmission} />);
+
+    // Assert
+    expect(screen.getByText('Per Workflow Cost Threshold:')).toBeInTheDocument();
+  });
+
+  test('should not render the Cost Capping feature when disabled', () => {
+    // Arrange
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+
+    // Act
+    renderWithAppContexts(<SubmissionWorkflowsTable workspace={testGoogleWorkspace} submission={testSubmission} />);
+
+    // Assert
+    expect(screen.queryByText('Per Workflow Cost Threshold:')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
@@ -31,7 +31,7 @@ describe('Route Accessibility', () => {
   });
 });
 
-describe('Cost Capping', () => {
+describe('Cost Threshold', () => {
   const testGoogleWorkspace = {
     accessLevel: 'OWNER',
     owners: ['groot@gmail.com'],
@@ -90,7 +90,7 @@ describe('Cost Capping', () => {
     validOutputs: ['echo_strings.echo_to_file.out'],
   };
 
-  test('should render the Cost Capping feature when enabled', () => {
+  test('should render the Cost Threshold when enabled', () => {
     // Arrange
     asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
 
@@ -101,7 +101,7 @@ describe('Cost Capping', () => {
     expect(screen.getByText('Per Workflow Cost Threshold:')).toBeInTheDocument();
   });
 
-  test('should not render the Cost Capping feature when disabled', () => {
+  test('should not render the Cost Threshold when disabled', () => {
     // Arrange
     asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
 

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -191,13 +191,13 @@ const LaunchAnalysisModal = ({
           isFeaturePreviewEnabled(PREVIEW_COST_CAPPING) &&
             (perWorkflowCostCap !== ''
               ? li([
-                  `You set a cost limit of ${Utils.formatUSD(perWorkflowCostCap)} per workflow run`,
+                  `You set a cost threshold of ${Utils.formatUSD(perWorkflowCostCap)} per workflow run`,
                   h('br'),
                   `x ${entityCount} workflow runs = ${Utils.formatUSD(entityCount * perWorkflowCostCap)}`,
                   b(' approximate maximum'),
                   ' submission cost.',
                 ])
-              : li(['You did not set a cost limit.'])),
+              : li(['You did not set a cost threshold.'])),
         ]),
       ]),
       h(IdContainer, [

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.test.ts
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.test.ts
@@ -29,7 +29,7 @@ describe('Launch Analysis Modal', () => {
     );
   };
 
-  it('reports workflow cost limit if set', async () => {
+  it('reports workflow cost threshold if set', async () => {
     // Arrange
 
     mockDefaultAjax();
@@ -96,7 +96,7 @@ describe('Launch Analysis Modal', () => {
     expect(screen.getByText('x 2 workflow runs = $20.00', { exact: false })).toBeInTheDocument();
   });
 
-  it('reports only number of submissions if no cost limit set', async () => {
+  it('reports only number of submissions if no cost threshold set', async () => {
     // Arrange
 
     mockDefaultAjax();
@@ -160,6 +160,6 @@ describe('Launch Analysis Modal', () => {
       screen.getByText('You are launching 2 workflow runs in this submission', { exact: false })
     ).toBeInTheDocument();
 
-    expect(screen.getByText('You did not set a cost limit', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('You did not set a cost threshold', { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1121,9 +1121,9 @@ export const WorkflowView = _.flow(
                   },
                   [
                     span([
-                      'Set cost limit per workflow (BETA) ',
+                      'Set cost threshold per workflow (BETA) ',
                       h(InfoBox, { style: { marginLeft: '0.1rem', whiteSpace: 'pre-line' } }, [
-                        'Important cost limit considerations:',
+                        'Important considerations:',
                         h('br'),
                         '1. Costs are in USD.',
                         h('br'),
@@ -1131,11 +1131,11 @@ export const WorkflowView = _.flow(
                         h('br'),
                         '3. Based on GCP list prices. Discounts are not included.',
                         h('br'),
-                        '4. GPU costs are not included (coming soon!).',
+                        '4. GPU costs are not included.',
                         h('br'),
-                        '5. Workflows may not terminate immediately upon hitting limit, plan for a margin of error.',
+                        '5. Workflows may not terminate immediately upon hitting threshold, plan for a margin of error.',
                         h('br'),
-                        '6. Workflow costs vary by input. Set a limit that considers variability.',
+                        '6. Workflow costs vary by input. Set a threshold that considers variability.',
                       ]),
                     ]),
                     div({ style: { display: 'flex', alignItems: 'center', marginLeft: '0rem', marginBottom: '0.5rem' } }, [
@@ -1149,6 +1149,9 @@ export const WorkflowView = _.flow(
                         onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : '' }),
                         style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                       }),
+                    ]),
+                    h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, [
+                      'Learn more about how Terra implements cost thresholds',
                     ]),
                   ]
                 ),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1150,8 +1150,9 @@ export const WorkflowView = _.flow(
                         style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                       }),
                     ]),
-                    h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, [
-                      'Learn more about how Terra implements cost thresholds',
+                    span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
+                      h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, ['Learn more']),
+                      ' about how Terra implements cost thresholds',
                     ]),
                   ]
                 ),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1150,7 +1150,7 @@ export const WorkflowView = _.flow(
                         style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
                       }),
                     ]),
-                    span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
+                    span([
                       h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, ['Learn more']),
                       ' about how Terra implements cost thresholds',
                     ]),

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -673,7 +673,7 @@ describe('Workflow View (GCP)', () => {
 
     // Assert
     // check that workflow cost capping is not shown
-    expect(screen.queryByText('Set cost limit per workflow (BETA)')).toBeNull();
+    expect(screen.queryByText('Set cost threshold per workflow (BETA)')).toBeNull();
   });
 
   it('does show cost capping input if the feature flag is enabled', async () => {
@@ -692,7 +692,7 @@ describe('Workflow View (GCP)', () => {
 
     // Assert
     // check that workflow cost capping is shown
-    expect(screen.queryByText('Set cost limit per workflow (BETA)')).not.toBeNull();
+    expect(screen.queryByText('Set cost threshold per workflow (BETA)')).not.toBeNull();
   });
 
   it('updates perWorkflowCostCap state on input change', async () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-317

### What
- This PR renames "Cost Limit" to "Cost Threshold" across the UI, based on user feedback. Key updates include:
  - Updating UI text in the feature preview, workflow configuration page, launch modal, and submission details page.
  - Adjusting tooltips and descriptions for clarity.
  - Removing the group requirement to make the feature publicly available.
  - Adding a documentation link for more details.

### Why
- Users found “limit” too strict, as the feature acts more like a safety net.
- “Threshold” is clearer and aligns with cost management terminology.
- This update also launches the feature to public preview.

### Testing strategy
- Unit Testing: Added/Updated Unit Tests
- Manual Testing:
  - Ensure all UI references to "Cost Limit" are updated to "Cost Threshold".
  - Verify the new terminology in all affected pages and tooltips.
  - Confirm the feature is publicly available after removing the group requirement.
  - Check that workflows behave correctly when a threshold is set.

### Screens

#### Feature Preview

**Enabling Cost Capping for Public Preview**
<img width="1791" alt="feature-preview" src="https://github.com/user-attachments/assets/b3cbf821-b6cb-4d41-8a9d-8992f05dbe2c" />

#### Rebrand Cost Limit to Cost Threshold

**Workflow Config**
<img width="1791" alt="workflow-config" src="https://github.com/user-attachments/assets/692eadd4-c25b-42c3-b73b-5090dd164113" />

**Workflow Launch Modal [No Threshold]**
<img width="1791" alt="launch-modal-no-threshold" src="https://github.com/user-attachments/assets/b2f82958-cc22-456e-9179-1f0e2672d52c" />

**Workflow Launch Modal [With Threshold]**
<img width="1791" alt="launch-modal-with-threshold" src="https://github.com/user-attachments/assets/ecfb51ff-c4d1-42f9-ae73-329656a66fba" />

**Submission Details**
<img width="1791" alt="submission-details" src="https://github.com/user-attachments/assets/32398cf1-3a76-4e46-8bdc-1a8bfa6e2649" />
