### PR TITLE
[CORE-507] Make Sage Account Linking Generally Available

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -1,7 +1,6 @@
 export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp';
 export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const COHORT_BUILDER_CARD = 'cohortBuilderCard';
-export const SAGE_ACCOUNT_LINKING = 'sageAccountLinking';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -64,13 +63,6 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Cohort Builder Card'
     )}`,
     lastUpdated: '7/25/2024',
-  },
-  {
-    id: SAGE_ACCOUNT_LINKING,
-    title: 'Sage AD Knowledge Portal Account Linking',
-    description: 'Enabling this feature will allow linking a Terra account to a Sage AD Knowledge Portal account.',
-    groups: ['preview-sage-account-linking'],
-    lastUpdated: '4/15/2025',
   },
 ];
 

--- a/src/profile/external-identities/ExternalIdentities.test.tsx
+++ b/src/profile/external-identities/ExternalIdentities.test.tsx
@@ -2,8 +2,6 @@ import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { act, screen } from '@testing-library/react';
 import React from 'react';
 import { AppConfigSettings, getConfig } from 'src/libs/config';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { SAGE_ACCOUNT_LINKING } from 'src/libs/feature-previews-config';
 import { TerraUserState, userStore } from 'src/libs/state';
 import { ExternalIdentities } from 'src/profile/external-identities/ExternalIdentities';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -67,49 +65,13 @@ describe('ExternalIdentities', () => {
       expect(screen.queryByText('GitHub')).toBeNull();
     });
   });
-  describe('when the user has the Sage Account Linking feature preview enabled', () => {
-    it('shows the Sage Account Linking card', async () => {
-      // Arrange
-      asMockedFn(getConfig).mockReturnValue(
-        partial<AppConfigSettings>({
-          externalCreds: { providers: ['sage'], urlRoot: 'https/foo.bar.com' },
-        })
-      );
-      asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === SAGE_ACCOUNT_LINKING);
-      asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
-
-      // Act
-      render(<ExternalIdentities queryParams={{}} />);
-
-      // Assert
-      screen.getByText('Sage Bionetworks');
-    });
-  });
-  describe('when the user has the Sage Account Linking feature preview disabled', () => {
-    it('hides the Sage Account Linking card', async () => {
-      // Arrange
-      asMockedFn(getConfig).mockReturnValue(
-        partial<AppConfigSettings>({
-          externalCreds: { providers: ['sage'], urlRoot: 'https/foo.bar.com' },
-        })
-      );
-      asMockedFn(isFeaturePreviewEnabled).mockImplementation((id) => id === SAGE_ACCOUNT_LINKING);
-      asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
-
-      // Act
-      render(<ExternalIdentities queryParams={{}} />);
-
-      // Assert
-      expect(screen.queryByText('Sage')).toBeNull();
-    });
-  });
 
   it('sorts providers based on desiredOrder', async () => {
     // Arrange
     asMockedFn(getConfig).mockReturnValue(
       partial<AppConfigSettings>({
         externalCreds: partial<AppConfigSettings['externalCreds']>({
-          providers: ['ras', 'fence', 'dcf-fence', 'kids-first', 'anvil'],
+          providers: ['ras', 'fence', 'dcf-fence', 'kids-first', 'anvil', 'sage'],
         }),
       })
     );
@@ -126,6 +88,7 @@ describe('ExternalIdentities', () => {
       'NCI CRDC Framework Services',
       'Kids First DRC Framework Services',
       'NHGRI AnVIL Data Commons Framework Services',
+      'Sage Bionetworks',
     ]);
   });
 });

--- a/src/profile/external-identities/ExternalIdentities.tsx
+++ b/src/profile/external-identities/ExternalIdentities.tsx
@@ -2,8 +2,6 @@ import React, { ReactNode } from 'react';
 import { PageBox, PageBoxVariants } from 'src/components/PageBox';
 import { userHasAccessToEnterpriseFeature } from 'src/enterprise-features/features';
 import { getConfig } from 'src/libs/config';
-import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
-import { SAGE_ACCOUNT_LINKING } from 'src/libs/feature-previews-config';
 import { NihAccount } from 'src/profile/external-identities/NihAccount';
 import { OAuth2Account } from 'src/profile/external-identities/OAuth2Account';
 import { oauth2Provider, OAuth2ProviderKey } from 'src/profile/external-identities/OAuth2Providers';
@@ -16,10 +14,7 @@ export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode =>
   const { queryParams } = props;
   const providers = (getConfig().externalCreds?.providers || []) as OAuth2ProviderKey[];
   const filteredProviders = providers.filter(
-    (p: any) =>
-      (p !== 'github' && p !== 'sage') ||
-      (p === 'github' && userHasAccessToEnterpriseFeature('github-account-linking')) ||
-      (p === 'sage' && isFeaturePreviewEnabled(SAGE_ACCOUNT_LINKING))
+    (p: any) => p !== 'github' || userHasAccessToEnterpriseFeature('github-account-linking')
   );
 
   return (


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-507

### What

- Removes the feature flag for Sage account linking.

### Why
- Sage’s Terra export UI  is now available through the Sage Account Linking so the feature is ready for all users.

### Testing strategy

- Unit Testing: Updated tests to check for sage in identities list
- Manual Testing: Validated the "Sage" Identity is accessible on the External Identities Page

### Screens

<table>
<tr><td>Before</td><td>After</td></tr>
<tr>
<td>
<img width="1795" alt="FeaturePreview-Before" src="https://github.com/user-attachments/assets/50c49d15-eb7c-49b7-b535-10a356305c69" />
</td>
<td>
<img width="1795" alt="FeaturePreview-After" src="https://github.com/user-attachments/assets/feb242b8-5d05-46d5-9ace-6fda1e958d99" />
</td>
</tr>
<tr>
<td>
<img width="1795" alt="ExternalIdentities-Before" src="https://github.com/user-attachments/assets/f5799c4b-7f80-490c-b0ec-66c0b9556b79" />
</td>
<td>
<img width="1795" alt="ExternalIdentities-After" src="https://github.com/user-attachments/assets/751fbf97-eec3-40e9-8864-1c5751dfa624" />
</td>
</tr>
</table>
