### PR TITLE
[CORE-411] Don't attempt to delete DeleteFailed workspaces

### DIFF
--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -36,10 +36,10 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
   const oldWorkspaces = await listOrphanWorkspaces(page);
   // List orphans which are already in state DeleteFailed (resistant to automated delete, don't fail on these)
   const oldWorkspaceNamesInDeleteFailed = getDeleteFailedWorkspaceNames(oldWorkspaces);
-  console.log(`${oldWorkspaceNamesInDeleteFailed.length} test workspaces in state DeleteFailed`);
+  const oldWorkspacesToDelete = oldWorkspaces.filter(({ workspace: { name } }) => !oldWorkspaceNamesInDeleteFailed.includes(name));
 
   // Delete orphans
-  console.log(`Attempting to delete ${oldWorkspaces.length} test workspaces created more than ${olderThanCount} ${timeUnit} ago.`);
+  console.log(`Attempting to delete ${oldWorkspacesToDelete.length} test workspaces created more than ${olderThanCount} ${timeUnit} ago.`);
   return Promise.all(
     _.map(async ({ workspace: { namespace, name, cloudPlatform } }) => {
       try {
@@ -50,7 +50,7 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
       } catch (e) {
         return { name, cloudPlatform, isDeleted: false };
       }
-    }, oldWorkspaces)
+    }, oldWorkspacesToDelete)
   ).then(async (results) => {
     // Report results
     const deletedNames =

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -68,6 +68,8 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
     const persistentOrphans = currentOrphans.filter(({ workspace: { name } }) =>
       oldWorkspaces.some(({ workspace: { name: oldName } }) => oldName === name)
     );
+    console.log(`${persistentOrphans.length} persistent orphans remaining after delete attempt.`);
+    console.log('persistent orphans: ', persistentOrphans);
     const deleteFailedOrphans = getDeleteFailedWorkspaceNames(persistentOrphans);
     const newlyFailedDeletes = deleteFailedOrphans.filter((newName) => !oldWorkspaceNamesInDeleteFailed.includes(newName));
 

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -70,7 +70,6 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
       oldWorkspaces.some(({ workspace: { name: oldName } }) => oldName === name)
     );
     console.log(`${persistentOrphans.length} persistent orphans remaining after delete attempt.`);
-    console.log('persistent orphans: ', persistentOrphans);
     const deleteFailedOrphans = getDeleteFailedWorkspaceNames(persistentOrphans);
     const newlyFailedDeletes = deleteFailedOrphans.filter((newName) => !oldWorkspaceNamesInDeleteFailed.includes(newName));
 

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -36,7 +36,9 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
   const oldWorkspaces = await listOrphanWorkspaces(page);
   // List orphans which are already in state DeleteFailed (resistant to automated delete, don't fail on these)
   const oldWorkspaceNamesInDeleteFailed = getDeleteFailedWorkspaceNames(oldWorkspaces);
-  const oldWorkspacesToDelete = oldWorkspaces.filter(({ workspace: { name } }) => !oldWorkspaceNamesInDeleteFailed.includes(name));
+  const oldWorkspacesToDelete = oldWorkspaces.filter(
+    ({ workspace: { namespace, name } }) => !oldWorkspaceNamesInDeleteFailed.includes(`${namespace}/${name}`)
+  );
 
   // Delete orphans
   console.log(`Attempting to delete ${oldWorkspacesToDelete.length} test workspaces created more than ${olderThanCount} ${timeUnit} ago.`);
@@ -71,7 +73,9 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
     );
     console.log(`${persistentOrphans.length} persistent orphans remaining after delete attempt.`);
     const deleteFailedOrphans = getDeleteFailedWorkspaceNames(persistentOrphans);
+    console.log(`deleteFailedOrphans: ${deleteFailedOrphans}`);
     const newlyFailedDeletes = deleteFailedOrphans.filter((newName) => !oldWorkspaceNamesInDeleteFailed.includes(newName));
