### PR TITLE
[CORE-383] Fix overlapping UX in workspace creation wizard with additional notifications

### DIFF
--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceWizard.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceWizard.tsx
@@ -386,7 +386,7 @@ export const NewWorkspaceWizard = withDisplayName(
               </ButtonPrimary>
             }
             width={620}
-            styles={{ modal: { height: 675 } }}
+            styles={{ modal: { height: '72vh' } }}
           >
             {creating ? (
               <CreatingWorkspaceMessage />

--- a/src/workspaces/NewWorkspaceModal/NewWorkspaceWizard.tsx
+++ b/src/workspaces/NewWorkspaceModal/NewWorkspaceWizard.tsx
@@ -385,8 +385,8 @@ export const NewWorkspaceWizard = withDisplayName(
                 )}
               </ButtonPrimary>
             }
-            width={620}
-            styles={{ modal: { height: '72vh' } }}
+            width={720}
+            styles={{ modal: { height: 720 } }}
           >
             {creating ? (
               <CreatingWorkspaceMessage />


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-383

### What
- This PR fixes the overlapping UX in the workspace creation wizard when additional notifications appear during the import flow. The modal for additional security options causes the UI to overlap due to improper height settings.

### Why
- The issue occurs because the modal's height isn't managed correctly when additional notifications are shown, causing overlap and poor user experience. This fix ensures the modal is sized properly to prevent overflow and maintain a clean UI.

### Testing strategy
- Manual Testing: Reproduce the bug and validate the fix

**Laptop Screen**
<img width="1459" alt="after-small-screen" src="https://github.com/user-attachments/assets/439b434e-35f1-49dd-97f7-5685f574968f" />

**Monitor Screen**
<img width="1581" alt="after-big-screen" src="https://github.com/user-attachments/assets/7a75e9e4-af7d-479a-8cff-7696182ed91f" />