### PR TITLE
[CORE-478] Make Workflow Cost Thresholds Feature Generally Available

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -1,8 +1,6 @@
 export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp';
 export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const COHORT_BUILDER_CARD = 'cohortBuilderCard';
-export const PREVIEW_COST_CAPPING = 'previewCostCapping';
-export const ENHANCED_WORKSPACE_CREATION = 'enhancedWorkspaceCreation';
 export const SAGE_ACCOUNT_LINKING = 'sageAccountLinking';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
@@ -66,14 +64,6 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Cohort Builder Card'
     )}`,
     lastUpdated: '7/25/2024',
-  },
-  {
-    id: PREVIEW_COST_CAPPING,
-    title: 'Workflow Cost Thresholds',
-    description:
-      'Enabling this feature will show a new workflow configuration option to add a user-configurable cost threshold to the workflow. Workflows will be terminated once they exceed the configured value.',
-    feedbackUrl: 'https://support.terra.bio/hc/en-us/articles/31269696049307',
-    lastUpdated: '2/28/2025',
   },
   {
     id: SAGE_ACCOUNT_LINKING,

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -28,8 +28,6 @@ import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { PREVIEW_COST_CAPPING } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 import { forwardRefWithName, useCancellation } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
@@ -118,11 +116,10 @@ export const SubmissionWorkflowsTable = ({ workspace, submission }) => {
         }),
       ]),
       h(Link, { onClick: () => downloadWorkflows(filteredWorkflows, submissionId) }, ['Download TSV']),
-      isFeaturePreviewEnabled(PREVIEW_COST_CAPPING) &&
-        div({ style: { marginLeft: 'auto' } }, [
-          b({}, ['Per Workflow Cost Threshold: ']),
-          perWorkflowCostCap ? Utils.formatUSD(perWorkflowCostCap) : 'N/A',
-        ]),
+      div({ style: { marginLeft: 'auto' } }, [
+        b({}, ['Per Workflow Cost Threshold: ']),
+        perWorkflowCostCap ? Utils.formatUSD(perWorkflowCostCap) : 'N/A',
+      ]),
     ]),
     // 48px is based on the default row height of FlexTable
     div({ style: { flex: `1 0 ${(1 + _.min([filteredWorkflows.length, 5.5])) * tableRowHeight}px` } }, [

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.test.tsx
@@ -1,8 +1,7 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { navPaths, SubmissionWorkflowsTable } from 'src/pages/workspaces/workspace/submissionHistory/SubmissionDetails';
-import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
+import { renderWithAppContexts } from 'src/testing/test-utils';
 
 type NavExports = typeof import('src/libs/nav');
 jest.mock(
@@ -90,25 +89,11 @@ describe('Cost Threshold', () => {
     validOutputs: ['echo_strings.echo_to_file.out'],
   };
 
-  test('should render the Cost Threshold when enabled', () => {
-    // Arrange
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
-
-    // Act
+  test('should render the Cost Threshold', () => {
+    // Arrange & Act
     renderWithAppContexts(<SubmissionWorkflowsTable workspace={testGoogleWorkspace} submission={testSubmission} />);
 
     // Assert
     expect(screen.getByText('Per Workflow Cost Threshold:')).toBeInTheDocument();
-  });
-
-  test('should not render the Cost Threshold when disabled', () => {
-    // Arrange
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
-
-    // Act
-    renderWithAppContexts(<SubmissionWorkflowsTable workspace={testGoogleWorkspace} submission={testSubmission} />);
-
-    // Assert
-    expect(screen.queryByText('Per Workflow Cost Threshold:')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -11,8 +11,6 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { launch } from 'src/libs/analysis';
 import colors from 'src/libs/colors';
 import { withErrorReporting } from 'src/libs/error';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { PREVIEW_COST_CAPPING } from 'src/libs/feature-previews-config';
 import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { warningBoxStyle } from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -201,16 +199,15 @@ const LaunchAnalysisModal = ({
       div({ style: { marginTop: '0.25rem' } }, [
         ul({ style: { paddingLeft: '1.5rem' } }, [
           li([`You are launching ${entityCount} workflow `, entityCount === 1 ? 'run' : 'runs', ' in this submission.']),
-          isFeaturePreviewEnabled(PREVIEW_COST_CAPPING) &&
-            (perWorkflowCostCap !== ''
-              ? li([
-                  `You set a cost threshold of ${Utils.formatUSD(perWorkflowCostCap)} per workflow run`,
-                  h('br'),
-                  `x ${entityCount} workflow runs = ${Utils.formatUSD(entityCount * perWorkflowCostCap)}`,
-                  b(' approximate maximum'),
-                  ' submission cost.',
-                ])
-              : li(['You did not set a cost threshold.'])),
+          perWorkflowCostCap !== ''
+            ? li([
+                `You set a cost threshold of ${Utils.formatUSD(perWorkflowCostCap)} per workflow run`,
+                h('br'),
+                `x ${entityCount} workflow runs = ${Utils.formatUSD(entityCount * perWorkflowCostCap)}`,
+                b(' approximate maximum'),
+                ' submission cost.',
+              ])
+            : li(['You did not set a cost threshold.']),
         ]),
       ]),
       h(IdContainer, [

--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.test.ts
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.test.ts
@@ -8,7 +8,6 @@ import {
   WorkspaceV2Contract,
 } from 'src/libs/ajax/workspaces/Workspaces';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { PREVIEW_COST_CAPPING } from 'src/libs/feature-previews-config';
 import { chooseRootType } from 'src/pages/workspaces/workspace/workflows/EntitySelectionType';
 import LaunchAnalysisModal from 'src/pages/workspaces/workspace/workflows/LaunchAnalysisModal';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -19,8 +18,6 @@ jest.mock('src/libs/feature-previews', () => ({
   ...jest.requireActual('src/libs/feature-previews'),
   isFeaturePreviewEnabled: jest.fn(),
 }));
-
-asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === PREVIEW_COST_CAPPING);
 
 describe('Launch Analysis Modal', () => {
   const mockDefaultAjax = () => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -35,8 +35,6 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors, { terraSpecial } from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { PREVIEW_COST_CAPPING } from 'src/libs/feature-previews-config';
 import { HiddenLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
@@ -999,54 +997,53 @@ export const WorkflowView = _.flow(
                   ]),
                 ]),
               ]),
-              isFeaturePreviewEnabled(PREVIEW_COST_CAPPING) &&
-                div(
-                  {
-                    style: {
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignSelf: 'flex-start',
-                      marginTop: '0.0rem',
-                      fontSize: 12,
-                    },
+              div(
+                {
+                  style: {
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignSelf: 'flex-start',
+                    marginTop: '0.0rem',
+                    fontSize: 12,
                   },
-                  [
-                    span([
-                      'Set cost threshold per workflow (BETA) ',
-                      h(InfoBox, { style: { marginLeft: '0.1rem', whiteSpace: 'pre-line' } }, [
-                        'Important considerations:',
-                        h('br'),
-                        '1. Costs are in USD.',
-                        h('br'),
-                        '2. Costs are VM and disk costs only. Bucket storage and egress costs are not included.',
-                        h('br'),
-                        '3. Based on GCP list prices. Discounts are not included.',
-                        h('br'),
-                        '4. GPU costs are not included.',
-                        h('br'),
-                        '5. Workflows may not terminate immediately upon hitting threshold, plan for a margin of error.',
-                        h('br'),
-                        '6. Workflow costs vary by input. Set a threshold that considers variability.',
-                      ]),
+                },
+                [
+                  span([
+                    'Set cost threshold per workflow',
+                    h(InfoBox, { style: { marginLeft: '0.1rem', whiteSpace: 'pre-line' } }, [
+                      'Important considerations:',
+                      h('br'),
+                      '1. Costs are in USD.',
+                      h('br'),
+                      '2. Costs are VM and disk costs only. Bucket storage and egress costs are not included.',
+                      h('br'),
+                      '3. Based on GCP list prices. Discounts are not included.',
+                      h('br'),
+                      '4. GPU costs are not included.',
+                      h('br'),
+                      '5. Workflows may not terminate immediately upon hitting threshold, plan for a margin of error.',
+                      h('br'),
+                      '6. Workflow costs vary by input. Set a threshold that considers variability.',
                     ]),
-                    div({ style: { display: 'flex', alignItems: 'center', marginLeft: '0rem', marginBottom: '0.5rem' } }, [
-                      span({ style: { marginRight: '0.5rem' } }, ['$']),
-                      h(NumberInput, {
-                        id: 'workflow-run-budget',
-                        value: perWorkflowCostCap || '',
-                        min: 0.01,
-                        max: 9999999999.99,
-                        placeholder: 'Example: 1.00',
-                        onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : '' }),
-                        style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
-                      }),
-                    ]),
-                    span([
-                      h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, ['Learn more']),
-                      ' about how Terra implements cost thresholds',
-                    ]),
-                  ]
-                ),
+                  ]),
+                  div({ style: { display: 'flex', alignItems: 'center', marginLeft: '0rem', marginBottom: '0.5rem' } }, [
+                    span({ style: { marginRight: '0.5rem' } }, ['$']),
+                    h(NumberInput, {
+                      id: 'workflow-run-budget',
+                      value: perWorkflowCostCap || '',
+                      min: 0.01,
+                      max: 9999999999.99,
+                      placeholder: 'Example: 1.00',
+                      onChange: (v) => this.setState({ perWorkflowCostCap: v ? v.toFixed(2) : '' }),
+                      style: { fontSize: 12, marginTop: '0.5rem', width: '100%', marginLeft: '0.1rem' },
+                    }),
+                  ]),
+                  span([
+                    h(Link, { href: this.getSupportLink('31269696049307'), ...Utils.newTabLinkProps }, ['Learn more']),
+                    ' about how Terra implements cost thresholds',
+                  ]),
+                ]
+              ),
               div({ style: { fontSize: 12, display: 'flex', alignItems: 'baseline', minWidth: 'max-content' } }, [
                 span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
                   div([

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -7,7 +7,6 @@ import { Runtimes } from 'src/libs/ajax/leonardo/Runtimes';
 import { Methods } from 'src/libs/ajax/methods/Methods';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { PREVIEW_COST_CAPPING } from 'src/libs/feature-previews-config';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
 import DataStepContent from 'src/pages/workspaces/workspace/workflows/DataStepContent';
 import { chooseRootType } from 'src/pages/workspaces/workspace/workflows/EntitySelectionType';
@@ -658,8 +657,6 @@ describe('Workflow View (GCP)', () => {
     );
   });
 
-  asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === PREVIEW_COST_CAPPING);
-
   it('does not show cost capping input if the feature flag is disabled', async () => {
     // Arrange
     asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
@@ -676,7 +673,7 @@ describe('Workflow View (GCP)', () => {
 
     // Assert
     // check that workflow cost capping is not shown
-    expect(screen.queryByText('Set cost threshold per workflow (BETA)')).toBeNull();
+    expect(screen.queryByText('Set cost threshold per workflow')).toBeNull();
   });
 
   it('does show cost capping input if the feature flag is enabled', async () => {
@@ -695,7 +692,7 @@ describe('Workflow View (GCP)', () => {
 
     // Assert
     // check that workflow cost capping is shown
-    expect(screen.queryByText('Set cost threshold per workflow (BETA)')).not.toBeNull();
+    expect(screen.queryByText('Set cost threshold per workflow')).not.toBeNull();
   });
 
   it('updates perWorkflowCostCap state on input change', async () => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -657,29 +657,8 @@ describe('Workflow View (GCP)', () => {
     );
   });
 
-  it('does not show cost capping input if the feature flag is disabled', async () => {
+  it('does show cost capping input', async () => {
     // Arrange
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
-
-    const namespace = 'gatk';
-    const name = 'echo_to_file-configured';
-
-    mockDefaultAjax();
-
-    // Act
-    await act(async () => {
-      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
-    });
-
-    // Assert
-    // check that workflow cost capping is not shown
-    expect(screen.queryByText('Set cost threshold per workflow')).toBeNull();
-  });
-
-  it('does show cost capping input if the feature flag is enabled', async () => {
-    // Arrange
-    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
-
     const namespace = 'gatk';
     const name = 'echo_to_file-configured';
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-478

### What
- This PR removes the Workflow Cost Thresholds feature from public preview and makes it generally available to all users.

### Why
- Given the limited engagement during the preview, we are confident in making it generally available to encourage more usage.

### Testing strategy
- Unit Testing: Updated tests
- Manual Testing: Verify no issues occur after removing the preview.
