### PR TITLE
[CORE-499] Add Support for Alert Severity and Banner for Blocker Alerts

### DIFF
--- a/src/alerts/BlockerAlerts.test.tsx
+++ b/src/alerts/BlockerAlerts.test.tsx
@@ -1,0 +1,77 @@
+import { useThemeFromContext } from '@terra-ui-packages/components';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { BlockerAlerts } from './BlockerAlerts';
+import * as AlertsModule from './service-alerts';
+
+jest.mock('src/alerts/service-alerts');
+jest.mock('@terra-ui-packages/components', () => ({
+  ...jest.requireActual('@terra-ui-packages/components'),
+  useThemeFromContext: jest.fn(),
+  icon: () => <span data-testid='icon'>[Icon]</span>,
+}));
+
+describe('BlockerAlerts', () => {
+  const mockTheme = {
+    colors: {
+      danger: (opacity?: number) => (opacity ? `rgba(255, 0, 0, ${opacity})` : 'red'),
+      dark: () => 'black',
+    },
+  };
+
+  beforeEach(() => {
+    (useThemeFromContext as jest.Mock).mockReturnValue(mockTheme);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when there are no alerts', () => {
+    (AlertsModule.useServiceAlerts as jest.Mock).mockReturnValue([]);
+
+    const { container } = render(<BlockerAlerts />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders only alerts with severity "error"', () => {
+    const alerts = [
+      { id: '1', severity: 'info', title: 'Info Alert', message: 'This is informational' },
+      { id: '2', severity: 'error', title: 'Error Alert', message: 'Something went wrong' },
+    ];
+    (AlertsModule.useServiceAlerts as jest.Mock).mockReturnValue(alerts);
+
+    render(<BlockerAlerts />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/Error Alert: Something went wrong/)).toBeInTheDocument();
+    expect(screen.queryByText(/Info Alert/)).not.toBeInTheDocument();
+  });
+
+  it('renders multiple error alerts if available', () => {
+    const alerts = [
+      { id: 'a', severity: 'error', title: 'Network', message: 'No connection' },
+      { id: 'b', severity: 'error', title: 'Database', message: 'Timeout' },
+    ];
+    (AlertsModule.useServiceAlerts as jest.Mock).mockReturnValue(alerts);
+
+    render(<BlockerAlerts />);
+
+    expect(screen.getByText(/Network: No connection/)).toBeInTheDocument();
+    expect(screen.getByText(/Database: Timeout/)).toBeInTheDocument();
+  });
+
+  it('applies appropriate styles and icon', () => {
+    const alerts = [{ id: 'x', severity: 'error', title: 'Crash', message: 'Critical failure' }];
+    (AlertsModule.useServiceAlerts as jest.Mock).mockReturnValue(alerts);
+
+    const { getByRole, getByTestId } = render(<BlockerAlerts />);
+    const alertDiv = getByRole('alert');
+
+    expect(alertDiv).toHaveStyle('border: 2px solid red');
+    expect(alertDiv).toHaveStyle('background-color: rgba(255, 0, 0, 0.15)');
+    expect(alertDiv).toHaveTextContent('Crash: Critical failure');
+    expect(getByTestId('icon')).toBeInTheDocument();
+  });
+});

--- a/src/alerts/BlockerAlerts.ts
+++ b/src/alerts/BlockerAlerts.ts
@@ -1,0 +1,42 @@
+import { icon, useThemeFromContext } from '@terra-ui-packages/components';
+import _ from 'lodash';
+import { ReactNode } from 'react';
+import { div } from 'react-hyperscript-helpers';
+import { Alert, Alert as AlertType } from 'src/alerts/Alert';
+import { useServiceAlerts } from 'src/alerts/service-alerts';
+
+export const BlockerAlerts = (): ReactNode => {
+  const { colors } = useThemeFromContext();
+
+  const blockerAlerts: AlertType[] = _.filter(useServiceAlerts(), { severity: 'error' }); // Blocker alerts are severity 'error'
+
+  if (!blockerAlerts) {
+    return null;
+  }
+
+  return _.map(blockerAlerts, (alert: Alert) =>
+    div(
+      {
+        key: alert.id,
+        role: 'alert',
+        style: {
+          display: 'flex',
+          alignItems: 'center',
+          padding: '1rem 1.25rem',
+          border: `2px solid ${colors.danger()}`,
+          backgroundColor: colors.danger(0.15),
+          color: colors.dark(),
+          fontWeight: 'bold',
+          fontSize: 12,
+          marginBottom: '0.5rem',
+        },
+      },
+      [
+        icon('error-standard', { size: 26, color: colors.danger(), style: { marginRight: '1ch' } }),
+        alert.title,
+        ': ',
+        alert.message,
+      ]
+    )
+  );
+};

