### PR TITLE
[CORE-456] Update UI to Support UUID Workspace URL and Add Permalink Clipboard

### DIFF
--- a/.github/workflows/appengine-cleanup.yml
+++ b/.github/workflows/appengine-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
           service_account: 'appengine-cleanup-non-prod@bvdp-saturn-dev.iam.gserviceaccount.com'
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
       # Delete old AppEngine versions in each environment
       - run: ./scripts/delete-old-app-engine-versions.sh dev
       - run: ./scripts/delete-old-app-engine-versions.sh staging

--- a/.github/workflows/tag-publish.yaml
+++ b/.github/workflows/tag-publish.yaml
@@ -75,7 +75,7 @@ jobs:
 
       # Install gcloud, `setup-gcloud` automatically picks up authentication from `auth`.
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v0'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       # authenticate to GAR docker repo
       - name: Docker Login

--- a/src/pages/workspaces/DashboardAuthContainer.test.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.test.tsx
@@ -2,10 +2,13 @@ import { screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { FirecloudBucket, FirecloudBucketAjaxContract } from 'src/libs/ajax/firecloud/FirecloudBucket';
+import { Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { AuthState, authStore } from 'src/libs/state';
 import { DashboardAuthContainer } from 'src/pages/workspaces/DashboardAuthContainer';
 import { asMockedFn, MockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 import { WorkspaceDashboardPage, WorkspaceDashboardPageProps } from 'src/workspaces/dashboard/WorkspaceDashboardPage';
+
+jest.mock('src/libs/ajax/workspaces/Workspaces');
 
 jest.mock('src/libs/ajax/firecloud/FirecloudBucket');
 
@@ -122,6 +125,40 @@ describe('DashboardAuthContainer', () => {
     });
 
     // Assert
+    expect(mockDashboard).toHaveBeenCalled();
+    expect(screen.getByText('test-namespace test-name')).toBeInTheDocument();
+  });
+
+  it('renders WorkspaceDashboardPage with id parameter when signed in', async () => {
+    // Arrange
+    authStore.update((state: AuthState) => ({ ...state, signInStatus: 'userLoaded' }));
+
+    const mockDashboard = asMockedFn(WorkspaceDashboardPage);
+    mockDashboard.mockImplementation((props: WorkspaceDashboardPageProps) => (
+      <div>{`${props.namespace} ${props.name}`}</div>
+    ));
+
+    const mockGetById = jest.fn().mockResolvedValue({
+      workspace: { namespace: 'test-namespace', name: 'test-name' },
+    });
+
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        getById: mockGetById,
+      })
+    );
+
+    const getFeaturedWorkspaces: MockedFn<FirecloudBucketAjaxContract['getFeaturedWorkspaces']> = jest.fn();
+    getFeaturedWorkspaces.mockResolvedValue([]);
+    asMockedFn(FirecloudBucket).mockReturnValue(partial<FirecloudBucketAjaxContract>({ getFeaturedWorkspaces }));
+
+    // Act
+    await act(async () => {
+      render(<DashboardAuthContainer id='test-id' />);
+    });
+
+    // Assert
+    expect(mockGetById).toHaveBeenCalledWith('test-id', []);
     expect(mockDashboard).toHaveBeenCalled();
     expect(screen.getByText('test-namespace test-name')).toBeInTheDocument();
   });

--- a/src/pages/workspaces/DashboardAuthContainer.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.tsx
@@ -3,23 +3,43 @@ import _ from 'lodash/fp';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { centeredSpinner } from 'src/components/icons';
 import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
-import { useStore } from 'src/libs/react-utils';
+import { WorkspaceWrapper } from 'src/libs/ajax/workspaces/workspace-models';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
+import { useCancellation, useStore } from 'src/libs/react-utils';
 import { authStore } from 'src/libs/state';
 import SignIn from 'src/pages/SignIn';
 import DashboardPublic from 'src/pages/workspaces/DashboardPublic';
 import { WorkspaceDashboardPage } from 'src/workspaces/dashboard/WorkspaceDashboardPage';
 
