### PR TITLE
[CORE-384] Update DataTable URI Viewer "View File" and Add "View Folder" Links

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -257,6 +257,12 @@ export const bucketBrowserUrl = (id) => {
   return `https://console.cloud.google.com/storage/browser/${id}?authuser=${getTerraUser().email}`;
 };
 
+export const bucketFileBrowserUrl = (bucketId, fileId) => {
+  return `https://console.cloud.google.com/storage/browser/_details/${bucketId}/${fileId};tab=live_object?authuser=${
+    getTerraUser().email
+  }`;
+};
+
 /*
  * Specifies whether the user has logged in via the Azure identity provider.
  */

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -2,8 +2,8 @@ import { ButtonOutline, icon, Modal, Spinner } from '@terra-ui-packages/componen
 import filesize from 'filesize';
 import _ from 'lodash/fp';
 import { Fragment, useState } from 'react';
-import { div, h, p, pre, span } from 'react-hyperscript-helpers';
-import { bucketBrowserUrl } from 'src/auth/auth';
+import { br, div, h, p, pre, span } from 'react-hyperscript-helpers';
+import { bucketBrowserUrl, bucketFileBrowserUrl } from 'src/auth/auth';
 import { LabeledRadioButton, LabeledRadioGroup } from 'src/billing/NewBillingProjectWizard/StepWizard/LabeledRadioButton';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import Collapse from 'src/components/Collapse';
@@ -268,9 +268,19 @@ export const UriViewer = _.flow(
                         Link,
                         {
                           ...Utils.newTabLinkProps,
-                          href: bucketBrowserUrl(gsUri.match(/gs:\/\/(.+)\//)[1]),
+                          href: bucketFileBrowserUrl(gsUri.match(/gs:\/\/(.+?)\/(.+)/)[1], gsUri.match(/gs:\/\/(.+?)\/(.+)/)[2]),
                         },
                         ['View this file in the Google Cloud Storage Browser']
+                      ),
+                      br(),
+                      br(),
+                      h(
+                        Link,
+                        {
+                          ...Utils.newTabLinkProps,
+                          href: bucketBrowserUrl(gsUri.match(/gs:\/\/(.+)\//)[1]),
+                        },
+                        ['View the folder containing this file in Google Cloud Storage Browser']
                       ),
                     ]),
                   h(UriDownloadButton, { uri, metadata, accessUrl, workspace }),

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react';
+import { h } from 'react-hyperscript-helpers';
+import { bucketBrowserUrl, bucketFileBrowserUrl } from 'src/auth/auth';
+import { Link } from 'src/components/common';
+import * as Utils from 'src/libs/utils';
+import { renderWithAppContexts } from 'src/testing/test-utils';
+
+describe('UriViewer Links', () => {
+  const gsUri = 'gs://my-bucket/my-file.txt';
+  const accessUrl = null;
+
+  it('should render link to view file in Google Cloud Storage Browser', () => {
+    renderWithAppContexts(
+      !accessUrl &&
+        !!gsUri &&
+        h(
+          Link,
+          {
+            ...Utils.newTabLinkProps,
+            href: bucketFileBrowserUrl(gsUri.match(/gs:\/\/(.+?)\/(.+)/)[1], gsUri.match(/gs:\/\/(.+?)\/(.+)/)[2]),
+          },
+          ['View this file in the Google Cloud Storage Browser']
+        )
+    );
+
+    const link = screen.getByText('View this file in the Google Cloud Storage Browser');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://console.cloud.google.com/storage/browser/_details/my-bucket/my-file.txt;tab=live_object?authuser=undefined'
+    );
+  });
+
+  it('should render link to view folder in Google Cloud Storage Browser', () => {
+    renderWithAppContexts(
+      !accessUrl &&
+        !!gsUri &&
+        h(
+          Link,
+          {
+            ...Utils.newTabLinkProps,
+            href: bucketBrowserUrl(gsUri.match(/gs:\/\/(.+)\//)[1]),
+          },
+          ['View the folder containing this file in Google Cloud Storage Browser']
+        )
+    );
+
+    const link = screen.getByText('View the folder containing this file in Google Cloud Storage Browser');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://console.cloud.google.com/storage/browser/my-bucket?authuser=undefined');
+  });
+});


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-384

### What
- This update changes the “View this file in Google Cloud Storage Browser” link to match the new pattern and adds a new “View the folder containing this file in Google Cloud Storage Browser” link with the current behavior.

### Why
- This ensures the links are consistent with the labels and adds an easy way for users to view either the file or folder containing the file.

### Testing strategy
- Unit Testing
  - Added Unit Tests to check links are generated
- Manual Testing
  -  Verify the “View this file” link follows the new pattern.
  - Check that the new “View folder” link is displayed correctly. 

### Screens

**Before**
<img width="1785" alt="before" src="https://github.com/user-attachments/assets/7e75d965-0f48-48bd-a9c1-c27c8ee1f415" />

**After**
<img width="1762" alt="after" src="https://github.com/user-attachments/assets/39021be0-ced6-41a5-bb19-9cf3e90715df" />