+    console.log(`newlyFailedDeletes: ${newlyFailedDeletes}`);
 
     if (newlyFailedDeletes.length) {
       const newlyFailedNames = newlyFailedDeletes.map(({ name, cloudPlatform }) => `${name} (${cloudPlatform})`).join(', ');
@@ -106,7 +110,9 @@ const listOrphanWorkspaces = async (page, { isVerbose = true } = {}) => {
 };
 
 const getDeleteFailedWorkspaceNames = (workspaces) => {
-  return workspaces.filter(({ workspace: { state } }) => state === 'DeleteFailed').map(({ workspace: { name } }) => name);
+  return workspaces
+    .filter(({ workspace: { state } }) => state === 'DeleteFailed')
+    .map(({ workspace: { namespace, name } }) => `${namespace}/${name}`);
 };
 
 registerTest({

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -73,14 +73,11 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
     );
     console.log(`${persistentOrphans.length} persistent orphans remaining after delete attempt.`);
     const deleteFailedOrphans = getDeleteFailedWorkspaceNames(persistentOrphans);
-    console.log(`deleteFailedOrphans: ${deleteFailedOrphans}`);
     const newlyFailedDeletes = deleteFailedOrphans.filter((newName) => !oldWorkspaceNamesInDeleteFailed.includes(newName));
-    console.log(`newlyFailedDeletes: ${newlyFailedDeletes}`);
 
     if (newlyFailedDeletes.length) {
-      const newlyFailedNames = newlyFailedDeletes.map(({ name, cloudPlatform }) => `${name} (${cloudPlatform})`).join(', ');
       throw new Error(
-        `${newlyFailedDeletes.length} workspaces entered state DeleteFailed after orphan cleanup. These should be manually deleted: ${newlyFailedNames}`
+        `${newlyFailedDeletes.length} workspaces entered state DeleteFailed after orphan cleanup. These should be manually deleted: ${newlyFailedDeletes}`
       );
     }
   });

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -36,6 +36,7 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
   const oldWorkspaces = await listOrphanWorkspaces(page);
   // List orphans which are already in state DeleteFailed (resistant to automated delete, don't fail on these)
   const oldWorkspaceNamesInDeleteFailed = getDeleteFailedWorkspaceNames(oldWorkspaces);
+  console.log(`${oldWorkspaceNamesInDeleteFailed.length} test workspaces in state DeleteFailed`);
 
   // Delete orphans
   console.log(`Attempting to delete ${oldWorkspaces.length} test workspaces created more than ${olderThanCount} ${timeUnit} ago.`);
@@ -61,7 +62,7 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
     const failedNames = failedDeletes.map(({ name, cloudPlatform }) => `${name} (${cloudPlatform})`).join(', ');
     console.info(`Triggered delete on workspaces: ${deletedNames}`);
     if (failedNames) {
-      console.warn(`Failed to delete workspaces: ${failedNames}`);
+      console.warn(`Failed to delete ${failedNames.length} workspaces : ${failedNames}`);
     }
 
     const currentOrphans = await listOrphanWorkspaces(page, { isVerbose: false });

--- a/integration-tests/tests/delete-orphaned-workspaces.js
+++ b/integration-tests/tests/delete-orphaned-workspaces.js
@@ -62,7 +62,7 @@ const deleteOrphanedWorkspaces = withUserToken(async ({ page, testUrl, token }) 
     const failedNames = failedDeletes.map(({ name, cloudPlatform }) => `${name} (${cloudPlatform})`).join(', ');
     console.info(`Triggered delete on workspaces: ${deletedNames}`);
     if (failedNames) {
-      console.warn(`Failed to delete ${failedNames.length} workspaces : ${failedNames}`);
+      console.warn(`Failed to delete ${failedDeletes.length} workspaces : ${failedNames}`);
     }
 
     const currentOrphans = await listOrphanWorkspaces(page, { isVerbose: false });

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -344,7 +344,6 @@ const deleteRuntimesV2 = async ({ page, billingProject, workspaceId }) => {
   const deletableRuntimes = await page.evaluate(async (workspaceId) => {
     return await window.Ajax().Runtimes.listV2WithWorkspace(workspaceId, { role: 'creator' });
   }, workspaceId);
-  console.log(`deletableRuntimes for ${workspaceId}:`, deletableRuntimes);
   const deletedRuntimes = await Promise.all(
     deletableRuntimes.map(async (runtime) => {
       const isRuntimeDeleted = await patientlyDeleteRuntime(page, runtime);

--- a/integration-tests/utils/integration-helpers.js
+++ b/integration-tests/utils/integration-helpers.js
@@ -344,6 +344,7 @@ const deleteRuntimesV2 = async ({ page, billingProject, workspaceId }) => {
   const deletableRuntimes = await page.evaluate(async (workspaceId) => {
     return await window.Ajax().Runtimes.listV2WithWorkspace(workspaceId, { role: 'creator' });
   }, workspaceId);
+  console.log(`deletableRuntimes for ${workspaceId}:`, deletableRuntimes);
   const deletedRuntimes = await Promise.all(
     deletableRuntimes.map(async (runtime) => {
       const isRuntimeDeleted = await patientlyDeleteRuntime(page, runtime);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-411
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
After cleanup prior to the start of and during investigation for this ticket, there are 51 orphaned test workspaces that are undeleteable.  Several of them remained in state `READY` despite failing to be deleted every time the test ran; I've manually set them to `DeleteFailed`.  This PR now filters out workspaces in the `DeleteFailed` state as there seems to be no point to continually attempt to delete them.  The test already fails if any new workspaces fail to be deleted, which will *hopefully* encourage someone to do so manually if possible.  

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
