### PR TITLE
[CORE-348] Clarify Estimated Costs on Workspace Dashboard

### DIFF
--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -108,6 +108,7 @@ describe('CloudInformation', () => {
     // Assert
     expect(screen.getByTitle('Google Cloud Platform')).not.toBeNull;
     // Cost estimate
+    expect(screen.getByText('Estimated Bucket Cost')).not.toBeNull();
     expect(screen.getAllByText('Updated on 12/1/2023')).not.toBeNull();
     expect(screen.getByText('$1,000,000.00')).not.toBeNull();
     // Bucket usage
@@ -195,7 +196,14 @@ describe('CloudInformation', () => {
     await user.click(screen.getByLabelText('More info'));
 
     // Assert
-    expect(screen.getAllByText('Based on list price. Does not include discounts.')).not.toBeNull();
+    expect(screen.getByText(/Only shows object storage costs/i)).toBeInTheDocument();
+    expect(screen.getByText(/Based on GCP list prices/i)).toBeInTheDocument();
+
+    // Clicking the info button again should hide the tooltip
+    await user.click(screen.getByLabelText('More info'));
+
+    // Expect the tooltip content to disappear
+    expect(screen.queryByText(/Only shows object storage costs/i)).not.toBeInTheDocument();
   });
 
   it('displays bucket size for users with reader access', async () => {

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -1,7 +1,7 @@
 import { InfoBox, Link } from '@terra-ui-packages/components';
 import { cond, formatUSD } from '@terra-ui-packages/core-utils';
 import { Fragment, ReactNode, useEffect, useState } from 'react';
-import { div, dl, h } from 'react-hyperscript-helpers';
+import { br, div, dl, h, span } from 'react-hyperscript-helpers';
 import { bucketBrowserUrl } from 'src/auth/auth';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { icon } from 'src/components/icons';
@@ -13,6 +13,7 @@ import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
 import { formatBytes, newTabLinkProps } from 'src/libs/utils';
+import * as Utils from 'src/libs/utils';
 import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/workspaces/common/state/useWorkspace';
 import { AzureStorageDetails } from 'src/workspaces/dashboard/AzureStorageDetails';
 import { BucketLocation } from 'src/workspaces/dashboard/BucketLocation';
@@ -154,7 +155,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
         h(
           InfoRow,
           {
-            title: 'Estimated Storage Cost',
+            title: 'Estimated Bucket Cost',
             subtitle: cond(
               [!storageCost, () => 'Loading last updated...'],
               [
@@ -171,7 +172,23 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           [
             storageCost?.estimate || '$ ...',
             h(InfoBox, { style: { marginLeft: '1ch' }, side: 'top' }, [
-              'Based on list price. Does not include discounts.',
+              'Shows estimated cost of all objects in the bucket. Important considerations:',
+              h(br),
+              h(br),
+              '1. Only shows object storage costs. Operations charges and other storage-related charges are not included.',
+              h(br),
+              '2. Based on GCP list prices. Discounts are not included.',
+              h(br),
+              h(br),
+              span([
+                'For more accurate costs, set up ',
+                h(
+                  Link,
+                  { href: 'https://support.terra.bio/hc/en-us/articles/10026441196187', ...Utils.newTabLinkProps },
+                  ['spend reporting']
+                ),
+                ' to access reports for financial oversight and optimization of your cloud costs and resources.',
+              ]),
             ]),
           ]
         ),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-348

### What
- This PR updates the workspace dashboard to improve clarity around storage cost estimates by:
  - Renaming the field "Estimated Storage Cost" to "Estimated Bucket Cost"
  - Updating the tooltip to clarify that the estimate only includes object storage costs and does not account for operational charges or discounts

### Why
- These updates ensure users understand what the dashboard estimate represents, preventing potential confusion when comparing it with spend reports.

### Testing strategy
- Unit Testing: Updated Unit tests to validate updated text
- Manual Testing
  - Verified that the updated field label appears correctly in the UI.
  - Confirmed that the new tooltip appears as expected and provides the updated messaging.

### Screens
<img width="1791" alt="BucketInfo" src="https://github.com/user-attachments/assets/6cbff2e6-9960-4e88-8add-5bfec1de0bbd" />