-export interface DashboardAuthContainerProps {
+export interface DashboardAuthContainerNameProps {
   namespace: string;
   name: string;
 }
 
+export interface DashboardAuthContainerIdProps {
+  id: string;
+}
+
+export type DashboardAuthContainerProps = DashboardAuthContainerNameProps | DashboardAuthContainerIdProps;
+
+const getWorkspaceNamespaceAndName = async (
+  props: DashboardAuthContainerProps,
+  signal: AbortSignal
+): Promise<DashboardAuthContainerNameProps> => {
+  const { id } = props as DashboardAuthContainerIdProps;
+  const workspace: WorkspaceWrapper = await Workspaces(signal).getById(id, []);
+  return { namespace: workspace.workspace.namespace, name: workspace.workspace.name };
+};
+
 export const DashboardAuthContainer = (props: DashboardAuthContainerProps): ReactNode => {
-  const { namespace, name } = props;
+  const [namespace, setNamespace] = useState<string>('');
+  const [name, setName] = useState<string>('');
   const { signInStatus } = useStore(authStore);
   const [featuredWorkspaces, setFeaturedWorkspaces] = useState<{ name: string; namespace: string }[]>();
 
   const isAuthInitialized = signInStatus !== 'uninitialized';
+
+  const signal = useCancellation();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -30,6 +50,23 @@ export const DashboardAuthContainer = (props: DashboardAuthContainerProps): Reac
     }
   }, [signInStatus]);
 
+  useEffect(() => {
+    const fetchNamespaceAndName = async () => {
+      if (signInStatus === 'userLoaded') {
+        const { namespace, name } = await getWorkspaceNamespaceAndName(props, signal);
+        setNamespace(namespace);
+        setName(name);
+        document.title = `${name} - Dashboard`;
+      }
+    };
+    if ('namespace' in props && 'name' in props) {
+      setNamespace(props.namespace);
+      setName(props.name);
+    } else {
+      fetchNamespaceAndName();
+    }
+  }, [props, signal, signInStatus]);
+
   const isFeaturedWorkspace = () => _.some((ws) => ws.namespace === namespace && ws.name === name, featuredWorkspaces);
 
   return cond(
@@ -39,6 +76,6 @@ export const DashboardAuthContainer = (props: DashboardAuthContainerProps): Reac
     ],
     [signInStatus === 'signedOut' && isFeaturedWorkspace(), () => <DashboardPublic {...{ name, namespace }} />],
     [signInStatus === 'signedOut', () => <SignIn />],
-    [DEFAULT, () => <WorkspaceDashboardPage {...{ name, namespace }} />]
+    [DEFAULT, () => namespace && name && <WorkspaceDashboardPage {...{ name, namespace }} />]
   );
 };

--- a/src/pages/workspaces/WorkspaceDashboard.test.ts
+++ b/src/pages/workspaces/WorkspaceDashboard.test.ts
@@ -1,0 +1,27 @@
+import { navPaths } from 'src/pages/workspaces/WorkspaceDashboard';
+
+describe('navPaths', () => {
+  it('should define the correct paths and configurations', () => {
+    expect(navPaths).toEqual([
+      {
+        path: '/workspaces/:namespace/:name',
+        title: expect.any(Function),
+        name: 'workspace-dashboard',
+        component: expect.any(Function),
+        public: true,
+      },
+      {
+        path: '/workspaces/:id',
+        title: '',
+        name: 'workspace-dashboard',
+        component: expect.any(Function),
+        public: true,
+      },
+    ]);
+  });
+
+  it('should generate the correct title for the first path', () => {
+    const titleFunction = navPaths[0].title as (params: { name: string }) => string;
+    expect(titleFunction({ name: 'TestWorkspace' })).toBe('TestWorkspace - Dashboard');
+  });
+});

--- a/src/pages/workspaces/WorkspaceDashboard.ts
+++ b/src/pages/workspaces/WorkspaceDashboard.ts
@@ -1,11 +1,19 @@
 import { DashboardAuthContainer } from 'src/pages/workspaces/DashboardAuthContainer';
 
+const workspacePathConfig = {
+  name: 'workspace-dashboard',
+  component: DashboardAuthContainer,
+  public: true,
+};
+
 export const navPaths = [
   {
-    name: 'workspace-dashboard',
     path: '/workspaces/:namespace/:name',
-    component: DashboardAuthContainer,
     title: ({ name }) => `${name} - Dashboard`,
-    public: true,
+    ...workspacePathConfig,
+  },
+  {
+    path: '/workspaces/:id',
+    ...workspacePathConfig,
   },
 ];

--- a/src/pages/workspaces/WorkspaceDashboard.ts
+++ b/src/pages/workspaces/WorkspaceDashboard.ts
@@ -14,6 +14,7 @@ export const navPaths = [
   },
   {
     path: '/workspaces/:id',
+    title: '',
     ...workspacePathConfig,
   },
 ];

--- a/src/workspaces/dashboard/InfoRow.ts
+++ b/src/workspaces/dashboard/InfoRow.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import { dd, div, dt } from 'react-hyperscript-helpers';
 
 interface InfoRowProps {
-  title: string;
+  title: string | ReactNode;
   subtitle?: string;
   children?: ReactNode;
 }

