### PR TITLE
[CORE-394] Ensure read2 Remains Null for Single-Read Sequencing Patterns

### DIFF
--- a/src/workspace-data/upload-data/UploadData.js
+++ b/src/workspace-data/upload-data/UploadData.js
@@ -698,7 +698,7 @@ const MetadataUploadPanel = ({
                 _.map(() => '', _.range(0, headerRow.length - row.length))
               ),
             // Replace any file references with bucket paths
-            _.map((cell) => (cell in filenames ? filenames[cell] : cell))
+            _.map((cell) => (cell && cell in filenames ? filenames[cell] : cell))
           ),
           otherRows
         );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-394

### What
- Fixes an issue where the `read2` field is populated for single-read sequencing patterns after [CORE-315](https://broadworkbench.atlassian.net/browse/CORE-315). This ensures that `read2` remains null/empty when only one file matches.

### Why
- Single-read sequencing patterns should not have a `read2` value. The unintended change could cause misinterpretation in downstream processing.

### Testing strategy
- Regression tests to verify paired-read patterns still work correctly.
- Manual checks on sample data.

### Screens

**Before**
<img width="2360" alt="before" src="https://github.com/user-attachments/assets/accea94d-ceea-4f96-b36e-d90bdac215bb" />

**After**
<img width="2360" alt="after" src="https://github.com/user-attachments/assets/dfe9c976-7e33-40e2-809c-4848e20cfaca" />

[CORE-315]: https://broadworkbench.atlassian.net/browse/CORE-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