### PR TITLE
[CORE-366] Add missing regions to allRegions

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -22,7 +22,6 @@
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-dev.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev",

--- a/config/prod.json
+++ b/config/prod.json
@@ -21,7 +21,6 @@
   "samUrlRoot": "https://sam.dsde-prod.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com",
   "workspaceManagerUrlRoot": "https://workspace.dsde-prod.broadinstitute.org",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-prod.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-prod",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_prod",

--- a/config/staging.json
+++ b/config/staging.json
@@ -22,7 +22,6 @@
   "samUrlRoot": "https://sam.dsde-staging.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-staging.broadinstitute.org",
-  "alphaRegionalityGroup": "Alpha_Regionality_Users",
   "terraDockerVersionsFile": "terra-docker-versions-staging.json",
   "terraDockerImageBucket": "terra-docker-image-documentation-staging",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_staging",

--- a/src/components/region-common.js
+++ b/src/components/region-common.js
@@ -173,12 +173,16 @@ export const locationTypes = {
 };
 
 export const allRegions = [
-  // In this list, us-east*, us-west*, northamerica-northeast2 and asia-northeast2 have purposefully been removed.
-  // This is to avoid creating within-country silos of life sciences community data.
-  // So for US, Canada and Japan, we are restricting to one region.
   // For more information, see https://support.terra.bio/hc/en-us/articles/360060777272-US-regional-versus-Multi-regional-US-buckets-trade-offs
   { value: 'US-CENTRAL1', label: 'us-central1 (Iowa) (default)', locationType: locationTypes.region },
   { value: 'US', label: 'US multi-regional', locationType: locationTypes.multiRegion },
+  { value: 'US-EAST1', label: 'us-east1 (South Carolina)', locationType: locationTypes.region },
+  { value: 'US-EAST4', label: 'us-east4 (Virginia)', locationType: locationTypes.region },
+  { value: 'US-WEST1', label: 'us-west1 (Oregon)', locationType: locationTypes.region },
+  { value: 'US-WEST2', label: 'us-west2 (California)', locationType: locationTypes.region },
+  { value: 'US-WEST3', label: 'us-west3 (Utah)', locationType: locationTypes.region },
+  { value: 'US-WEST4', label: 'us-west4 (Nevada)', locationType: locationTypes.region },
+  { value: 'NORTHAMERICA-NORTHEAST2', label: 'northamerica-northeast2 (Ontario)', locationType: locationTypes.region },
   { value: 'NORTHAMERICA-NORTHEAST1', label: 'northamerica-northeast1 (Montreal)', locationType: locationTypes.region },
   { value: 'SOUTHAMERICA-EAST1', label: 'southamerica-east1 (Sao Paulo)', locationType: locationTypes.region },
   { value: 'EUROPE-CENTRAL2', label: 'europe-central2 (Warsaw)', locationType: locationTypes.region },
@@ -196,6 +200,7 @@ export const allRegions = [
   { value: 'ASIA-SOUTHEAST1', label: 'asia-southeast1 (Singapore)', locationType: locationTypes.region },
   { value: 'ASIA-SOUTHEAST2', label: 'asia-southeast2 (Jakarta)', locationType: locationTypes.region },
   { value: 'AUSTRALIA-SOUTHEAST1', label: 'australia-southeast1 (Sydney)', locationType: locationTypes.region },
+  { value: 'ASIA-NORTHEAST2', label: 'asia-northeast1 (Osaka)', locationType: locationTypes.region },
 ];
 
 export const getLocationInfo = (location) => _.find({ value: location.toUpperCase() }, allRegions);

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceModal.tsx
@@ -17,7 +17,7 @@ import {
 } from 'src/components/common';
 import { InfoBox } from 'src/components/InfoBox';
 import { TextArea, ValidatedInput } from 'src/components/input';
-import { allRegions, availableBucketRegions, isSupportedBucketLocation } from 'src/components/region-common';
+import { availableBucketRegions, isSupportedBucketLocation } from 'src/components/region-common';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { Billing } from 'src/libs/ajax/billing/Billing';
 import { resolveWdsApp } from 'src/libs/ajax/data-table-providers/WdsDataTableProvider';
@@ -30,8 +30,7 @@ import { WorkspaceData } from 'src/libs/ajax/WorkspaceDataService';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { getRegionLabel } from 'src/libs/azure-utils';
 import colors from 'src/libs/colors';
-import { getConfig } from 'src/libs/config';
-import { reportErrorAndRethrow, withErrorReportingInModal } from 'src/libs/error';
+import { withErrorReportingInModal } from 'src/libs/error';
 import Events, { extractCrossWorkspaceDetails, extractWorkspaceDetails } from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
@@ -126,7 +125,6 @@ export const NewWorkspaceModal = withDisplayName(
     const [sourceAzureWorkspaceRegion, setSourceAzureWorkspaceRegion] = useState<string>('');
     const [sourceGCPWorkspaceRegion, setSourceGcpWorkspaceRegion] = useState<string>(defaultLocation);
     const [sourceGCPWorkspaceRegionError, setSourceGCPWorkspaceRegionError] = useState(false);
-    const [isAlphaRegionalityUser, setIsAlphaRegionalityUser] = useState(false);
     const [phiTracking, setPhiTracking] = useState<boolean | undefined>(undefined);
     const signal = useCancellation();
 
@@ -136,10 +134,6 @@ export const NewWorkspaceModal = withDisplayName(
         ...(cloneWorkspace ? _.map('membersGroupName', cloneWorkspace.workspace.authorizationDomain) : []),
         ...(requiredAuthDomain ? [requiredAuthDomain] : []),
       ]);
-
-    const loadAlphaRegionalityUser = reportErrorAndRethrow('Error loading regionality group membership')(async () => {
-      setIsAlphaRegionalityUser(await Groups(signal).group(getConfig().alphaRegionalityGroup).isMember());
-    });
 
     const create = async (): Promise<void> => {
       try {
@@ -382,7 +376,6 @@ export const NewWorkspaceModal = withDisplayName(
         setEnhancedBucketLogging(true);
       }
       loadData();
-      loadAlphaRegionalityUser();
     });
 
     // Render
@@ -585,7 +578,7 @@ export const NewWorkspaceModal = withDisplayName(
                           id={id}
                           value={bucketLocation}
                           onChange={(opt) => setBucketLocation(opt!.value)}
-                          options={isAlphaRegionalityUser ? allRegions : availableBucketRegions}
+                          options={availableBucketRegions}
                         />
                       </>
                     )}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-366

The falsely-named `allRegions` list was missing several regions; workspaces using any of those regions would error upon trying to determine the bucket location.  This PR updates the list to match [leo's region list](https://github.com/DataBiosphere/leonardo/blob/develop/http/src/main/resources/reference.conf#L22); the cities in the labels were taken from https://cloud.google.com/compute/docs/regions-zones.  
Also removes use of `alphaRegionalityUsers`, which relied on `allRegions` but is no longer used.

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
