### PR TITLE
[CORE-368] Validate table rename

### DIFF
--- a/src/workspace-data/data-table/entity-service/RenameTableModal.js
+++ b/src/workspace-data/data-table/entity-service/RenameTableModal.js
@@ -63,9 +63,9 @@ export const RenameTableModal = ({
       message: 'Table name is required',
     },
     format: {
-      pattern: '^(?!sys_)[a-z0-9_.-]*',
+      pattern: '^[a-z0-9_-]*',
       flags: 'i',
-      message: "Table name may only contain alphanumeric characters, underscores, dashes, and periods and cannot start with 'sys_'.",
+      message: 'Table name may only contain alphanumeric characters, underscores, and dashes.',
     },
   });
 

--- a/src/workspace-data/data-table/entity-service/RenameTableModal.js
+++ b/src/workspace-data/data-table/entity-service/RenameTableModal.js
@@ -13,6 +13,7 @@ import Events from 'src/libs/events';
 import { FormLabel } from 'src/libs/forms';
 import { warningBoxStyle } from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
+import validate from 'validate.js';
 
 import { allSavedColumnSettingsEntityTypeKey } from './SavedColumnSettings';
 
@@ -30,6 +31,7 @@ export const RenameTableModal = ({
   const [newName, setNewName] = useState('');
   const [renaming, setRenaming] = useState(false);
   const [renameSetTables, setRenameSetTables] = useState(false);
+  const [recordTypeInputTouched, setRecordTypeInputTouched] = useState(false);
 
   const handleTableRename = async ({ oldName, newName }) => {
     void Metrics().captureEvent(Events.workspaceDataRenameTable, { oldName, newName });
@@ -55,6 +57,18 @@ export const RenameTableModal = ({
     }
   };
 
+  const recordTypeNameErrors = validate.single(newName, {
+    presence: {
+      allowEmpty: false,
+      message: 'Table name is required',
+    },
+    format: {
+      pattern: '^(?!sys_)[a-z0-9_.-]*',
+      flags: 'i',
+      message: "Table name may only contain alphanumeric characters, underscores, dashes, and periods and cannot start with 'sys_'.",
+    },
+  });
+
   return h(
     Modal,
     {
@@ -63,7 +77,7 @@ export const RenameTableModal = ({
       okButton: h(
         ButtonPrimary,
         {
-          disabled: renaming,
+          disabled: renaming || recordTypeNameErrors,
           onClick: _.flow(
             withErrorReporting('Error renaming data table.'),
             Utils.withBusyState(setRenaming)
@@ -103,9 +117,11 @@ export const RenameTableModal = ({
                 autoFocus: true,
                 placeholder: 'Enter a name',
                 onChange: (v) => {
+                  setRecordTypeInputTouched(true);
                   setNewName(v);
                 },
               },
+              error: recordTypeInputTouched && Utils.summarizeErrors(recordTypeNameErrors),
             }),
             !_.isEmpty(setTableNames) &&
               div(

--- a/src/workspace-data/data-table/entity-service/RenameTableModal.test.ts
+++ b/src/workspace-data/data-table/entity-service/RenameTableModal.test.ts
@@ -1,0 +1,111 @@
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { h } from 'react-hyperscript-helpers';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { RenameTableModal } from './RenameTableModal';
+
+jest.mock('src/libs/ajax/Metrics');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
+
+describe('RenameTableModal', () => {
+  const validTableNames = ['aliquot', 'Some-Name_With_123-789-Chars'];
+  const invalidCharacters = [
+    'unknownprefix:sample',
+    'disallowed/characters',
+    'space character',
+    'or 1=1; drop table users; --',
+  ];
+  validTableNames.forEach((newName) => {
+    it(`passes validation for "${newName}"`, async () => {
+      // Act
+      await act(async () => {
+        render(
+          h(RenameTableModal, {
+            onDismiss: jest.fn(),
+            onUpdateSuccess: jest.fn(),
+            getAllSavedColumnSettings: jest.fn(),
+            updateAllSavedColumnSettings: jest.fn(),
+            setTableNames: [],
+            namespace: 'namespace',
+            name: 'name',
+            selectedDataType: 'selectedDataType',
+          })
+        );
+      });
+
+      const input = screen.getByLabelText(/New Name/);
+      await userEvent.type(input, newName);
+
+      const submitButton = screen.getByRole('button', { name: /Rename/ });
+
+      // Assert
+      expect(submitButton).not.toHaveAttribute('disabled');
+      expect(screen.queryByText(/Table name may only/)).toBeNull();
+      expect(screen.queryByText(/Table name is required/)).toBeNull();
+    });
+  });
+
+  invalidCharacters.forEach((newName) => {
+    it(`fails validation for "${newName}"`, async () => {
+      // Act
+      await act(async () => {
+        render(
+          h(RenameTableModal, {
+            onDismiss: jest.fn(),
+            onUpdateSuccess: jest.fn(),
+            getAllSavedColumnSettings: jest.fn(),
+            updateAllSavedColumnSettings: jest.fn(),
+            setTableNames: [],
+            namespace: 'namespace',
+            name: 'name',
+            selectedDataType: 'selectedDataType',
+          })
+        );
+      });
+
+      const input = screen.getByLabelText(/New Name/);
+      await userEvent.type(input, newName);
+
+      const submitButton = screen.getByRole('button', { name: /Rename/ });
+
+      // Assert
+      expect(submitButton).toHaveAttribute('disabled');
+      expect(screen.queryByText(/Table name may only/)).not.toBeNull();
+      expect(screen.queryByText(/Table name is required/)).toBeNull();
+    });
+  });
+
+  it('requires table name', async () => {
+    // Act
+    await act(async () => {
+      render(
+        h(RenameTableModal, {
+          onDismiss: jest.fn(),
+          onUpdateSuccess: jest.fn(),
+          getAllSavedColumnSettings: jest.fn(),
+          updateAllSavedColumnSettings: jest.fn(),
+          setTableNames: [],
+          namespace: 'namespace',
+          name: 'name',
+          selectedDataType: 'selectedDataType',
+        })
+      );
+    });
+
+    const input = screen.getByLabelText(/New Name/);
+    await userEvent.type(input, 'anewname');
+
+    const submitButton = screen.getByRole('button', { name: /Rename/ });
+
+    // Assert
+    expect(submitButton).not.toHaveAttribute('disabled');
+    expect(screen.queryByText(/Table name may only/)).toBeNull();
+    expect(screen.queryByText(/Table name is required/)).toBeNull();
+
+    await userEvent.clear(input);
+    expect(submitButton).toHaveAttribute('disabled');
+    expect(screen.queryByText(/Table name may only/)).toBeNull();
+    expect(screen.queryByText(/Table name is required/)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-368

Validates table name before allowing rename.
Note: compare to [EntityUploader.js](https://github.com/DataBiosphere/terra-ui/blob/1ad3e8ad50a7aa44e8e463f52e6f06c22bbb4a0d/src/workspace-data/data-table/shared/EntityUploader.js#L120) - the logic was copied from there but there appears to be some extra validation coming from the datatable provider.  Does that need to be included in renaming as well?

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