--- a/src/alerts/service-alerts.test.ts
+++ b/src/alerts/service-alerts.test.ts
@@ -65,7 +65,7 @@ describe('getServiceAlerts', () => {
     ]);
   });
 
-  it('defaults severity to warning', async () => {
+  it('map severity to alerts', async () => {
     // Arrange
     asMockedFn(FirecloudBucket).mockReturnValue(
       partial<FirecloudBucketAjaxContract>({
@@ -73,11 +73,21 @@ describe('getServiceAlerts', () => {
           {
             title: 'The systems are down!',
             message: 'Something is terribly wrong',
+            severity: 'blocker', // This should be mapped to 'error'
+          },
+          {
+            title: 'The systems are down!',
+            message: 'Something is terribly wrong',
+            severity: 'critical', // This should be mapped to 'warn'
+          },
+          {
+            title: 'The systems are down!',
+            message: 'Something is terribly wrong', // This should be mapped to 'warn'
           },
           {
             title: 'Scheduled maintenance',
             message: 'Offline tomorrow',
-            severity: 'info',
+            severity: 'info', // This should be mapped to 'info'
           },
         ],
       })
@@ -87,6 +97,6 @@ describe('getServiceAlerts', () => {
     const serviceAlerts = await getServiceAlerts();
 
     // Assert
-    expect(serviceAlerts.map((alert) => alert.severity)).toEqual(['warn', 'info']);
+    expect(serviceAlerts.map((alert) => alert.severity)).toEqual(['error', 'warn', 'warn', 'info']);
   });
 });

--- a/src/alerts/service-alerts.ts
+++ b/src/alerts/service-alerts.ts
@@ -9,8 +9,17 @@ import { Alert } from './Alert';
 export const getServiceAlerts = async (): Promise<Alert[]> => {
   const serviceAlerts = await FirecloudBucket().getServiceAlerts();
   const hashes = await Promise.all(_.map(_.flow(JSON.stringify, Utils.sha256), serviceAlerts));
+  const severityMap = {
+    blocker: 'error',
+    critical: 'warn',
+    default: 'info',
+  };
   return _.flow(
-    _.map(_.defaults({ severity: 'warn' })),
+    _.map(_.defaults({ severity: 'critical' })),
+    _.map((alert: Alert) => ({
+      ...alert,
+      severity: severityMap[alert.severity ?? 'default'] ?? 'info',
+    })),
     _.zip(hashes),
     _.map(([id, alert]) => ({ ...alert, id })),
     _.uniqBy('id')

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,6 +4,7 @@ import React, { CSSProperties, PropsWithChildren, ReactNode, useRef, useState } 
 import { UnmountClosed as RCollapse } from 'react-collapse';
 import { Transition } from 'react-transition-group';
 import { AlertsIndicator } from 'src/alerts/Alerts';
+import { BlockerAlerts } from 'src/alerts/BlockerAlerts';
 import { RequiredUpdateAlert } from 'src/alerts/RequiredUpdateAlert';
 import { signIn } from 'src/auth/auth';
 import { signOut } from 'src/auth/signout/sign-out';
@@ -457,6 +458,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
         </div>
       </div>
       <RequiredUpdateAlert />
+      <BlockerAlerts />
       <SkipNavTarget ref={mainRef} />
     </div>
   );


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-499

### What
- Added a new severity field to alerts.
- Alerts marked with severity: `blocker` will display as an always-visible banner.

### Why
- Not all alerts have the same urgency. This change helps highlight critical alerts so users don’t miss them.
- Improves communication during outages or major issues.

### Testing strategy
- Unit Testing
  - Added and Updated unit tests
- Manual Testing
  -  Confirmed UI updates for blocker alerts using test data.
  - Verified alert mapping when severity is missing (warn) or set to non-blocker (critical->warn and default->info).

### Screens

**Severity to Alert Mapping**
<img width="1802" alt="Screenshot 2025-05-22 at 5 24 17 PM" src="https://github.com/user-attachments/assets/5f567f2f-73d3-464e-b55c-d0f0dae9de6f" />

**Blockers always displayed**
<img width="1802" alt="Screenshot 2025-05-22 at 4 20 17 PM" src="https://github.com/user-attachments/assets/e6469ed7-e817-42bd-80ce-c1926dcbb815" />

