### PR TITLE
CORE-489 support NIH account and RAS simultaneously

### DIFF
--- a/src/profile/external-identities/ExternalIdentities.test.tsx
+++ b/src/profile/external-identities/ExternalIdentities.test.tsx
@@ -104,32 +104,7 @@ describe('ExternalIdentities', () => {
     });
   });
 
-  it('sorts providers based on desiredOrder without RAS', async () => {
-    // Arrange
-    asMockedFn(getConfig).mockReturnValue(
-      partial<AppConfigSettings>({
-        externalCreds: partial<AppConfigSettings['externalCreds']>({
-          providers: ['era-commons', 'fence', 'dcf-fence', 'kids-first', 'anvil'],
-        }),
-      })
-    );
-
-    // Act
-    render(<ExternalIdentities queryParams={{}} />);
-
-    // Assert
-    const providerElements = Array.from(screen.getByRole('main').querySelectorAll('div')).map((div) => div.textContent);
-    expect(providerElements).toStrictEqual([
-      'Nih Account',
-      'eRA Commons',
-      'NHLBI BioData Catalyst Framework Services',
-      'NCI CRDC Framework Services',
-      'Kids First DRC Framework Services',
-      'NHGRI AnVIL Data Commons Framework Services',
-    ]);
-  });
-
-  it('sorts providers based on desiredOrder with RAS', async () => {
+  it('sorts providers based on desiredOrder', async () => {
     // Arrange
     asMockedFn(getConfig).mockReturnValue(
       partial<AppConfigSettings>({
@@ -145,6 +120,7 @@ describe('ExternalIdentities', () => {
     // Assert
     const providerElements = Array.from(screen.getByRole('main').querySelectorAll('div')).map((div) => div.textContent);
     expect(providerElements).toStrictEqual([
+      'Nih Account',
       'NIH Researcher Auth Service (RAS)',
       'NHLBI BioData Catalyst Framework Services',
       'NCI CRDC Framework Services',

--- a/src/profile/external-identities/ExternalIdentities.tsx
+++ b/src/profile/external-identities/ExternalIdentities.tsx
@@ -15,7 +15,6 @@ type ExternalIdentitiesProps = {
 export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode => {
   const { queryParams } = props;
   const providers = (getConfig().externalCreds?.providers || []) as OAuth2ProviderKey[];
-  const hasRas = providers.includes('ras');
   const filteredProviders = providers.filter(
     (p: any) =>
       (p !== 'github' && p !== 'sage') ||
@@ -25,7 +24,7 @@ export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode =>
 
   return (
     <PageBox role='main' style={{ flexGrow: 1 }} variant={PageBoxVariants.light}>
-      {!hasRas && <NihAccount nihToken={queryParams?.['nih-username-token']} />}
+      <NihAccount nihToken={queryParams?.['nih-username-token']} />
       {filteredProviders.map((providerKey: OAuth2ProviderKey) => (
         <OAuth2Account
           key={`oauth2link-${providerKey}`}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-489

we need to support NIH account links for TCGA and TARGET at the same time as RAS for anvil

![image](https://github.com/user-attachments/assets/9fb40e64-350c-482e-8306-1f49e94cbca6)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
