### PR TITLE
[CORE-442] Fix missing workspace costs in billing project reports

### DIFF
--- a/src/billing/Workspaces/Workspaces.tsx
+++ b/src/billing/Workspaces/Workspaces.tsx
@@ -222,7 +222,7 @@ export const Workspaces = (props: WorkspacesProps): ReactNode => {
         // Create a map of spend data by workspace identifier
         const spendDataMap = _.keyBy(
           (spendItem: WorkspaceSpendData) => `${spendItem.workspace.namespace}-${spendItem.workspace.name}`,
-          (billingProjectSpentReport.spendDetails[0] as AggregatedWorkspaceSpendData).spendData
+          _.flatMap((detail: AggregatedWorkspaceSpendData) => detail.spendData, billingProjectSpentReport.spendDetails)
         );
 
         // Update each workspace with spend data or default values

--- a/src/billing/Workspaces/Workspaces.tsx
+++ b/src/billing/Workspaces/Workspaces.tsx
@@ -228,7 +228,7 @@ export const Workspaces = (props: WorkspacesProps): ReactNode => {
         // Update each workspace with spend data or default values
         return workspacesInProject.map((workspace) => {
           const key = `${workspace.namespace}-${workspace.name}`;
-          const spendItem = spendDataMap[key];
+          const spendItem = spendDataMap[key] as unknown as WorkspaceSpendData | undefined;
 
           if (!spendItem) {
             return setDefaultSpendValues(workspace);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-442

### What
- This PR fixes an issue where workspace costs show as "N/A" in individual billing project reports, even though the user still has access and can see the costs in the consolidated report.

### Why
- To ensure consistency between the consolidated and individual views and avoid confusion for users.

### Testing strategy
- Manual Testing: Ensure all workspace spend data is viewable in both Consolidated and Billing Project Tabs

### Screens

**Consolidated Spend Report**
<img width="1794" alt="Consolidated" src="https://github.com/user-attachments/assets/481215cc-44db-4a09-8951-dd2495faed00" />

**Billing Project Spend Report**
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="1794" alt="Before" src="https://github.com/user-attachments/assets/713bf451-bbf4-434d-bb94-737fb6bb9dae" />
</td>
<td>
<img width="1794" alt="After" src="https://github.com/user-attachments/assets/4ddb8e85-8f96-4a80-a2c8-311b7b5fa9ae" />
</td>
</tr>
</table>