### PR TITLE
FireCloud Data Library now powered by DUOS

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -8,6 +8,7 @@
   "devUrlRoot": "https://bvdp-saturn-dev.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
   "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
+  "duosUrlRoot": "https://duos-k8s.dsde-dev.broadinstitute.org",
   "externalCreds": {
     "providers": ["ras", "fence", "dcf-fence", "kids-first", "github", "sage"],
     "urlRoot": "https://externalcreds.dsde-dev.broadinstitute.org"

--- a/config/prod.json
+++ b/config/prod.json
@@ -7,6 +7,7 @@
   "dataRepoUrlRoot": "https://data.terra.bio",
   "dockstoreUrlRoot": "https://dockstore.org",
   "drsHubUrlRoot": "https://drshub.dsde-prod.broadinstitute.org",
+  "duosUrlRoot": "https://duos.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "firecloudUrlRoot": "https://portal.firecloud.org",
   "externalCreds": {

--- a/config/staging.json
+++ b/config/staging.json
@@ -8,6 +8,7 @@
   "devUrlRoot": "https://bvdp-saturn-staging.appspot.com",
   "dockstoreUrlRoot": "https://staging.dockstore.org",
   "drsHubUrlRoot": "https://drshub.dsde-staging.broadinstitute.org",
+  "duosUrlRoot": "https://duos-k8s.dsde-staging.broadinstitute.org",
   "externalCreds": {
     "providers": ["ras", "fence", "dcf-fence", "kids-first", "github", "sage"],
     "urlRoot": "https://externalcreds.dsde-staging.broadinstitute.org"

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -383,31 +383,6 @@ const encode = () =>
     ]
   );
 
-const fcDataLib = () =>
-  h(
-    Participant,
-    {
-      logo: { src: broadLogo, alt: 'Broad logo', height: '40%' },
-      title: 'Broad Dataset Workspace Library',
-      description: `Search for datasets sequenced at the Broad Institute, or public datasets hosted at the Broad. Datasets
-   are pre-loaded as workspaces. You can clone these, or copy data into the workspace of your choice.`,
-      sizeText: h(TooltipTrigger, { content: 'As of October 2018' }, [span('Samples: > 158,629')]),
-    },
-    [
-      h(
-        ButtonPrimary,
-        {
-          'aria-label': 'Browse Broad Institute datasets',
-          tooltip: 'Search for dataset workspaces',
-          href: `${getConfig().duosUrlRoot}/datalibrary/firecloud`,
-          onClick: () => captureBrowseDataEvent('Broad Institute Datasets'),
-          ...Utils.newTabLinkProps,
-        },
-        ['Browse Datasets']
-      ),
-    ]
-  );
-
 const framingham = () =>
   h(
     Participant,
@@ -670,7 +645,6 @@ export const Datasets = () => {
           ccdg(),
           cmg(),
           encode(),
-          fcDataLib(),
           framingham(),
           gp2(),
           hca(),

--- a/src/pages/library/Datasets.js
+++ b/src/pages/library/Datasets.js
@@ -21,7 +21,6 @@ import targetLogo from 'src/images/library/datasets/target_logo.jpeg';
 import tcgaLogo from 'src/images/library/datasets/TCGALogo.jpg';
 import topMedLogo from 'src/images/library/datasets/TopMed@2x.png';
 import { Metrics } from 'src/libs/ajax/Metrics';
-import { getEnabledBrand } from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import Events from 'src/libs/events';
@@ -400,7 +399,7 @@ const fcDataLib = () =>
         {
           'aria-label': 'Browse Broad Institute datasets',
           tooltip: 'Search for dataset workspaces',
-          href: `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}#library`,
+          href: `${getConfig().duosUrlRoot}/datalibrary/firecloud`,
           onClick: () => captureBrowseDataEvent('Broad Institute Datasets'),
           ...Utils.newTabLinkProps,
         },
@@ -554,7 +553,7 @@ const target = () =>
         ButtonPrimary,
         {
           'aria-label': 'Browse TARGET data',
-          href: `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}&project=TARGET#library`,
+          href: `${getConfig().duosUrlRoot}/datalibrary/firecloud`,
           onClick: () => captureBrowseDataEvent('TARGET'),
           ...Utils.newTabLinkProps,
         },
@@ -583,7 +582,7 @@ const tcga = () =>
         ButtonPrimary,
         {
           'aria-label': 'Browse Cancer Genome Atlas data',
-          href: `${getConfig().firecloudUrlRoot}/?return=${getEnabledBrand().queryName}&project=TCGA#library`,
+          href: `${getConfig().duosUrlRoot}/datalibrary/firecloud`,
           onClick: () => captureBrowseDataEvent('Cancer Genome Atlas'),
           ...Utils.newTabLinkProps,
         },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-381

On the Datasets Library (aka Data Browser) page:
* remove the Broad Dataset Workspace Library card entirely
* update the TARGET and TCGA cards to link to DUOS instead of FireCloud UI

### Testing strategy
- [x] Tested by running locally

Broad Dataset Workspace Library is no longer present:
![Screenshot 13-03-2025 at 12 17](https://github.com/user-attachments/assets/8088781f-7ca9-441c-ba04-1629ca10987e)