### PR TITLE
[CORE-474] Enable lock/unlock for workspace owner with no access

### DIFF
--- a/src/workspaces/common/WorkspaceMenu.ts
+++ b/src/workspaces/common/WorkspaceMenu.ts
@@ -264,7 +264,7 @@ const LoadedWorkspaceMenuContent = (props: LoadedWorkspaceMenuContentProps) => {
     h(
       MenuButton,
       {
-        disabled: !workspaceLoaded || !isOwner || state === 'Deleting' || state === 'DeleteFailed' || noAccess,
+        disabled: !workspaceLoaded || !isOwner || state === 'Deleting' || state === 'DeleteFailed',
         tooltip: workspaceLoaded &&
           !isOwner && [isLocked ? tooltipText.unlockNoPermission : tooltipText.lockNoPermission],
         tooltipSide: 'left',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-474

### What
- This PR allows workspace owners to lock or unlock their workspaces, even if they don't have access to the AuthDomain.

### Why
-  This change completes the functionality for workspace owners to manage all aspects of their workspaces, including locking/unlocking, without needing AuthDomain access.

### Testing strategy
- Manual Testing: Validated that workspace owner can `lock` and `unlock` workspace after losing AuthDomain access.

### Screens
<img width="1768" alt="After" src="https://github.com/user-attachments/assets/99385549-31be-4e23-bf51-31564cfac656" />
