### PR TITLE
[CORE-477] Handle Invalid or Inaccessible UUIDs for Linking to Terra Workspace

### DIFF
--- a/src/pages/workspaces/DashboardAuthContainer.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.tsx
@@ -30,8 +30,7 @@ const getWorkspaceNamespaceAndName = async (
     const { id } = props as DashboardAuthContainerIdProps;
     const workspace: WorkspaceWrapper = await Workspaces(signal).getById(id, []);
     return { namespace: workspace.workspace.namespace, name: workspace.workspace.name };
-  } catch (error) {
-    console.error('Error fetching workspace namespace and name:', error);
+  } catch {
     return { namespace: ' ', name: ' ' };
   }
 };

--- a/src/pages/workspaces/DashboardAuthContainer.tsx
+++ b/src/pages/workspaces/DashboardAuthContainer.tsx
@@ -26,9 +26,14 @@ const getWorkspaceNamespaceAndName = async (
   props: DashboardAuthContainerProps,
   signal: AbortSignal
 ): Promise<DashboardAuthContainerNameProps> => {
-  const { id } = props as DashboardAuthContainerIdProps;
-  const workspace: WorkspaceWrapper = await Workspaces(signal).getById(id, []);
-  return { namespace: workspace.workspace.namespace, name: workspace.workspace.name };
+  try {
+    const { id } = props as DashboardAuthContainerIdProps;
+    const workspace: WorkspaceWrapper = await Workspaces(signal).getById(id, []);
+    return { namespace: workspace.workspace.namespace, name: workspace.workspace.name };
+  } catch (error) {
+    console.error('Error fetching workspace namespace and name:', error);
+    return { namespace: ' ', name: ' ' };
+  }
 };
 
 export const DashboardAuthContainer = (props: DashboardAuthContainerProps): ReactNode => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-477

### What
- This PR adds error handling for invalid or inaccessible UUIDs when linking to a Terra workspace. Instead of a blank page, users will now see the standard page: "You cannot access this workspace because it either does not exist or you do not have access to it."

### Why
- To improve user experience by providing a clear error message when an invalid or inaccessible UUID is used, instead of showing a blank page.

### Testing strategy
- Manual Testing: Verified that invalid workspaceId redirect to "Cannot display workspace" Page

### Screens
<img width="1787" alt="After" src="https://github.com/user-attachments/assets/6bd935af-d4c7-4cce-bbc8-d073ed9ba036" />

