### PR TITLE
AN-597 Add warning for PAPI users on workflow launch

### DIFF
--- a/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
+++ b/src/pages/workspaces/workspace/workflows/LaunchAnalysisModal.js
@@ -224,6 +224,29 @@ const LaunchAnalysisModal = ({
             }),
           ]),
       ]),
+      workflowBackend === 'LifeSciences' &&
+        div(
+          {
+            style: { ...warningBoxStyle, fontSize: 14, display: 'flex', flexDirection: 'column' },
+          },
+          [
+            div({ style: { display: 'flex', flexDirection: 'row', alignItems: 'center' } }, [
+              icon('warning-standard', { size: 19, style: { color: colors.warning(), flex: 'none', marginRight: '0.5rem' } }),
+              'LifeSciences API Deprecation Warning',
+            ]),
+            div({ style: { fontWeight: 'normal', marginTop: '0.5rem' } }, [
+              'This workspace is launching workflows with the LifeSciences API, which will be removed from Terra on or after June 16, 2025. Please switch to using its successor, Batch API, by updating your Workspace Settings. ',
+              h(
+                Link,
+                {
+                  href: 'https://support.terra.bio/hc/en-us/articles/31190930435483-Cromwell-on-Google-Batch-API-released-May-19',
+                  ...Utils.newTabLinkProps,
+                },
+                ['Learn more', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
+              ),
+            ]),
+          ]
+        ),
       warnDuplicateAnalyses &&
         div(
           {


### PR DESCRIPTION
### Jira Ticket: [AN-597](https://broadworkbench.atlassian.net/browse/AN-597)

Add a warning that users see when they launch a workflow with LifeSciences API that encourages them to switch to Batch, links to docs, and informs them of the likely end date for LifeSciences.

<img width="473" alt="Screenshot 2025-05-28 at 9 43 50 AM" src="https://github.com/user-attachments/assets/192e6916-4232-4230-be5e-fc0a4688b038" />


[AN-597]: https://broadworkbench.atlassian.net/browse/AN-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