--- a/src/workspaces/dashboard/WorkspaceDashboard.test.tsx
+++ b/src/workspaces/dashboard/WorkspaceDashboard.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { navPaths } from 'src/pages/workspaces/WorkspaceDashboard';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleBucketOptions, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/workspaces/common/state/useWorkspace';
@@ -83,30 +82,5 @@ describe('WorkspaceDashboard', () => {
     // Assert
     expect(screen.getByText('Last Updated')).toBeInTheDocument();
     expect(screen.getByText('Creation Date')).toBeInTheDocument();
-  });
-});
-
-describe('navPaths', () => {
-  it('should define the correct paths and configurations', () => {
-    expect(navPaths).toEqual([
-      {
-        path: '/workspaces/:namespace/:name',
-        title: expect.any(Function),
-        name: 'workspace-dashboard',
-        component: expect.any(Function),
-        public: true,
-      },
-      {
-        path: '/workspaces/:id',
-        name: 'workspace-dashboard',
-        component: expect.any(Function),
-        public: true,
-      },
-    ]);
-  });
-
-  it('should generate the correct title for the first path', () => {
-    const titleFunction = navPaths[0].title;
-    expect(titleFunction({ name: 'TestWorkspace' })).toBe('TestWorkspace - Dashboard');
   });
 });

--- a/src/workspaces/dashboard/WorkspaceDashboard.test.tsx
+++ b/src/workspaces/dashboard/WorkspaceDashboard.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
+import { navPaths } from 'src/pages/workspaces/WorkspaceDashboard';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 import { defaultGoogleBucketOptions, defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
 import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/workspaces/common/state/useWorkspace';
@@ -82,5 +83,30 @@ describe('WorkspaceDashboard', () => {
     // Assert
     expect(screen.getByText('Last Updated')).toBeInTheDocument();
     expect(screen.getByText('Creation Date')).toBeInTheDocument();
+  });
+});
+
+describe('navPaths', () => {
+  it('should define the correct paths and configurations', () => {
+    expect(navPaths).toEqual([
+      {
+        path: '/workspaces/:namespace/:name',
+        title: expect.any(Function),
+        name: 'workspace-dashboard',
+        component: expect.any(Function),
+        public: true,
+      },
+      {
+        path: '/workspaces/:id',
+        name: 'workspace-dashboard',
+        component: expect.any(Function),
+        public: true,
+      },
+    ]);
+  });
+
+  it('should generate the correct title for the first path', () => {
+    const titleFunction = navPaths[0].title;
+    expect(titleFunction({ name: 'TestWorkspace' })).toBe('TestWorkspace - Dashboard');
   });
 });

--- a/src/workspaces/dashboard/WorkspaceInformation.test.ts
+++ b/src/workspaces/dashboard/WorkspaceInformation.test.ts
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as clipboard from 'clipboard-polyfill/text';
 import { axe } from 'jest-axe';
 import { h } from 'react-hyperscript-helpers';
 import { azureRegions } from 'src/libs/azure-regions';
@@ -16,7 +17,20 @@ import { WorkspacePolicy } from 'src/workspaces/utils';
 
 jest.mock('src/libs/notifications');
 
+type ClipboardPolyfillExports = typeof import('clipboard-polyfill/text');
+jest.mock('clipboard-polyfill/text', (): ClipboardPolyfillExports => {
+  const actual = jest.requireActual<ClipboardPolyfillExports>('clipboard-polyfill/text');
+  return {
+    ...actual,
+    writeText: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
 describe('WorkspaceInformation', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('renders information for a non-protected workspace without region constraints and does not fail accessibility tests', async () => {
     // Act
     const { container } = render(
@@ -142,4 +156,38 @@ describe('WorkspaceInformation', () => {
       }
     }
   );
+
+  it('renders the permalink to the workspace', async () => {
+    // Act
+    const { container } = render(
+      h(WorkspaceInformation, { workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true } })
+    );
+
+    // Assert
+    const permalinkButton = screen.getByLabelText('Copy Permalink to this workspace to clipboard');
+    expect(permalinkButton).toBeInTheDocument();
+
+    // Accessibility
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('copies the correct permalink to the clipboard', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const { container } = render(
+      h(WorkspaceInformation, { workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true } })
+    );
+
+    // Act
+    const permalinkButton = screen.getByLabelText('Copy Permalink to this workspace to clipboard');
+    await user.click(permalinkButton);
+
+    // Assert
+    expect(clipboard.writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/#workspaces/${defaultGoogleWorkspace.workspace.workspaceId}`
+    );
+
+    // Accessibility
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });

--- a/src/workspaces/dashboard/WorkspaceInformation.ts
+++ b/src/workspaces/dashboard/WorkspaceInformation.ts
@@ -1,4 +1,4 @@
-import { icon, InfoBox, Link } from '@terra-ui-packages/components';
+import { InfoBox, Link } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode } from 'react';
 import { dl, h } from 'react-hyperscript-helpers';
@@ -37,15 +37,8 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
         ]
       );
     }, policyDescriptions),
