### PR TITLE
[CORE-481] Fix Version History Display Issue for '_set' Tables in Terra UI

### DIFF
--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -820,6 +820,7 @@ export const WorkspaceData = _.flow(
                                 },
                                 isShowingVersionHistory,
                                 onSaveVersion: withErrorReporting('Error saving version')((versionOpts) => {
+                                  type = type.endsWith('_set') ? getRootTypeForSetTable(type) : type;
                                   setShowDataTableVersionHistory(_.set(type, true));
                                   return saveDataTableVersion(type, versionOpts);
                                 }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-481

### What
- This PR addresses an issue in Terra UI where the version history for '_set' tables (e.g., 'sample_set') is not displayed correctly when users select 'Show version history'.

### Why
- To resolve an issue where version history is displayed correctly for all table types, particularly '_set' tables, providing consistent behavior and improving the user experience.

### Testing strategy
- Manual Testing: Validated that entity sets can be versioned

### Screens

https://github.com/user-attachments/assets/e664dffa-e36e-494d-b757-d1ed81b4ac21

