### PR TITLE
[AN-590] Add more information about the boot disk

### DIFF
--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
@@ -17,13 +17,13 @@ describe('AboutPersistentDiskSection', () => {
     render(h(AboutPersistentDiskSection, defaultAboutPersistentDiskSectionProps));
     // Assert
     expect(screen.getByText('Persistent disk')).toBeTruthy();
-    expect(screen.getByText('Learn more about the disks mounted to your cloud compute.')).toBeTruthy();
+    expect(screen.getByText('Learn more about the disks mounted to your cloud compute')).toBeTruthy();
   });
 
   it('should call onClick when clicked', async () => {
     // Arrange
     render(h(AboutPersistentDiskSection, defaultAboutPersistentDiskSectionProps));
-    await userEvent.click(screen.getByText('Learn more about the disks mounted to your cloud compute.'));
+    await userEvent.click(screen.getByText('Learn more about the disks mounted to your cloud compute'));
 
     // Assert
     expect(defaultAboutPersistentDiskSectionProps.onClick).toBeCalled();

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.test.ts
@@ -17,13 +17,13 @@ describe('AboutPersistentDiskSection', () => {
     render(h(AboutPersistentDiskSection, defaultAboutPersistentDiskSectionProps));
     // Assert
     expect(screen.getByText('Persistent disk')).toBeTruthy();
-    expect(screen.getByText('Learn more about persistent disks and where your disk is mounted.')).toBeTruthy();
+    expect(screen.getByText('Learn more about the disks mounted to your cloud compute.')).toBeTruthy();
   });
 
   it('should call onClick when clicked', async () => {
     // Arrange
     render(h(AboutPersistentDiskSection, defaultAboutPersistentDiskSectionProps));
-    await userEvent.click(screen.getByText('Learn more about persistent disks and where your disk is mounted.'));
+    await userEvent.click(screen.getByText('Learn more about the disks mounted to your cloud compute.'));
 
     // Assert
     expect(defaultAboutPersistentDiskSectionProps.onClick).toBeCalled();

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskSection.ts
@@ -20,7 +20,7 @@ export const AboutPersistentDiskSection: React.FC<AboutPersistentDiskSectionProp
           style: { marginLeft: '0.5rem' },
         },
         [
-          'Learn more about persistent disks and where your disk is mounted.',
+          'Learn more about the disks mounted to your cloud compute',
           icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } }),
         ]
       ),

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
@@ -18,7 +18,7 @@ export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactN
   return div({ style: computeStyles.drawerContent }, [
     h(TitleBar, {
       id: titleId,
-      title: 'About persistent disk',
+      title: 'Persistent disks',
       style: computeStyles.titleBar,
       titleChildren: [],
       hideCloseButton: true,
@@ -45,6 +45,23 @@ export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactN
         'Learn more about persistent disks',
         h(Icon, { icon: 'pop-out', size: 12, style: { marginLeft: '0.25rem' } }),
       ]),
+    ]),
+    br(),
+    br(),
+    h(TitleBar, {
+      id: titleId,
+      title: 'Boot disks',
+      style: computeStyles.titleBar,
+      titleChildren: [],
+    }),
+    div({ style: { lineHeight: 1.5 } }, [
+      p([
+        'An additional `boot` disk is attached to your cloud compute. This disk pre-caches the container images so your cloud compute starts up faster.',
+      ]),
+      p([
+        'The boot disk is automatically deleted when you delete your cloud compute. You cannot delete the boot disk separately.',
+      ]),
+      p(['The cost of this extra boot disk is ~0.01$ / hr, which is accounted for in the Paused cloud compute cost.']),
     ]),
   ]);
 };

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
@@ -56,12 +56,14 @@ export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactN
     }),
     div({ style: { lineHeight: 1.5 } }, [
       p([
-        'An additional `boot` disk is attached to your cloud compute. This disk pre-caches the container images so your cloud compute starts up faster.',
+        'Besides the persistent disk, an additional boot disk is attached to your cloud compute. This disk pre-caches the container images so your cloud compute starts up faster.',
       ]),
       p([
-        'The boot disk is automatically deleted when you delete your cloud compute. You cannot delete the boot disk separately.',
+        'The boot disk is automatically deleted along with your cloud compute. You cannot delete the boot disk separately.',
       ]),
-      p(['The cost of this extra boot disk is ~0.01$ / hr, which is accounted for in the Paused cloud compute cost.']),
+      p([
+        'The cost of this extra boot disk amounts to ~0.01$ / hr, which is accounted for in the paused cloud compute cost.',
+      ]),
     ]),
   ]);
 };

