### PR TITLE
[CORE-448] Show Workspace Menu for No Access Users

### DIFF
--- a/src/libs/ajax/SamResources.ts
+++ b/src/libs/ajax/SamResources.ts
@@ -57,6 +57,13 @@ export const SamResources = (signal?: AbortSignal) => ({
       _.mergeAll([authOpts(), { signal }])
     ).then((r) => r.json());
   },
+
+  getResourceRolesV2: async (fqResourceId: FullyQualifiedResourceId): Promise<string[]> => {
+    return fetchSam(
+      `api/resources/v2/${fqResourceId.resourceTypeName}/${fqResourceId.resourceId}/roles`,
+      _.mergeAll([authOpts(), { signal }])
+    ).then((r) => r.json());
+  },
 });
 
 export type SamResourcesContract = ReturnType<typeof SamResources>;

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -67,10 +67,7 @@ const azureWorkspace: AzureWorkspace = {
   policies: [protectedDataPolicy],
 };
 
-const loggedInUser = {
-  userEmail: 'test@example.com',
-  accessLevel: 'OWNER' as WorkspaceAccessLevel,
-};
+const accessLevel: WorkspaceAccessLevel = 'OWNER';
 
 const workspaceMenuProps = {
   iconSize: 20,
@@ -87,7 +84,7 @@ const workspaceMenuProps = {
     name: 'example1',
     namespace: 'example-billing-project',
     selectedWorkspace: googleWorkspace,
-    loggedInUser,
+    accessLevel,
   },
 };
 
@@ -504,7 +501,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
       name,
       namespace,
       selectedWorkspace: googleWorkspace,
-      loggedInUser,
+      accessLevel,
     },
   };
 
@@ -538,7 +535,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
         namespace,
         name,
         selectedWorkspace: googleWorkspace,
-        loggedInUser,
+        accessLevel,
       },
       expectedRequestedFields
     );

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -507,7 +507,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
 
   it('requests expected fields', async () => {
     // Arrange
-    asMockedFn(useWorkspaceDetails).mockReturnValue({
+    const workspaceDetails = asMockedFn(useWorkspaceDetails).mockReturnValue({
       workspace: googleWorkspace,
       refresh: jest.fn(),
       loading: false,
@@ -530,7 +530,7 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     render(h(WorkspaceMenu, workspaceMenuProps));
 
     // Assert
-    expect(asMockedFn(useWorkspaceDetails)).toHaveBeenCalledWith(
+    expect(workspaceDetails).toHaveBeenCalledWith(
       {
         namespace,
         name,

--- a/src/workspaces/common/WorkspaceMenu.test.ts
+++ b/src/workspaces/common/WorkspaceMenu.test.ts
@@ -33,20 +33,6 @@ jest.mock('src/components/PopupTrigger', () => {
   };
 });
 
-const workspaceMenuProps = {
-  iconSize: 20,
-  popupLocation: 'left',
-  callbacks: {
-    onClone: () => {},
-    onShare: () => {},
-    onLock: () => {},
-    onDelete: () => {},
-    onLeave: () => {},
-    onShowSettings: () => {},
-  },
-  workspaceInfo: { name: 'example1', namespace: 'example-billing-project' },
-};
-
 const descriptionText =
   'This description is longer then two hundred and fifty five characters, to ensure we can test that all two hundred and fifty five characters actually get copied over during a cloning event. If they are not copied over then it is indeed a bug that needs to fail the test. (280chars)';
 const googleWorkspace: GoogleWorkspace = {
@@ -79,6 +65,30 @@ const azureWorkspace: AzureWorkspace = {
   accessLevel: 'OWNER',
   canShare: true,
   policies: [protectedDataPolicy],
+};
+
+const loggedInUser = {
+  userEmail: 'test@example.com',
+  accessLevel: 'OWNER' as WorkspaceAccessLevel,
+};
+
+const workspaceMenuProps = {
+  iconSize: 20,
+  popupLocation: 'left',
+  callbacks: {
+    onClone: () => {},
+    onShare: () => {},
+    onLock: () => {},
+    onDelete: () => {},
+    onLeave: () => {},
+    onShowSettings: () => {},
+  },
+  workspaceInfo: {
+    name: 'example1',
+    namespace: 'example-billing-project',
+    selectedWorkspace: googleWorkspace,
+    loggedInUser,
+  },
 };
 
 beforeEach(() => {
@@ -490,12 +500,17 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
       onLeave: jest.fn(),
       onShowSettings: jest.fn(),
     },
-    workspaceInfo: { namespace, name },
+    workspaceInfo: {
+      name,
+      namespace,
+      selectedWorkspace: googleWorkspace,
+      loggedInUser,
+    },
   };
 
   it('requests expected fields', async () => {
     // Arrange
-    const workspaceDetails = asMockedFn(useWorkspaceDetails).mockReturnValue({
+    asMockedFn(useWorkspaceDetails).mockReturnValue({
       workspace: googleWorkspace,
       refresh: jest.fn(),
       loading: false,
@@ -518,7 +533,15 @@ describe('DynamicWorkspaceMenuContent fetches specific workspace details', () =>
     render(h(WorkspaceMenu, workspaceMenuProps));
 
     // Assert
-    expect(workspaceDetails).toHaveBeenCalledWith({ namespace, name }, expectedRequestedFields);
+    expect(asMockedFn(useWorkspaceDetails)).toHaveBeenCalledWith(
+      {
+        namespace,
+        name,
+        selectedWorkspace: googleWorkspace,
+        loggedInUser,
+      },
+      expectedRequestedFields
+    );
   });
 
   it('passes onClone the bucketName, description, and googleProject for a Google workspace', async () => {

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -14,6 +14,7 @@ import {
   getCloudProviderFromWorkspace,
   isGoogleWorkspace,
   isOwner,
+  WorkspaceAccessLevel,
   WorkspacePolicy,
   WorkspaceState,
   WorkspaceWrapper as Workspace,
@@ -24,7 +25,7 @@ const isNameType = (o: WorkspaceInfo): o is DynamicWorkspaceInfo =>
   typeof o.name === 'string' &&
   'namespace' in o &&
   typeof o.namespace === 'string' &&
-  Object.keys(o).length === 2;
+  Object.keys(o).length === 4;
 
 type LoadedWorkspaceInfo = {
   state?: WorkspaceState;
@@ -35,9 +36,23 @@ type LoadedWorkspaceInfo = {
   cloudProvider?: CloudProvider;
   namespace: string;
   name: string;
+  selectedWorkspace?: Workspace;
+  loggedInUser?: {
+    userEmail?: string;
+    accessLevel: WorkspaceAccessLevel;
+  };
+  accessLevel?: WorkspaceAccessLevel;
 };
 
-type DynamicWorkspaceInfo = { name: string; namespace: string };
+type DynamicWorkspaceInfo = {
+  name: string;
+  namespace: string;
+  selectedWorkspace?: Workspace;
+  loggedInUser?: {
+    userEmail?: string;
+    accessLevel: WorkspaceAccessLevel;
+  };
+};
 type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
 interface WorkspaceMenuCallbacks {
@@ -99,24 +114,33 @@ interface DynamicWorkspaceMenuContentProps {
 /**
  * DynamicWorkspaceInfo is invoked when the name/namespace is passed instead of the derived states.
  * This happens from the list component, which also needs the workspace policies and bucketName for
- * sharing and cloning the workspace. This is also leveraged to pass the full decription during cloning as well.
+ * sharing and cloning the workspace. This is also leveraged to pass the full description during cloning as well.
  */
 const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) => {
   const {
-    workspaceInfo: { name, namespace },
+    workspaceInfo: { name, namespace, selectedWorkspace, loggedInUser },
     callbacks,
   } = props;
-  const { workspace } = useWorkspaceDetails({ namespace, name }, [
-    'accessLevel',
-    'canShare',
-    'policies',
-    'workspace.bucketName',
-    'workspace.attributes.description',
-    'workspace.cloudPlatform',
-    'workspace.googleProject',
-    'workspace.isLocked',
-    'workspace.state',
-  ]) as { workspace?: Workspace };
+
+  const { workspace } = useWorkspaceDetails(
+    {
+      namespace,
+      name,
+      selectedWorkspace,
+      loggedInUser: loggedInUser ?? {},
+    },
+    [
+      'accessLevel',
+      'canShare',
+      'policies',
+      'workspace.bucketName',
+      'workspace.attributes.description',
+      'workspace.cloudPlatform',
+      'workspace.googleProject',
+      'workspace.isLocked',
+      'workspace.state',
+    ]
+  ) as { workspace?: Workspace };
   const bucketName = !!workspace && isGoogleWorkspace(workspace) ? workspace.workspace.bucketName : undefined;
   const googleProject = !!workspace && isGoogleWorkspace(workspace) ? workspace.workspace.googleProject : undefined;
 
@@ -135,6 +159,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
       cloudProvider: !workspace ? undefined : getCloudProviderFromWorkspace(workspace),
       namespace,
       name,
+      accessLevel: loggedInUser?.accessLevel,
     },
     // The list component doesn't fetch all the workspace details in order to keep the size of returned payload
     // as small as possible, so we need to pass policies and bucketName for use by the ShareWorkspaceModal
@@ -171,7 +196,7 @@ interface LoadedWorkspaceMenuContentProps {
 }
 const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
   const {
-    workspaceInfo: { state, canShare, isLocked, isOwner, workspaceLoaded, cloudProvider, namespace, name },
+    workspaceInfo: { state, canShare, isLocked, isOwner, workspaceLoaded, cloudProvider, namespace, name, accessLevel },
     callbacks: { onShare, onLock, onLeave, onClone, onDelete, onShowSettings },
     origin,
   } = props;
@@ -194,6 +219,8 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     });
   };
 
+  const noAccess = accessLevel === 'NO ACCESS';
+
   return h(Fragment, [
     h(
       MenuButton,
@@ -202,7 +229,8 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
           cloudProvider !== cloudProviderTypes.GCP ||
           !workspaceLoaded ||
           state === 'Deleting' ||
-          state === 'DeleteFailed',
+          state === 'DeleteFailed' ||
+          noAccess,
         onClick: () => {
           menuClicked('Settings');
           onShowSettings();
@@ -219,7 +247,8 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
           !workspaceLoaded ||
           state === 'Deleting' ||
           state === 'DeleteFailed' ||
-          cloudProvider !== cloudProviderTypes.GCP,
+          cloudProvider !== cloudProviderTypes.GCP ||
+          noAccess,
         onClick: () => {
           menuClicked('Clone');
           onClone();
@@ -243,7 +272,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || !isOwner || state === 'Deleting' || state === 'DeleteFailed',
+        disabled: !workspaceLoaded || !isOwner || state === 'Deleting' || state === 'DeleteFailed' || noAccess,
         tooltip: workspaceLoaded &&
           !isOwner && [isLocked ? tooltipText.unlockNoPermission : tooltipText.lockNoPermission],
         tooltipSide: 'left',
@@ -257,7 +286,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed',
+        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed' || noAccess,
         onClick: () => {
           menuClicked('Leave');
           onLeave();

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -279,7 +279,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed' || noAccess,
+        disabled: !workspaceLoaded || state === 'Deleting' || state === 'DeleteFailed',
         onClick: () => {
           menuClicked('Leave');
           onLeave();

--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -37,10 +37,6 @@ type LoadedWorkspaceInfo = {
   namespace: string;
   name: string;
   selectedWorkspace?: Workspace;
-  loggedInUser?: {
-    userEmail?: string;
-    accessLevel: WorkspaceAccessLevel;
-  };
   accessLevel?: WorkspaceAccessLevel;
 };
 
@@ -48,10 +44,7 @@ type DynamicWorkspaceInfo = {
   name: string;
   namespace: string;
   selectedWorkspace?: Workspace;
-  loggedInUser?: {
-    userEmail?: string;
-    accessLevel: WorkspaceAccessLevel;
-  };
+  accessLevel: WorkspaceAccessLevel;
 };
 type WorkspaceInfo = DynamicWorkspaceInfo | LoadedWorkspaceInfo;
 
@@ -118,7 +111,7 @@ interface DynamicWorkspaceMenuContentProps {
  */
 const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) => {
   const {
-    workspaceInfo: { name, namespace, selectedWorkspace, loggedInUser },
+    workspaceInfo: { name, namespace, selectedWorkspace, accessLevel },
     callbacks,
   } = props;
 
@@ -127,7 +120,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
       namespace,
       name,
       selectedWorkspace,
-      loggedInUser: loggedInUser ?? {},
+      accessLevel,
     },
     [
       'accessLevel',
@@ -159,7 +152,7 @@ const DynamicWorkspaceMenuContent = (props: DynamicWorkspaceMenuContentProps) =>
       cloudProvider: !workspace ? undefined : getCloudProviderFromWorkspace(workspace),
       namespace,
       name,
-      accessLevel: loggedInUser?.accessLevel,
+      accessLevel,
     },
     // The list component doesn't fetch all the workspace details in order to keep the size of returned payload
     // as small as possible, so we need to pass policies and bucketName for use by the ShareWorkspaceModal

--- a/src/workspaces/common/state/useWorkspaceDetails.test.tsx
+++ b/src/workspaces/common/state/useWorkspaceDetails.test.tsx
@@ -1,0 +1,97 @@
+import { act } from '@testing-library/react';
+import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
+import { asMockedFn, partial, renderHookInAct } from 'src/testing/test-utils';
+import { canRead } from 'src/workspaces/utils';
+
+import { useWorkspaceDetails } from './useWorkspaceDetails';
+
+jest.mock('src/libs/ajax/workspaces/Workspaces');
+jest.mock('src/workspaces/utils', () => ({
+  ...jest.requireActual('src/workspaces/utils'),
+  canRead: jest.fn(),
+}));
+
+describe('useWorkspaceDetails', () => {
+  const mockWorkspaceDetails = { workspace: { name: 'test-workspace' }, accessLevel: 'READER' };
+  const mockGetAcl = { acl: { user1: { accessLevel: 'OWNER', canShare: true, canCompute: true } } };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMockedFn(canRead).mockReturnValue(true);
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: jest.fn(() =>
+          partial<WorkspaceContract>({
+            details: jest.fn().mockResolvedValue(mockWorkspaceDetails),
+            getAcl: jest.fn().mockResolvedValue(mockGetAcl),
+          })
+        ),
+      })
+    );
+  });
+
+  it('fetches workspace details when user has read access', async () => {
+    // Arrange & Act
+    const { result } = await renderHookInAct(() =>
+      useWorkspaceDetails(
+        { namespace: 'test-namespace', name: 'test-name', loggedInUser: { userEmail: 'user1', accessLevel: 'READER' } },
+        ['field1', 'field2']
+      )
+    );
+
+    // Assert
+    expect(result.current.workspace).toEqual(mockWorkspaceDetails);
+    expect(result.current.loading).toBe(false);
+    expect(Workspaces().workspace).toHaveBeenCalledWith('test-namespace', 'test-name');
+  });
+
+  it('fetches ACL and sets workspace when user does not have read access', async () => {
+    // Arrange
+    asMockedFn(canRead).mockReturnValue(false);
+
+    // Act
+    const { result } = await renderHookInAct(() =>
+      useWorkspaceDetails(
+        {
+          namespace: 'test-namespace',
+          name: 'test-name',
+          loggedInUser: { userEmail: 'user1', accessLevel: 'NO ACCESS' },
+        },
+        ['field1', 'field2']
+      )
+    );
+
+    // Assert
+    expect(result.current.workspace).toEqual({
+      accessLevel: 'OWNER',
+      canCompute: true,
+      canShare: true,
+      policies: [],
+      workspace: expect.objectContaining({
+        namespace: 'test-namespace',
+        name: 'test-name',
+      }),
+    });
+    expect(result.current.loading).toBe(false);
+    expect(Workspaces().workspace).toHaveBeenCalledWith('test-namespace', 'test-name');
+  });
+
+  it('refreshes workspace details when refresh is called', async () => {
+    // Arrange
+    const { result } = await renderHookInAct(() =>
+      useWorkspaceDetails(
+        { namespace: 'test-namespace', name: 'test-name', loggedInUser: { userEmail: 'user1', accessLevel: 'READER' } },
+        ['field1', 'field2']
+      )
+    );
+
+    // Act
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    // Assert
+    expect(result.current.workspace).toEqual(mockWorkspaceDetails);
+    expect(Workspaces().workspace).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/workspaces/common/state/useWorkspaceDetails.test.tsx
+++ b/src/workspaces/common/state/useWorkspaceDetails.test.tsx
@@ -1,19 +1,30 @@
 import { act } from '@testing-library/react';
+import { SamResources, SamResourcesContract } from 'src/libs/ajax/SamResources';
 import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { asMockedFn, partial, renderHookInAct } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { canRead } from 'src/workspaces/utils';
 
 import { useWorkspaceDetails } from './useWorkspaceDetails';
 
+jest.mock('src/libs/ajax/SamResources');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
 jest.mock('src/workspaces/utils', () => ({
   ...jest.requireActual('src/workspaces/utils'),
   canRead: jest.fn(),
 }));
+type NotificationExports = typeof import('src/libs/notifications');
+jest.mock<NotificationExports>(
+  'src/libs/notifications',
+  (): NotificationExports => ({
+    ...jest.requireActual('src/libs/notifications'),
+    notify: jest.fn(),
+  })
+);
 
 describe('useWorkspaceDetails', () => {
   const mockWorkspaceDetails = { workspace: { name: 'test-workspace' }, accessLevel: 'READER' };
-  const mockGetAcl = { acl: { user1: { accessLevel: 'OWNER', canShare: true, canCompute: true } } };
+  const mockRoles = ['project-owner', 'owner'];
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -23,9 +34,13 @@ describe('useWorkspaceDetails', () => {
         workspace: jest.fn(() =>
           partial<WorkspaceContract>({
             details: jest.fn().mockResolvedValue(mockWorkspaceDetails),
-            getAcl: jest.fn().mockResolvedValue(mockGetAcl),
           })
         ),
+      })
+    );
+    asMockedFn(SamResources).mockReturnValue(
+      partial<SamResourcesContract>({
+        getResourceRolesV2: jest.fn().mockResolvedValue(mockRoles),
       })
     );
   });
@@ -34,7 +49,12 @@ describe('useWorkspaceDetails', () => {
     // Arrange & Act
     const { result } = await renderHookInAct(() =>
       useWorkspaceDetails(
-        { namespace: 'test-namespace', name: 'test-name', loggedInUser: { userEmail: 'user1', accessLevel: 'READER' } },
+        {
+          namespace: 'test-namespace',
+          name: 'test-name',
+          selectedWorkspace: defaultGoogleWorkspace,
+          accessLevel: 'READER',
+        },
         ['field1', 'field2']
       )
     );
@@ -45,7 +65,7 @@ describe('useWorkspaceDetails', () => {
     expect(Workspaces().workspace).toHaveBeenCalledWith('test-namespace', 'test-name');
   });
 
-  it('fetches ACL and sets workspace when user does not have read access', async () => {
+  it('fetches workspace user roles and sets workspace when user does not have read access', async () => {
     // Arrange
     asMockedFn(canRead).mockReturnValue(false);
 
@@ -55,7 +75,8 @@ describe('useWorkspaceDetails', () => {
         {
           namespace: 'test-namespace',
           name: 'test-name',
-          loggedInUser: { userEmail: 'user1', accessLevel: 'NO ACCESS' },
+          selectedWorkspace: defaultGoogleWorkspace,
+          accessLevel: 'READER',
         },
         ['field1', 'field2']
       )
@@ -63,7 +84,7 @@ describe('useWorkspaceDetails', () => {
 
     // Assert
     expect(result.current.workspace).toEqual({
-      accessLevel: 'OWNER',
+      accessLevel: 'PROJECT_OWNER', // Updated to match new logic
       canCompute: true,
       canShare: true,
       policies: [],
@@ -73,14 +94,22 @@ describe('useWorkspaceDetails', () => {
       }),
     });
     expect(result.current.loading).toBe(false);
-    expect(Workspaces().workspace).toHaveBeenCalledWith('test-namespace', 'test-name');
+    expect(SamResources().getResourceRolesV2).toHaveBeenCalledWith({
+      resourceTypeName: 'workspace',
+      resourceId: defaultGoogleWorkspace.workspace.workspaceId,
+    });
   });
 
   it('refreshes workspace details when refresh is called', async () => {
     // Arrange
     const { result } = await renderHookInAct(() =>
       useWorkspaceDetails(
-        { namespace: 'test-namespace', name: 'test-name', loggedInUser: { userEmail: 'user1', accessLevel: 'READER' } },
+        {
+          namespace: 'test-namespace',
+          name: 'test-name',
+          selectedWorkspace: defaultGoogleWorkspace,
+          accessLevel: 'READER',
+        },
         ['field1', 'field2']
       )
     );

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -33,12 +33,13 @@ export const useWorkspaceDetails = (
     });
     const isProjectOwner = workspaceUserRoles.includes('project-owner');
     const isOwner = workspaceUserRoles.includes('owner');
+    const canShare = workspaceUserRoles.includes('share-reader') || workspaceUserRoles.includes('share-writer');
 
     // Construct a workspace object (contains dummy values for TS compliance) for users without read access
     return {
       accessLevel: isProjectOwner ? 'PROJECT_OWNER' : (isOwner && 'OWNER') || 'NO ACCESS',
       canCompute: isProjectOwner || isOwner,
-      canShare: isProjectOwner || isOwner,
+      canShare: canShare || isProjectOwner || isOwner,
       policies: selectedWorkspace?.policies ?? [],
       workspace: {
         ...selectedWorkspace?.workspace,

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -34,6 +34,7 @@ export const useWorkspaceDetails = (
     const isProjectOwner = workspaceUserRoles.includes('project-owner');
     const isOwner = workspaceUserRoles.includes('owner');
 
+    // Construct a workspace object (contains dummy values for TS compliance) for users without read access
     return {
       accessLevel: isProjectOwner ? 'PROJECT_OWNER' : (isOwner && 'OWNER') || 'NO ACCESS',
       canCompute: isProjectOwner || isOwner,

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -1,25 +1,75 @@
 import _ from 'lodash/fp';
 import { useState } from 'react';
+import { RawAccessEntry, RawWorkspaceAcl } from 'src/libs/ajax/workspaces/workspace-models';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { withErrorReporting } from 'src/libs/error';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
-import { WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
+import { canRead, WorkspaceAccessLevel, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
-export const useWorkspaceDetails = (workspaceName: { namespace: string; name: string }, fields: string[]) => {
-  const { namespace, name } = workspaceName;
+export const useWorkspaceDetails = (
+  workspaceName: {
+    namespace: string;
+    name: string;
+    selectedWorkspace?: Workspace;
+    loggedInUser: { userEmail?: string; accessLevel: WorkspaceAccessLevel } | {};
+  },
+  fields: string[]
+) => {
+  const { namespace, name, selectedWorkspace, loggedInUser } = workspaceName;
+  const userEmail = (loggedInUser as { userEmail?: string })?.userEmail ?? '';
+  const initialAccessLevel = (loggedInUser as { accessLevel?: WorkspaceAccessLevel })?.accessLevel ?? 'NO ACCESS';
 
   const [workspace, setWorkspace] = useState<Workspace>();
-
   const [loading, setLoading] = useState(true);
   const signal = useCancellation();
+
+  const fetchWorkspaceDetails = async (): Promise<Workspace | undefined> => {
+    if (canRead(initialAccessLevel)) {
+      // Fetch workspace details if the user has read access
+      return await Workspaces(signal).workspace(namespace, name).details(fields);
+    }
+    // Fetch ACL and construct workspace object for users without read access
+    const wsAcls: Record<'acl', RawWorkspaceAcl> = await Workspaces(signal).workspace(namespace, name).getAcl();
+    const accessEntry = _.flow(
+      _.toPairs,
+      _.find(([key, entry]: [string, RawAccessEntry]) => key === userEmail && entry.accessLevel === 'OWNER'),
+      _.last
+    )(wsAcls.acl) as RawAccessEntry | undefined;
+
+    return {
+      accessLevel: accessEntry?.accessLevel ?? 'NO ACCESS',
+      canCompute: accessEntry?.canCompute ?? false,
+      canShare: accessEntry?.canShare ?? false,
+      policies: selectedWorkspace?.policies ?? [],
+      workspace: {
+        ...selectedWorkspace?.workspace,
+        namespace,
+        name,
+        authorizationDomain: selectedWorkspace?.workspace?.authorizationDomain ?? [],
+        billingAccount: '',
+        bucketName: selectedWorkspace?.workspace?.bucketName ?? '',
+        cloudPlatform: 'Gcp',
+        createdBy: selectedWorkspace?.workspace?.createdBy ?? '',
+        createdDate: selectedWorkspace?.workspace?.createdDate ?? '',
+        googleProject: selectedWorkspace?.workspace?.googleProject ?? '',
+        lastModified: selectedWorkspace?.workspace?.lastModified ?? '',
+        workspaceId: selectedWorkspace?.workspace?.workspaceId ?? '',
+      },
+    };
+  };
 
   const refresh = _.flow(
     withErrorReporting('Error loading workspace details'),
     Utils.withBusyState(setLoading)
   )(async () => {
-    const ws: Workspace = await Workspaces(signal).workspace(namespace, name).details(fields);
-    setWorkspace(ws);
+    const ws = await fetchWorkspaceDetails();
+
+    if (ws?.workspace) {
+      // Update the cloud platform based on the selected workspace
+      ws.workspace.cloudPlatform = selectedWorkspace?.workspace.cloudPlatform === 'Gcp' ? 'Gcp' : 'Azure';
+      setWorkspace(ws);
+    }
   });
 
   useOnMount(() => {

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -33,7 +33,7 @@ export const useWorkspaceDetails = (
     const wsAcls: Record<'acl', RawWorkspaceAcl> = await Workspaces(signal).workspace(namespace, name).getAcl();
     const accessEntry = _.flow(
       _.toPairs,
-      _.find(([key, entry]: [string, RawAccessEntry]) => key === userEmail && entry.accessLevel === 'OWNER'),
+      _.find(([key]: [string, RawAccessEntry]) => key === userEmail),
       _.last
     )(wsAcls.acl) as RawAccessEntry | undefined;
 

--- a/src/workspaces/common/state/useWorkspaceDetails.ts
+++ b/src/workspaces/common/state/useWorkspaceDetails.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp';
 import { useState } from 'react';
-import { RawAccessEntry, RawWorkspaceAcl } from 'src/libs/ajax/workspaces/workspace-models';
+import { SamResources } from 'src/libs/ajax/SamResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { withErrorReporting } from 'src/libs/error';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
@@ -12,14 +12,11 @@ export const useWorkspaceDetails = (
     namespace: string;
     name: string;
     selectedWorkspace?: Workspace;
-    loggedInUser: { userEmail?: string; accessLevel: WorkspaceAccessLevel } | {};
+    accessLevel: WorkspaceAccessLevel;
   },
   fields: string[]
 ) => {
-  const { namespace, name, selectedWorkspace, loggedInUser } = workspaceName;
-  const userEmail = (loggedInUser as { userEmail?: string })?.userEmail ?? '';
-  const initialAccessLevel = (loggedInUser as { accessLevel?: WorkspaceAccessLevel })?.accessLevel ?? 'NO ACCESS';
-
+  const { namespace, name, selectedWorkspace, accessLevel: initialAccessLevel } = workspaceName;
   const [workspace, setWorkspace] = useState<Workspace>();
   const [loading, setLoading] = useState(true);
   const signal = useCancellation();
@@ -29,18 +26,18 @@ export const useWorkspaceDetails = (
       // Fetch workspace details if the user has read access
       return await Workspaces(signal).workspace(namespace, name).details(fields);
     }
-    // Fetch ACL and construct workspace object for users without read access
-    const wsAcls: Record<'acl', RawWorkspaceAcl> = await Workspaces(signal).workspace(namespace, name).getAcl();
-    const accessEntry = _.flow(
-      _.toPairs,
-      _.find(([key]: [string, RawAccessEntry]) => key === userEmail),
-      _.last
-    )(wsAcls.acl) as RawAccessEntry | undefined;
+    // Fetch Workspace User Resource Roles and construct workspace object for users without read access
+    const workspaceUserRoles: string[] = await SamResources(signal).getResourceRolesV2({
+      resourceTypeName: 'workspace',
+      resourceId: `${selectedWorkspace?.workspace?.workspaceId}`,
+    });
+    const isProjectOwner = workspaceUserRoles.includes('project-owner');
+    const isOwner = workspaceUserRoles.includes('owner');
 
     return {
-      accessLevel: accessEntry?.accessLevel ?? 'NO ACCESS',
-      canCompute: accessEntry?.canCompute ?? false,
-      canShare: accessEntry?.canShare ?? false,
+      accessLevel: isProjectOwner ? 'PROJECT_OWNER' : (isOwner && 'OWNER') || 'NO ACCESS',
+      canCompute: isProjectOwner || isOwner,
+      canShare: isProjectOwner || isOwner,
       policies: selectedWorkspace?.policies ?? [],
       workspace: {
         ...selectedWorkspace?.workspace,

--- a/src/workspaces/list/RenderedWorkspaces.tsx
+++ b/src/workspaces/list/RenderedWorkspaces.tsx
@@ -246,11 +246,11 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     workspace: { workspaceId, namespace, name, state },
   } = props.workspace;
   const { setUserActions } = useContext(WorkspaceUserActionsContext);
+  const {
+    profile: { contactEmail: userEmail },
+  } = useStore<TerraUserState>(userStore);
+  const loggedInUser = { userEmail, accessLevel };
 
-  if (!canRead(accessLevel)) {
-    // No menu shown if user does not have read access.
-    return <div className='sr-only'>You do not have permission to perform actions on this workspace.</div>;
-  }
   if (state === 'Deleted') {
     return null;
   }
@@ -297,7 +297,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
           iconSize={20}
           popupLocation='left'
           callbacks={{ onClone, onShare, onLock, onDelete, onLeave, onShowSettings }}
-          workspaceInfo={{ namespace, name }}
+          workspaceInfo={{ namespace, name, selectedWorkspace: props.workspace, loggedInUser }}
         />
       </div>
     </div>

--- a/src/workspaces/list/RenderedWorkspaces.tsx
+++ b/src/workspaces/list/RenderedWorkspaces.tsx
@@ -246,10 +246,6 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
     workspace: { workspaceId, namespace, name, state },
   } = props.workspace;
   const { setUserActions } = useContext(WorkspaceUserActionsContext);
-  const {
-    profile: { contactEmail: userEmail },
-  } = useStore<TerraUserState>(userStore);
-  const loggedInUser = { userEmail, accessLevel };
 
   if (state === 'Deleted') {
     return null;
@@ -297,7 +293,7 @@ const ActionsCell = (props: ActionsCellProps): ReactNode => {
           iconSize={20}
           popupLocation='left'
           callbacks={{ onClone, onShare, onLock, onDelete, onLeave, onShowSettings }}
-          workspaceInfo={{ namespace, name, selectedWorkspace: props.workspace, loggedInUser }}
+          workspaceInfo={{ namespace, name, selectedWorkspace: props.workspace, accessLevel }}
         />
       </div>
     </div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-448

### What
- This PR enables workspace owners or users with "can-share" permissions to manage workspaces via the UI, even without AuthDomain access, by adding the three-dot menu for actions like share, leave, and delete.

### Why
- Due to NIH security changes, users initially registered with free emails lost workspace access. This feature provides a UI solution to regain management access, consistent with existing patterns used elsewhere.

### Testing strategy
- Unit Testing
  - Added/Updated Unit Tests
- Manual Testing
  - Verified three-dot menu visibility for affected users.
  - I tested the workspace deletion functionality.
  - I tested the sharing functionality.


### Screens
**Before**
<img width="1769" alt="Before" src="https://github.com/user-attachments/assets/96382a32-6313-4539-abde-aa7b7a7c4637" />

**After**
<img width="1769" alt="After" src="https://github.com/user-attachments/assets/90c47f3c-cfec-4cd5-893f-277701303a86" />