-    h(
-      InfoRow,
-      {
-        title: h(Link, { href: workspaceUrl }, [
-          'Permalink to this workspace',
-          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
-        ]),
-      },
-      [h(ClipboardButton, { 'aria-label': 'Copy Permalink to this workspace to clipboard', text: workspaceUrl })]
-    ),
+    h(InfoRow, { title: h(Link, { href: workspaceUrl }, ['Permalink to this workspace']) }, [
+      h(ClipboardButton, { 'aria-label': 'Copy Permalink to this workspace to clipboard', text: workspaceUrl }),
+    ]),
   ]);
 };

--- a/src/workspaces/dashboard/WorkspaceInformation.ts
+++ b/src/workspaces/dashboard/WorkspaceInformation.ts
@@ -1,4 +1,4 @@
-import { InfoBox } from '@terra-ui-packages/components';
+import { icon, InfoBox, Link } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode } from 'react';
 import { dl, h } from 'react-hyperscript-helpers';
@@ -20,6 +20,7 @@ interface WorkspaceInformationProps {
 export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNode => {
   const { workspace } = props;
   const policyDescriptions = getPolicyDescriptions(workspace);
+  const workspaceUrl = `${window.location.origin}/#workspaces/${workspace.workspace.workspaceId}`;
 
   return dl([
     h(InfoRow, { title: 'Last Updated' }, [new Date(workspace.workspace.lastModified).toLocaleDateString()]),
@@ -36,12 +37,15 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
         ]
       );
     }, policyDescriptions),
-    h(InfoRow, { title: 'Permalink to this workspace' }, [
-      h(ClipboardButton, {
-        'aria-label': 'Copy Permalink to this workspace to clipboard',
-        text: `${window.location.origin}/#workspaces/${workspace.workspace.workspaceId}`,
-        style: { marginLeft: '0.25rem' },
-      }),
-    ]),
+    h(
+      InfoRow,
+      {
+        title: h(Link, { href: workspaceUrl }, [
+          'Permalink to this workspace',
+          icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
+        ]),
+      },
+      [h(ClipboardButton, { 'aria-label': 'Copy Permalink to this workspace to clipboard', text: workspaceUrl })]
+    ),
   ]);
 };

--- a/src/workspaces/dashboard/WorkspaceInformation.ts
+++ b/src/workspaces/dashboard/WorkspaceInformation.ts
@@ -2,6 +2,7 @@ import { InfoBox } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import { ReactNode } from 'react';
 import { dl, h } from 'react-hyperscript-helpers';
+import { ClipboardButton } from 'src/components/ClipboardButton';
 import { InitializedWorkspaceWrapper as Workspace } from 'src/workspaces/common/state/useWorkspace';
 import { InfoRow } from 'src/workspaces/dashboard/InfoRow';
 import { getPolicyDescriptions } from 'src/workspaces/utils';
@@ -35,5 +36,12 @@ export const WorkspaceInformation = (props: WorkspaceInformationProps): ReactNod
         ]
       );
     }, policyDescriptions),
+    h(InfoRow, { title: 'Permalink to this workspace' }, [
+      h(ClipboardButton, {
+        'aria-label': 'Copy Permalink to this workspace to clipboard',
+        text: `${window.location.origin}/#workspaces/${workspace.workspace.workspaceId}`,
+        style: { marginLeft: '0.25rem' },
+      }),
+    ]),
   ]);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-456

### What
- This PR updates the Terra UI to allow users to access a workspace using either the UUID-based URL `{terra_base_url}/{workspace_UUID}` or the original namespace-based URL `{terra_base_url}/{workspace_namespace}/{workspace_name}`. It also adds a `Permalink to this workspace` button on the workspace dashboard to copy the UUID URL.

### Why
- The update lets users change the billing project while still accessing the workspace via both the old namespace URL and the new UUID URL, improving flexibility and ease of sharing.

### Testing strategy
- Unit Testing: Added and Updated Unit Tests
- Manual Testing:
  - Confirmed that both URL formats work for accessing the workspace.
  - Ensured the “Permalink” button copies the correct UUID URL

### Screens
![Screenshot 2025-04-17 at 2 34 40 PM](https://github.com/user-attachments/assets/6f84d7bd-cd31-4a6e-a443-a079343e0db2)