--- a/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
+++ b/src/analysis/modals/ComputeModal/AboutPersistentDiskView.ts
@@ -55,9 +55,7 @@ export const AboutPersistentDiskView = (props: PersistentDiskAboutProps): ReactN
       titleChildren: [],
     }),
     div({ style: { lineHeight: 1.5 } }, [
-      p([
-        'Besides the persistent disk, an additional boot disk is attached to your cloud compute. This disk pre-caches the container images so your cloud compute starts up faster.',
-      ]),
+      p(['An additional boot disk is attached to spin up your cloud compute faster']),
       p([
         'The boot disk is automatically deleted along with your cloud compute. You cannot delete the boot disk separately.',
       ]),

--- a/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
+++ b/src/analysis/modals/ComputeModal/AzureComputeModal/AzurePersistentDiskSection.test.ts
@@ -72,7 +72,7 @@ describe('AzurePersistentDiskSection', () => {
     render(h(AzurePersistentDiskSection, defaultAzurePersistentDiskSectionProps));
 
     // Act
-    const aboutLink = screen.getByText('Learn more about persistent disks and where your disk is mounted.');
+    const aboutLink = screen.getByText('Learn more about the disks mounted to your cloud compute');
     await userEvent.click(aboutLink);
 
     // Assert

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.js
@@ -1593,7 +1593,7 @@ export const GcpComputeModalBase = ({
                     Metrics().captureEvent(Events.aboutPersistentDiskView, { cloudPlatform: cloudProviderTypes.GCP });
                   },
                 },
-                ['Learn more about Persistent disks and where your disk is mounted']
+                ['Learn more about the disks mounted to your cloud compute']
               ),
             ]),
             h(

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -1245,7 +1245,7 @@ describe('GcpComputeModal', () => {
     await user.click(link);
 
     // Assert
-    screen.getByText('About persistent disk');
+    screen.getByText('Persistent disk');
     screen.getByText(/Your persistent disk is mounted in the directory/);
   });
 
@@ -1380,7 +1380,7 @@ describe('GcpComputeModal', () => {
     // Assert
     const link = screen.getByText('Learn more about the disks mounted to your cloud compute');
     await user.click(link);
-    screen.getByText('About persistent disk');
+    screen.getByText('Persistent disk');
     screen.getByText(expectedLabel);
   });
 

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -1245,7 +1245,7 @@ describe('GcpComputeModal', () => {
     await user.click(link);
 
     // Assert
-    screen.getByText('Persistent disk');
+    screen.getByText('Persistent disks');
     screen.getByText(/Your persistent disk is mounted in the directory/);
   });
 
@@ -1380,7 +1380,7 @@ describe('GcpComputeModal', () => {
     // Assert
     const link = screen.getByText('Learn more about the disks mounted to your cloud compute');
     await user.click(link);
-    screen.getByText('Persistent disk');
+    screen.getByText('Persistent disks');
     screen.getByText(expectedLabel);
   });
 

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -1241,7 +1241,7 @@ describe('GcpComputeModal', () => {
 
     // Act
     render(h(GcpComputeModalBase, defaultModalProps));
-    const link = screen.getByText('Learn more about the disks mounted to your cloud compute.');
+    const link = screen.getByText('Learn more about the disks mounted to your cloud compute');
     await user.click(link);
 
     // Assert
@@ -1378,7 +1378,7 @@ describe('GcpComputeModal', () => {
     });
 
     // Assert
-    const link = screen.getByText('Learn more about the disks mounted to your cloud compute.');
+    const link = screen.getByText('Learn more about the disks mounted to your cloud compute');
     await user.click(link);
     screen.getByText('About persistent disk');
     screen.getByText(expectedLabel);

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -1241,7 +1241,7 @@ describe('GcpComputeModal', () => {
 
     // Act
     render(h(GcpComputeModalBase, defaultModalProps));
-    const link = screen.getByText('Learn more about persistent disks and where your disk is mounted.');
+    const link = screen.getByText('Learn more about the disks mounted to your cloud compute.');
     await user.click(link);
 
     // Assert
@@ -1378,7 +1378,7 @@ describe('GcpComputeModal', () => {
     });
 
     // Assert
-    const link = screen.getByText('Learn more about persistent disks and where your disk is mounted.');
+    const link = screen.getByText('Learn more about the disks mounted to your cloud compute.');
     await user.click(link);
     screen.getByText('About persistent disk');
     screen.getByText(expectedLabel);

--- a/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
+++ b/src/analysis/modals/ComputeModal/GcpComputeModal/GcpComputeModal.test.ts
@@ -1247,6 +1247,7 @@ describe('GcpComputeModal', () => {
     // Assert
     screen.getByText('Persistent disks');
     screen.getByText(/Your persistent disk is mounted in the directory/);
+    screen.getByText('Boot disks');
   });
 
   it.each([{ tool: runtimeTools.Jupyter }, { tool: runtimeTools.RStudio }])(
@@ -1382,6 +1383,7 @@ describe('GcpComputeModal', () => {
     await user.click(link);
     screen.getByText('Persistent disks');
     screen.getByText(expectedLabel);
+    screen.getByText('Boot disks');
   });
 
   it('correctly renders and updates timeoutInMinutes', async () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-590
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
![Screenshot 2025-05-21 at 11 34 09 AM](https://github.com/user-attachments/assets/eabf97e6-32b5-430e-a1a5-ff0fffc7f217)

<img width="656" alt="image" src="https://github.com/user-attachments/assets/6f4c2370-a633-431b-ac37-2f36602c62c8" />


---------------------
![Screenshot 2025-05-21 at 11 33 02 AM](https://github.com/user-attachments/assets/3231456d-81b3-462f-a9c4-02acdb90acc7)

![Screenshot 2025-05-21 at 11 35 22 AM](https://github.com/user-attachments/assets/faff0adc-446e-45c3-9511-4a8ae91ff36a)


### What
- Adds a boot disk explanation to the info about persistent disks

### Why
- Users complained there was no transparency about the VM boot disk

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
