### PR TITLE
[CORE-491] Fix Role Selection in WorkspaceShareModal for "NoAccess" Owner

### DIFF
--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.tsx
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.test.tsx
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import React from 'react';
 import { CurrentUserGroupMembership, Groups, GroupsContract } from 'src/libs/ajax/Groups';
 import { Metrics, MetricsContract } from 'src/libs/ajax/Metrics';
+import { SamResources, SamResourcesContract } from 'src/libs/ajax/SamResources';
 import { WorkspaceContract, Workspaces, WorkspacesAjaxContract } from 'src/libs/ajax/workspaces/Workspaces';
 import { getTerraUser } from 'src/libs/state';
 import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -13,7 +14,7 @@ import {
   protectedGoogleWorkspace,
 } from 'src/testing/workspace-fixtures';
 import { AccessEntry, RawWorkspaceAcl } from 'src/workspaces/acl-utils';
-import ShareWorkspaceModal from 'src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal';
+import ShareWorkspaceModal, { getAccessLevel } from 'src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal';
 import { GoogleWorkspace } from 'src/workspaces/utils';
 
 jest.mock('src/libs/state', () => ({
@@ -24,6 +25,7 @@ jest.mock('src/libs/state', () => ({
 jest.mock('src/libs/ajax/Groups');
 jest.mock('src/libs/ajax/Metrics');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
+jest.mock('src/libs/ajax/SamResources');
 
 describe('the share workspace modal', () => {
   beforeEach(() => {
@@ -244,6 +246,100 @@ describe('the share workspace modal', () => {
       });
       expect(defaultAzureWorkspace.policies).toEqual([]);
       expect(screen.queryByText(policyTitle)).toBeNull();
+    });
+  });
+
+  describe('Enable Acl selection when user has NoAccess', () => {
+    // Helper function to set up mocks
+    const setupMock = (roles: string[]) => {
+      const mockGetResourceRolesV2 = jest.fn(() => Promise.resolve(roles));
+      asMockedFn(SamResources).mockReturnValue(
+        partial<SamResourcesContract>({
+          getResourceRolesV2: mockGetResourceRolesV2,
+        })
+      );
+      return mockGetResourceRolesV2;
+    };
+
+    it('returns the correct access level based on user roles', async () => {
+      // Arrange
+      const mockGetResourceRolesV2 = setupMock(['reader', 'writer', 'owner']);
+      const workspaceId = 'test-workspace-id';
+      const accessLevel = 'NO ACCESS';
+      const mockAbortSignal = {} as AbortSignal;
+
+      // Act
+      const result = await getAccessLevel(workspaceId, accessLevel, mockAbortSignal);
+
+      // Assert
+      expect(mockGetResourceRolesV2).toHaveBeenCalledWith({
+        resourceTypeName: 'workspace',
+        resourceId: workspaceId,
+      });
+      expect(result).toBe('OWNER');
+    });
+
+    it('returns NO ACCESS if no roles match', async () => {
+      // Arrange
+      const mockGetResourceRolesV2 = setupMock([]);
+      const workspaceId = 'test-workspace-id';
+      const accessLevel = 'NO ACCESS';
+      const mockAbortSignal = {} as AbortSignal;
+
+      // Act
+      const result = await getAccessLevel(workspaceId, accessLevel, mockAbortSignal);
+
+      // Assert
+      expect(mockGetResourceRolesV2).toHaveBeenCalledWith({
+        resourceTypeName: 'workspace',
+        resourceId: workspaceId,
+      });
+      expect(result).toBe('NO ACCESS');
+    });
+
+    it('returns OWNER for project-owner or owner roles', async () => {
+      // Arrange
+      const mockGetResourceRolesV2 = setupMock(['project-owner', 'owner']);
+      const workspaceId = 'test-workspace-id';
+      const accessLevel = 'NO ACCESS';
+      const mockAbortSignal = {} as AbortSignal;
+
+      // Act
+      const result = await getAccessLevel(workspaceId, accessLevel, mockAbortSignal);
+
+      // Assert
+      expect(mockGetResourceRolesV2).toHaveBeenCalledWith({
+        resourceTypeName: 'workspace',
+        resourceId: workspaceId,
+      });
+      expect(result).toBe('OWNER');
+    });
+
+    it('returns WRITER for writer role and READER for reader role', async () => {
+      // Arrange
+      const mockGetResourceRolesV2 = setupMock(['writer']);
+      const workspaceId = 'test-workspace-id';
+      const accessLevel = 'NO ACCESS';
+      const mockAbortSignal = {} as AbortSignal;
+
+      // Act
+      const writerResult = await getAccessLevel(workspaceId, accessLevel, mockAbortSignal);
+
+      // Assert
+      expect(mockGetResourceRolesV2).toHaveBeenCalledWith({
+        resourceTypeName: 'workspace',
+        resourceId: workspaceId,
+      });
+      expect(writerResult).toBe('WRITER');
+
+      // Arrange for reader
+      mockGetResourceRolesV2.mockResolvedValueOnce(['reader']);
+
+      // Act
+      const readerResult = await getAccessLevel(workspaceId, accessLevel, mockAbortSignal);
+
+      // Assert
+      expect(readerResult).toBe('READER');
     });
   });
 });

--- a/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.tsx
+++ b/src/workspaces/ShareWorkspaceModal/ShareWorkspaceModal.tsx
@@ -6,6 +6,7 @@ import { ButtonPrimary, ButtonSecondary, spinnerOverlay } from 'src/components/c
 import { centeredSpinner } from 'src/components/icons';
 import { EmailSelect } from 'src/groups/Members/EmailSelect';
 import { Metrics } from 'src/libs/ajax/Metrics';
+import { SamResources } from 'src/libs/ajax/SamResources';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { reportError } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
@@ -21,7 +22,14 @@ import {
 } from 'src/workspaces/acl-utils';
 import { AclInput } from 'src/workspaces/ShareWorkspaceModal/Collaborator';
 import { CurrentCollaborators } from 'src/workspaces/ShareWorkspaceModal/CurrentCollaborators';
-import { isAzureWorkspace, WorkspaceWrapper } from 'src/workspaces/utils';
+import {
+  canRead,
+  canWrite,
+  isAzureWorkspace,
+  isOwner,
+  WorkspaceAccessLevel,
+  WorkspaceWrapper,
+} from 'src/workspaces/utils';
 import { WorkspacePolicies } from 'src/workspaces/WorkspacePolicies/WorkspacePolicies';
 import validate from 'validate.js';
 
@@ -29,6 +37,27 @@ interface ShareWorkspaceModalProps {
   workspace: WorkspaceWrapper;
   onDismiss: () => void;
 }
+
+export const getAccessLevel = async (
+  workspaceId: string,
+  accessLevel: WorkspaceAccessLevel,
+  signal: AbortSignal
+): Promise<WorkspaceAccessLevel> => {
+  if (canRead(accessLevel) || canWrite(accessLevel) || isOwner(accessLevel)) {
+    return accessLevel;
+  }
+  const workspaceUserRoles: string[] = await SamResources(signal).getResourceRolesV2({
+    resourceTypeName: 'workspace',
+    resourceId: `${workspaceId}`,
+  });
+
+  const roleHierarchy: WorkspaceAccessLevel[] = ['OWNER', 'WRITER', 'READER'];
+  const mappedRoles: string[] = workspaceUserRoles.map((role) =>
+    role === 'project-owner' || role === 'owner' ? 'OWNER' : role.toUpperCase()
+  );
+
+  return roleHierarchy.find((role) => mappedRoles.includes(role)) ?? 'NO ACCESS';
+};
 
 const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWorkspaceModalProps) => {
   const { onDismiss, workspace } = props;
@@ -52,6 +81,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
   const [updateError, setUpdateError] = useState(undefined);
   const [lastAddedEmail, setLastAddedEmail] = useState<string | undefined>(undefined);
   const list = useRef<HTMLDivElement>(null);
+  const [workspaceAccessLevel, setWorkspaceAccessLevel] = useState<WorkspaceAccessLevel>(workspace.accessLevel);
 
   const signal = useCancellation();
 
@@ -64,6 +94,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
         const fixedAcl: WorkspaceAcl = transformAcl(acl);
         setAcl(fixedAcl);
         setOriginalAcl(fixedAcl);
+        setWorkspaceAccessLevel(await getAccessLevel(workspace.workspace.workspaceId, workspace.accessLevel, signal));
         setLoaded(true);
       } catch (error) {
         onDismiss();
@@ -146,7 +177,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
             value={newAcl}
             onChange={setNewAcl}
             disabled={false}
-            maxAccessLevel={workspace.accessLevel}
+            maxAccessLevel={workspaceAccessLevel}
             isAzureWorkspace={isAzureWorkspace(workspace)}
             showRow={false}
           />
@@ -167,7 +198,7 @@ const ShareWorkspaceModal: React.FC<ShareWorkspaceModalProps> = (props: ShareWor
         setAcl={setAcl}
         originalAcl={originalAcl}
         lastAddedEmail={lastAddedEmail}
-        workspaceAccessLevel={workspace.accessLevel}
+        workspaceAccessLevel={workspaceAccessLevel}
         isAzureWorkspace={isAzureWorkspace(workspace)}
       />
       <WorkspacePolicies workspace={workspace} noCheckboxes />


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-491

### What
- This PR resolves an issue where users can only select the `READER` role when sharing access to a workspace after losing access due to the removal of an auth domain.

### Why
- Users with the right permissions should be able to select any role, even if they don't have access via the auth domain.

### Testing strategy
- Unit Testing
  -  Added unit tests for multiple scenarios
- Manual Testing:
  - I reproduced the issue and confirmed that only `READER` was selectable.
  - Verified that the fix works for users with and without access to the auth domain.



### Screens
**Before**
<img width="1768" alt="Before" src="https://github.com/user-attachments/assets/643ae1b7-5cb8-4587-a70b-76e8bdb82a6c" />

**After**
<img width="1768" alt="After" src="https://github.com/user-attachments/assets/2ad71131-29f4-4f20-9357-4bd0c69de9e2" />


