### PR TITLE
[CORE-64] Remove Temporary Banner

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -1194,14 +1194,6 @@ export const WorkspaceData = _.flow(
                           },
                           ['Workspace Data']
                         ),
-                        div(
-                          // File Browser Banner
-                          { style: { padding: '1rem', margin: '0.75rem', backgroundColor: colors.dark(0.1), borderRadius: '0.5rem' } },
-                          [
-                            span({ style: { fontWeight: 'bold' } }, ['Looking for the Files folder?']),
-                            div(['Use the folder icon in the right side-bar to access the workspace Bucket directory.']),
-                          ]
-                        ),
                       ]
                     ),
                 ]),

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -214,7 +214,7 @@ const DataTypeSection = ({ title, error, retryFunction, children }) => {
         ),
     },
     [
-      !!children?.length &&
+      children &&
         div(
           {
             style: { display: 'flex', flexDirection: 'column', width: '100%' },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-64

### What
- Removes the "Looking for the Files folder?" banner.

### Why
- The banner is no longer needed now that the transition to the new file manager is complete.

### Testing strategy
- Confirm the banner is no longer visible.
- Check for any UI or layout issues.
- Ensure the file manager works as expected.

**Before**
<img width="1791" alt="Before" src="https://github.com/user-attachments/assets/17a63fad-57fe-4a8f-be87-abf61cdaa9d7" />

**After**
<img width="1791" alt="After" src="https://github.com/user-attachments/assets/34e3f58e-184d-42f3-95de-c3ddb4257ec3" />

