### PR TITLE
[AN-520] Reflects Batch as default backend in Dev and BEEs

### DIFF
--- a/src/workspaces/SettingsModal/SettingsModal.test.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.test.tsx
@@ -7,6 +7,7 @@ import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
 import { SamResources, SamResourcesContract } from 'src/libs/ajax/SamResources';
 import { SeparateSubmissionFinalOutputsSetting } from 'src/libs/ajax/workspaces/workspace-models';
 import { Workspaces, WorkspacesAjaxContract, WorkspaceV2Contract } from 'src/libs/ajax/workspaces/Workspaces';
+import { AppConfigSettings, getConfig } from 'src/libs/config';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { asMockedFn, partial, renderWithAppContexts as render, SelectHelper } from 'src/testing/test-utils';
 import { defaultGoogleWorkspace, makeGoogleWorkspace } from 'src/testing/workspace-fixtures';
@@ -43,6 +44,11 @@ jest.mock('src/libs/ajax/SamResources', () => ({
 jest.mock('src/workspaces/utils', () => ({
   ...jest.requireActual('src/workspaces/utils'),
   isOwner: jest.fn(),
+}));
+
+jest.mock('src/libs/config', () => ({
+  ...jest.requireActual('src/libs/config'),
+  getConfig: jest.fn().mockReturnValue({}),
 }));
 
 describe('SettingsModal', () => {
@@ -164,6 +170,8 @@ describe('SettingsModal', () => {
       })
     );
     asMockedFn(isWorkspaceOwner).mockReturnValue(true);
+
+    asMockedFn(getConfig).mockReturnValue(partial<AppConfigSettings>({ isProd: true }));
   };
 
   const mockNotOwner = () => {
@@ -174,6 +182,12 @@ describe('SettingsModal', () => {
     );
     asMockedFn(isWorkspaceOwner).mockReturnValue(false);
   };
+
+  const mockNonProd = () => {
+    asMockedFn(getConfig).mockReturnValue(partial<AppConfigSettings>({ isProd: false }));
+  };
+
+  const getBatchToggle = () => screen.getByLabelText('Run Workflows on GCP Batch:');
 
   it('has no accessibility errors', async () => {
     // Arrange
@@ -202,9 +216,8 @@ describe('SettingsModal', () => {
 
     // Assert
     expect(onDismiss).toHaveBeenCalled();
-    expect(captureEvent).not.toHaveBeenCalled();
-    // On save we do persist the default soft delete setting so it is now explicit.
-    expect(updateSettingsMock).toHaveBeenCalledWith([defaultSoftDeleteSetting]);
+    // On save we do persist the default soft delete setting and Batch setting, so it is now explicit.
+    expect(updateSettingsMock).toHaveBeenCalledWith([batchDisabledSetting, defaultSoftDeleteSetting]);
   });
 
   it('calls onDismiss on Cancel and does not event', async () => {
@@ -381,7 +394,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([fourDaysAllObjects], updateSettingsMock);
+      setup([fourDaysAllObjects, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -402,6 +415,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         defaultSoftDeleteSetting,
         separateSubmissionOutputsDisabledSetting,
         noLifecycleRules,
@@ -418,7 +432,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([twoRules], updateSettingsMock);
+      setup([twoRules, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -439,6 +453,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         defaultSoftDeleteSetting,
         separateSubmissionOutputsDisabledSetting,
         {
@@ -470,7 +485,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([twoRules], updateSettingsMock);
+      setup([twoRules, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -486,6 +501,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         defaultSoftDeleteSetting,
         separateSubmissionOutputsEnabledSetting,
         {
@@ -526,7 +542,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([zeroDaysTwoPrefixes], updateSettingsMock);
+      setup([zeroDaysTwoPrefixes, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -541,6 +557,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         defaultSoftDeleteSetting,
         separateSubmissionOutputsEnabledSetting,
         {
@@ -572,7 +589,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([fourDaysAllObjects], updateSettingsMock);
+      setup([fourDaysAllObjects, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -599,6 +616,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         defaultSoftDeleteSetting,
         separateSubmissionOutputsEnabledSetting,
         {
@@ -704,7 +722,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([defaultSoftDeleteSetting], updateSettingsMock);
+      setup([defaultSoftDeleteSetting, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -720,6 +738,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         {
           settingType: 'GcpBucketSoftDelete',
           config: { retentionDurationInSeconds: 80 * secondsInADay },
@@ -736,7 +755,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([defaultSoftDeleteSetting], updateSettingsMock);
+      setup([defaultSoftDeleteSetting, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -750,6 +769,7 @@ describe('SettingsModal', () => {
 
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
         {
           settingType: 'GcpBucketSoftDelete',
           config: { retentionDurationInSeconds: 0 },
@@ -766,7 +786,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([defaultSoftDeleteSetting], updateSettingsMock);
+      setup([defaultSoftDeleteSetting, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -775,7 +795,7 @@ describe('SettingsModal', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       // Assert
-      expect(updateSettingsMock).toHaveBeenCalledWith([defaultSoftDeleteSetting]);
+      expect(updateSettingsMock).toHaveBeenCalledWith([batchDisabledSetting, defaultSoftDeleteSetting]);
       // An above case captures testing that there is no event if Save is pressed and the user initially
       // had no soft delete setting (although the default setting is then persisted).
       expect(captureEvent).not.toHaveBeenCalledWith();
@@ -843,7 +863,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([requesterPaysEnabledSetting], updateSettingsMock);
+      setup([requesterPaysEnabledSetting, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -858,7 +878,11 @@ describe('SettingsModal', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       // Assert
-      expect(updateSettingsMock).toHaveBeenCalledWith([requesterPaysDisabledSetting, defaultSoftDeleteSetting]);
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
+        requesterPaysDisabledSetting,
+        defaultSoftDeleteSetting,
+      ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsRequesterPays, {
         enabled: false,
         ...extractWorkspaceDetails(defaultGoogleWorkspace),
@@ -884,7 +908,11 @@ describe('SettingsModal', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       // Assert
-      expect(updateSettingsMock).toHaveBeenCalledWith([requesterPaysEnabledSetting, defaultSoftDeleteSetting]);
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
+        requesterPaysEnabledSetting,
+        defaultSoftDeleteSetting,
+      ]);
       expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsRequesterPays, {
         enabled: true,
         ...extractWorkspaceDetails(defaultGoogleWorkspace),
@@ -895,7 +923,7 @@ describe('SettingsModal', () => {
       // Arrange
       const user = userEvent.setup();
       const updateSettingsMock = jest.fn();
-      setup([requesterPaysEnabledSetting], updateSettingsMock);
+      setup([requesterPaysEnabledSetting, batchDisabledSetting], updateSettingsMock);
 
       // Act
       await act(async () => {
@@ -904,14 +932,16 @@ describe('SettingsModal', () => {
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
       // Assert
-      expect(updateSettingsMock).toHaveBeenCalledWith([requesterPaysEnabledSetting, defaultSoftDeleteSetting]);
+      expect(updateSettingsMock).toHaveBeenCalledWith([
+        batchDisabledSetting,
+        requesterPaysEnabledSetting,
+        defaultSoftDeleteSetting,
+      ]);
       expect(captureEvent).not.toHaveBeenCalledWith();
     });
   });
 
-  describe('Batch Setting', () => {
-    const getBatchToggle = () => screen.getByLabelText('Run Workflows on GCP Batch:');
-
+  describe('Batch Setting (prod environment)', () => {
     it('renders the option as disabled if the user is not an owner', async () => {
       // Arrange
       setup([], jest.fn());
@@ -929,7 +959,6 @@ describe('SettingsModal', () => {
     it('renders the option as off if no settings exist', async () => {
       // Arrange
       setup([], jest.fn());
-      mockNotOwner();
 
       // Act
       await act(async () => {
@@ -1033,6 +1062,80 @@ describe('SettingsModal', () => {
       // Assert
       expect(updateSettingsMock).toHaveBeenCalledWith([batchEnabledSetting, defaultSoftDeleteSetting]);
       expect(captureEvent).not.toHaveBeenCalledWith();
+    });
+
+    it('saves default batch setting if no such setting previously existed', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([], updateSettingsMock);
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([batchDisabledSetting, defaultSoftDeleteSetting]);
+      expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBatch, {
+        enabled: false,
+        ...extractWorkspaceDetails(defaultGoogleWorkspace),
+      });
+    });
+  });
+
+  describe('Batch Setting (non-prod environment)', () => {
+    it('renders the option as disabled if the user is not an owner', async () => {
+      // Arrange
+      setup([], jest.fn());
+      mockNotOwner();
+      mockNonProd();
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={makeGoogleWorkspace({ accessLevel: 'READER' })} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getBatchToggle()).toBeDisabled();
+    });
+
+    it('renders the option as on if no settings exist', async () => {
+      // Arrange
+      setup([], jest.fn());
+      mockNonProd();
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      // Assert
+      expect(getBatchToggle()).toBeChecked();
+    });
+
+    it('saves default batch setting if no such setting previously existed', async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const updateSettingsMock = jest.fn();
+      setup([], updateSettingsMock);
+      mockNonProd();
+
+      // Act
+      await act(async () => {
+        render(<SettingsModal workspace={defaultGoogleWorkspace} onDismiss={jest.fn()} />);
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Assert
+      expect(updateSettingsMock).toHaveBeenCalledWith([batchEnabledSetting, defaultSoftDeleteSetting]);
+      expect(captureEvent).toHaveBeenCalledWith(Events.workspaceSettingsBatch, {
+        enabled: true,
+        ...extractWorkspaceDetails(defaultGoogleWorkspace),
+      });
     });
   });
 });

--- a/src/workspaces/SettingsModal/SettingsModal.tsx
+++ b/src/workspaces/SettingsModal/SettingsModal.tsx
@@ -5,6 +5,7 @@ import { Metrics } from 'src/libs/ajax/Metrics';
 import { SamResources } from 'src/libs/ajax/SamResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors from 'src/libs/colors';
+import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
@@ -65,6 +66,9 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
   const [busy, setBusy] = useState(true);
 
   const signal = useCancellation();
+
+  // GCP Batch is default backend in BEEs and Dev environment. Note: 'isProd' is true for both staging and prod
+  const isBatchDefaultBackend = !getConfig().isProd;
 
   // Check if the user has owner access to the workspace
   useEffect(() => {
@@ -179,12 +183,12 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
       setRequesterPaysEnabled(requesterPaysEnabled);
 
       const batchSetting = getBatchSetting(settings);
-      const batchEnabled = batchSetting === undefined ? false : batchSetting.config.enabled;
+      const batchEnabled = batchSetting === undefined ? isBatchDefaultBackend : batchSetting.config.enabled;
       setBatchEnabled(batchEnabled);
     });
 
     loadSettings();
-  }, [namespace, name, signal]);
+  }, [namespace, name, signal, isBatchDefaultBackend]);
 
   const persistSettings = _.flow(
     Utils.withBusyState(setBusy),
@@ -265,13 +269,11 @@ const SettingsModal = (props: SettingsModalProps): ReactNode => {
       });
     }
 
-    // Event about batch setting only if something actually changed.
+    // Event about batch setting only if it changed
     const originalBatchSetting = getBatchSetting(workspaceSettings || []);
     const newBatchSetting = getBatchSetting(newSettings);
-    if (originalBatchSetting === undefined && !newBatchSetting?.config.enabled) {
-      // If the bucket had no batch setting before, and the current one is disabled, don't event.
-    } else if (!_.isEqual(originalBatchSetting, newBatchSetting)) {
-      // Event if the setting changed.
+    if (!_.isEqual(originalBatchSetting, newBatchSetting)) {
+      // Event if the setting changed
       void Metrics().captureEvent(Events.workspaceSettingsBatch, {
         enabled: batchEnabled,
         ...extractWorkspaceDetails(props.workspace),

--- a/src/workspaces/SettingsModal/utils.test.ts
+++ b/src/workspaces/SettingsModal/utils.test.ts
@@ -1,5 +1,6 @@
 import {
   BucketLifecycleSetting,
+  modifyBatchSetting,
   modifyFirstBucketDeletionRule,
   modifyFirstSoftDeleteSetting,
   removeFirstBucketDeletionRule,
@@ -499,6 +500,46 @@ describe('modifyFirstSoftDeleteSetting', () => {
       },
       {
         settingType: 'OtherSetting', // Algorithm concats other settings at the end
+      },
+    ]);
+  });
+});
+
+describe('modifyBatchSetting', () => {
+  it('adds Batch setting if one did not exist', async () => {
+    // Act
+    const result = modifyBatchSetting([], false);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'UseCromwellGcpBatchBackend',
+        config: { enabled: false },
+      },
+    ]);
+  });
+
+  it('modifies Batch setting', async () => {
+    // Arrange
+    const originalSettings: WorkspaceSetting[] = [
+      otherSetting,
+      {
+        settingType: 'UseCromwellGcpBatchBackend',
+        config: { enabled: false },
+      },
+    ];
+
+    // Act
+    const result = modifyBatchSetting(originalSettings, true);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        settingType: 'UseCromwellGcpBatchBackend',
+        config: { enabled: true },
+      },
+      {
+        settingType: 'OtherSetting', // function appends other settings at the end
       },
     ]);
   });

--- a/src/workspaces/SettingsModal/utils.ts
+++ b/src/workspaces/SettingsModal/utils.ts
@@ -245,24 +245,14 @@ const modifySeparateSubmissionOutputsSetting = (
 };
 
 /**
- * Modifies the batch setting in the workspace settings.
- * If no such setting exists and batch is set to enabled, it will be created.
+ * Modifies the Batch setting in the workspace settings. If no such setting exists, it will be created.
  *
  * Note that any other settings will be preserved but moved to the end of the array.
  */
 export const modifyBatchSetting = (originalSettings: WorkspaceSetting[], enabled: boolean): WorkspaceSetting[] => {
-  // Clone original for testing purposes and to allow eventing only if there was a change.
-  const workspaceSettings = _.cloneDeep(originalSettings);
+  const otherSettings: WorkspaceSetting[] = originalSettings.filter((setting) => !isBatchSetting(setting));
 
-  const batchSettings: BatchSetting[] = workspaceSettings.filter((setting: WorkspaceSetting) =>
-    isBatchSetting(setting)
-  ) as BatchSetting[];
-  const otherSettings: WorkspaceSetting[] = workspaceSettings.filter((setting) => !isBatchSetting(setting));
-
-  // If no batchSetting existed and batch is set to disabled, do nothing
-  if (batchSettings.length === 0 && !enabled) {
-    return workspaceSettings;
-  }
+  // Save the current Batch setting preference. Rawls will handle it appropriately if there's no change in the setting.
   return _.concat(
     [
       {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-520

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Reflects Batch as default backend in Workspace settings for Dev and BEEs 

### Why
- Batch migration

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] manual testing
- [x] unit tests

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
