### PR TITLE
[TSPS-486] Limit TopBar options for Imputation UI

### DIFF
--- a/src/components/TopBar.test.ts
+++ b/src/components/TopBar.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { TopBar } from 'src/components/TopBar';
-import { authStore, SignInStatus } from 'src/libs/state';
+import { authStore, configOverridesStore, SignInStatus } from 'src/libs/state';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
 jest.mock('src/auth/auth');
@@ -46,5 +46,21 @@ describe('TopBar', () => {
     } else {
       expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
     }
+  });
+
+  it('renders limited options when compactTopBar brand option is enabled', async () => {
+    // scientificServices is a brand config that has compactTopBar enabled
+    configOverridesStore.set({ brand: 'scientificServices' });
+
+    authStore.update((authState) => ({ ...authState, signInStatus: 'uninitialized' as SignInStatus }));
+
+    // Act
+    render(h(TopBar));
+    fireEvent.click(screen.getByLabelText('Toggle main menu'));
+
+    // Assert
+    expect(screen.queryByText('Sign In')).toBeInTheDocument();
+    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument();
+    expect(screen.queryByText('Support')).not.toBeInTheDocument();
   });
 });

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -10,7 +10,14 @@ import { signOut } from 'src/auth/signout/sign-out';
 import { Clickable, Link } from 'src/components/common';
 import { SkipNavLink, SkipNavTarget } from 'src/components/skipNavLink';
 import headerRightHexes from 'src/images/brands/terra/header-right-hexes.svg';
-import { isBaseline, isBioDataCatalyst, isDatastage, isFirecloud, isTerra } from 'src/libs/brand-utils';
+import {
+  getEnabledBrand,
+  isBaseline,
+  isBioDataCatalyst,
+  isDatastage,
+  isFirecloud,
+  isTerra,
+} from 'src/libs/brand-utils';
 import colors from 'src/libs/colors';
 import { getBuildTimestamp, getConfig } from 'src/libs/config';
 import { topBarLogo } from 'src/libs/logos';
@@ -132,7 +139,6 @@ interface TopBarProps extends PropsWithChildren {
   title: string;
   showMenu?: boolean;
   href?: string;
-  compact?: boolean; // whether to show only sign-in/sign-out (used for Teaspoons UI)
 }
 
 export const TopBar = (props: TopBarProps): ReactNode => {
@@ -142,6 +148,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
   const [openLibraryMenu, setOpenLibraryMenu] = useState(false);
   const [openSupportMenu, setOpenSupportMenu] = useState(false);
   const [openPlatformNewsMenu, setOpenPlatformNewsMenu] = useState(false);
+  const compact = getEnabledBrand().compactSidebar;
 
   const authState = useStore(authStore);
   const userState = useStore(userStore);
@@ -163,7 +170,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
     document.body.classList.remove('overlayOpen', 'overHeight');
   };
 
-  const buildNav = (transitionState: string, compact?: boolean) => {
+  const buildNav = (transitionState) => {
     const { signInStatus } = authState;
     const {
       profile: { firstName = 'Loading...', lastName = '' },
@@ -402,7 +409,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
     <div role='banner' style={{ flex: 'none', display: 'flex', flexFlow: 'column nowrap' }}>
       <SkipNavLink ref={mainRef} />
       <Transition in={navShown} timeout={{ exit: 200 }} mountOnEnter unmountOnExit>
-        {(transitionState) => buildNav(transitionState, props.compact)}
+        {(transitionState) => buildNav(transitionState)}
       </Transition>
       <div
         style={{

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -148,10 +148,11 @@ export const TopBar = (props: TopBarProps): ReactNode => {
   const [openLibraryMenu, setOpenLibraryMenu] = useState(false);
   const [openSupportMenu, setOpenSupportMenu] = useState(false);
   const [openPlatformNewsMenu, setOpenPlatformNewsMenu] = useState(false);
-  const compact = getEnabledBrand().compactSidebar;
 
   const authState = useStore(authStore);
   const userState = useStore(userStore);
+
+  const compact = getEnabledBrand().compactTopBar;
 
   const showNav = () => {
     setNavShown(true);

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -132,6 +132,7 @@ interface TopBarProps extends PropsWithChildren {
   title: string;
   showMenu?: boolean;
   href?: string;
+  compact?: boolean; // whether to show only sign-in/sign-out (used for Teaspoons UI)
 }
 
 export const TopBar = (props: TopBarProps): ReactNode => {
@@ -162,7 +163,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
     document.body.classList.remove('overlayOpen', 'overHeight');
   };
 
-  const buildNav = (transitionState: string) => {
+  const buildNav = (transitionState: string, compact?: boolean) => {
     const { signInStatus } = authState;
     const {
       profile: { firstName = 'Loading...', lastName = '' },
@@ -189,18 +190,22 @@ export const TopBar = (props: TopBarProps): ReactNode => {
                 onClick={() => setOpenUserMenu(!openUserMenu)}
                 isOpened={openUserMenu}
               >
-                <DropDownSubItem href={Nav.getLink('profile')} onClick={hideNav}>
-                  Profile
-                </DropDownSubItem>
-                <DropDownSubItem href={Nav.getLink('groups')} onClick={hideNav}>
-                  Groups
-                </DropDownSubItem>
-                <DropDownSubItem href={Nav.getLink('billing')} onClick={hideNav}>
-                  Billing
-                </DropDownSubItem>
-                <DropDownSubItem href={Nav.getLink('environments')} onClick={hideNav}>
-                  Cloud Environments
-                </DropDownSubItem>
+                {!compact && (
+                  <>
+                    <DropDownSubItem href={Nav.getLink('profile')} onClick={hideNav}>
+                      Profile
+                    </DropDownSubItem>
+                    <DropDownSubItem href={Nav.getLink('groups')} onClick={hideNav}>
+                      Groups
+                    </DropDownSubItem>
+                    <DropDownSubItem href={Nav.getLink('billing')} onClick={hideNav}>
+                      Billing
+                    </DropDownSubItem>
+                    <DropDownSubItem href={Nav.getLink('environments')} onClick={hideNav}>
+                      Cloud Environments
+                    </DropDownSubItem>
+                  </>
+                )}
                 <DropDownSubItem onClick={() => signOut('requested')}>Sign Out</DropDownSubItem>
               </DropDownSection>
             ) : (
@@ -237,150 +242,154 @@ export const TopBar = (props: TopBarProps): ReactNode => {
                 </Clickable>
               </div>
             )}
-            <NavSection href={Nav.getLink('workspaces')} onClick={hideNav}>
-              <Icon icon='view-cards' size={24} style={navIconStyles} />
-              Workspaces
-            </NavSection>
-            <DropDownSection
-              titleIcon='library'
-              title='Library'
-              onClick={() => setOpenLibraryMenu(!openLibraryMenu)}
-              isOpened={openLibraryMenu}
-            >
-              <DropDownSubItem href={Nav.getLink('library-datasets')} onClick={hideNav}>
-                Datasets
-              </DropDownSubItem>
-              <DropDownSubItem href={Nav.getLink('library-showcase')} onClick={hideNav}>
-                Featured Workspaces
-              </DropDownSubItem>
-              <DropDownSubItem href={Nav.getLink('library-workflows')} onClick={hideNav}>
-                Workflows
-              </DropDownSubItem>
-            </DropDownSection>
-            <DropDownSection
-              titleIcon='newspaper'
-              title='Platform News'
-              onClick={() => setOpenPlatformNewsMenu(!openPlatformNewsMenu)}
-              isOpened={openPlatformNewsMenu}
-            >
-              <DropDownSubItem
-                href='https://support.terra.bio/hc/en-us/sections/30968105851931-Terra-Roadmap'
-                onClick={hideNav}
-                {...Utils.newTabLinkProps}
-              >
-                Terra Roadmap
-              </DropDownSubItem>
-              <DropDownSubItem href='#feature-preview' onClick={hideNav}>
-                Feature Preview
-              </DropDownSubItem>
-              <DropDownSubItem
-                href='https://support.terra.bio/hc/en-us/community/topics/360000500452'
-                onClick={hideNav}
-                {...Utils.newTabLinkProps}
-              >
-                Request a Feature
-              </DropDownSubItem>
-              <DropDownSubItem
-                href='https://support.terra.bio/hc/en-us/sections/4414878945819'
-                onClick={hideNav}
-                {...Utils.newTabLinkProps}
-              >
-                Release Notes
-              </DropDownSubItem>
-            </DropDownSection>
-            <DropDownSection
-              titleIcon='help'
-              title='Support'
-              onClick={() => setOpenSupportMenu(!openSupportMenu)}
-              isOpened={openSupportMenu}
-            >
-              <DropDownSubItem
-                href={window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/categories/360005881492'}
-                onClick={() => {
-                  hideNav();
-                  window.Appcues?.show('-M3lNP6ncNr-42_78TOX');
-                }}
-                {...Utils.newTabLinkProps}
-              >
-                Quickstart Guide
-              </DropDownSubItem>
-              <DropDownSubItem href='https://support.terra.bio/' onClick={hideNav} {...Utils.newTabLinkProps}>
-                Terra Support Home
-              </DropDownSubItem>
-              {isBaseline() && (
-                <DropDownSubItem
-                  href='https://support.terra.bio/hc/en-us/sections/360010495892-Baseline'
-                  onClick={hideNav}
-                  {...Utils.newTabLinkProps}
+            {!compact && (
+              <>
+                <NavSection href={Nav.getLink('workspaces')} onClick={hideNav}>
+                  <Icon icon='view-cards' size={24} style={navIconStyles} />
+                  Workspaces
+                </NavSection>
+                <DropDownSection
+                  titleIcon='library'
+                  title='Library'
+                  onClick={() => setOpenLibraryMenu(!openLibraryMenu)}
+                  isOpened={openLibraryMenu}
                 >
-                  Baseline Documentation
-                </DropDownSubItem>
-              )}
-              <DropDownSubItem
-                href='https://support.terra.bio/hc/en-us/community/topics'
-                onClick={hideNav}
-                {...Utils.newTabLinkProps}
-              >
-                Community Forum
-              </DropDownSubItem>
-              {isFirecloud() && (
-                <DropDownSubItem
-                  href='https://support.terra.bio/hc/en-us/articles/360022694271'
-                  onClick={hideNav}
-                  {...Utils.newTabLinkProps}
+                  <DropDownSubItem href={Nav.getLink('library-datasets')} onClick={hideNav}>
+                    Datasets
+                  </DropDownSubItem>
+                  <DropDownSubItem href={Nav.getLink('library-showcase')} onClick={hideNav}>
+                    Featured Workspaces
+                  </DropDownSubItem>
+                  <DropDownSubItem href={Nav.getLink('library-workflows')} onClick={hideNav}>
+                    Workflows
+                  </DropDownSubItem>
+                </DropDownSection>
+                <DropDownSection
+                  titleIcon='newspaper'
+                  title='Platform News'
+                  onClick={() => setOpenPlatformNewsMenu(!openPlatformNewsMenu)}
+                  isOpened={openPlatformNewsMenu}
                 >
-                  What&apos;s different in Terra
-                </DropDownSubItem>
-              )}
-              <DropDownSubItem
-                onClick={() => {
-                  hideNav();
-                  contactUsActive.set(true);
-                }}
-              >
-                Contact Us
-              </DropDownSubItem>
-              <DropDownSubItem
-                href='https://support.terra.bio/hc/en-us/sections/4415104213787'
-                onClick={hideNav}
-                {...Utils.newTabLinkProps}
-              >
-                Service Notifications
-              </DropDownSubItem>
-            </DropDownSection>
-            <div style={{ borderTop: `1px solid ${colors.dark(0.55)}` }} />
-            <div style={{ flex: 'none', padding: 28, marginTop: 'auto' }}>
-              {isBioDataCatalyst() && (
-                <>
-                  <Link
-                    variant='light'
-                    style={{ display: 'block', textDecoration: 'underline', color: colors.light() }}
-                    href={Nav.getLink('privacy')}
+                  <DropDownSubItem
+                    href='https://support.terra.bio/hc/en-us/sections/30968105851931-Terra-Roadmap'
                     onClick={hideNav}
+                    {...Utils.newTabLinkProps}
                   >
-                    Terra Privacy Policy
-                  </Link>
-                  <Link
-                    variant='light'
-                    href={Nav.getLink('terms-of-service')}
-                    style={{ display: 'block', textDecoration: 'underline', color: colors.light() }}
+                    Terra Roadmap
+                  </DropDownSubItem>
+                  <DropDownSubItem href='#feature-preview' onClick={hideNav}>
+                    Feature Preview
+                  </DropDownSubItem>
+                  <DropDownSubItem
+                    href='https://support.terra.bio/hc/en-us/community/topics/360000500452'
                     onClick={hideNav}
+                    {...Utils.newTabLinkProps}
                   >
-                    Terra Terms of Service
-                  </Link>
-                </>
-              )}
-              <div style={{ color: 'white', fontSize: 10, fontWeight: 600, marginTop: '0.5rem' }}>
-                Built on:
-                <Clickable
-                  href={`https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`}
-                  {...Utils.newTabLinkProps}
-                  style={{ textDecoration: 'underline', marginLeft: '0.25rem' }}
+                    Request a Feature
+                  </DropDownSubItem>
+                  <DropDownSubItem
+                    href='https://support.terra.bio/hc/en-us/sections/4414878945819'
+                    onClick={hideNav}
+                    {...Utils.newTabLinkProps}
+                  >
+                    Release Notes
+                  </DropDownSubItem>
+                </DropDownSection>
+                <DropDownSection
+                  titleIcon='help'
+                  title='Support'
+                  onClick={() => setOpenSupportMenu(!openSupportMenu)}
+                  isOpened={openSupportMenu}
                 >
-                  {new Date(getBuildTimestamp()).toLocaleString()}
-                </Clickable>
-              </div>
-            </div>
+                  <DropDownSubItem
+                    href={window.Appcues ? undefined : 'https://support.terra.bio/hc/en-us/categories/360005881492'}
+                    onClick={() => {
+                      hideNav();
+                      window.Appcues?.show('-M3lNP6ncNr-42_78TOX');
+                    }}
+                    {...Utils.newTabLinkProps}
+                  >
+                    Quickstart Guide
+                  </DropDownSubItem>
+                  <DropDownSubItem href='https://support.terra.bio/' onClick={hideNav} {...Utils.newTabLinkProps}>
+                    Terra Support Home
+                  </DropDownSubItem>
+                  {isBaseline() && (
+                    <DropDownSubItem
+                      href='https://support.terra.bio/hc/en-us/sections/360010495892-Baseline'
+                      onClick={hideNav}
+                      {...Utils.newTabLinkProps}
+                    >
+                      Baseline Documentation
+                    </DropDownSubItem>
+                  )}
+                  <DropDownSubItem
+                    href='https://support.terra.bio/hc/en-us/community/topics'
+                    onClick={hideNav}
+                    {...Utils.newTabLinkProps}
+                  >
+                    Community Forum
+                  </DropDownSubItem>
+                  {isFirecloud() && (
+                    <DropDownSubItem
+                      href='https://support.terra.bio/hc/en-us/articles/360022694271'
+                      onClick={hideNav}
+                      {...Utils.newTabLinkProps}
+                    >
+                      What&apos;s different in Terra
+                    </DropDownSubItem>
+                  )}
+                  <DropDownSubItem
+                    onClick={() => {
+                      hideNav();
+                      contactUsActive.set(true);
+                    }}
+                  >
+                    Contact Us
+                  </DropDownSubItem>
+                  <DropDownSubItem
+                    href='https://support.terra.bio/hc/en-us/sections/4415104213787'
+                    onClick={hideNav}
+                    {...Utils.newTabLinkProps}
+                  >
+                    Service Notifications
+                  </DropDownSubItem>
+                </DropDownSection>
+                <div style={{ borderTop: `1px solid ${colors.dark(0.55)}` }} />
+                <div style={{ flex: 'none', padding: 28, marginTop: 'auto' }}>
+                  {isBioDataCatalyst() && (
+                    <>
+                      <Link
+                        variant='light'
+                        style={{ display: 'block', textDecoration: 'underline', color: colors.light() }}
+                        href={Nav.getLink('privacy')}
+                        onClick={hideNav}
+                      >
+                        Terra Privacy Policy
+                      </Link>
+                      <Link
+                        variant='light'
+                        href={Nav.getLink('terms-of-service')}
+                        style={{ display: 'block', textDecoration: 'underline', color: colors.light() }}
+                        onClick={hideNav}
+                      >
+                        Terra Terms of Service
+                      </Link>
+                    </>
+                  )}
+                  <div style={{ color: 'white', fontSize: 10, fontWeight: 600, marginTop: '0.5rem' }}>
+                    Built on:
+                    <Clickable
+                      href={`https://github.com/DataBiosphere/terra-ui/commits/${getConfig().gitRevision}`}
+                      {...Utils.newTabLinkProps}
+                      style={{ textDecoration: 'underline', marginLeft: '0.25rem' }}
+                    >
+                      {new Date(getBuildTimestamp()).toLocaleString()}
+                    </Clickable>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </FocusTrap>
@@ -393,7 +402,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
     <div role='banner' style={{ flex: 'none', display: 'flex', flexFlow: 'column nowrap' }}>
       <SkipNavLink ref={mainRef} />
       <Transition in={navShown} timeout={{ exit: 200 }} mountOnEnter unmountOnExit>
-        {(transitionState) => buildNav(transitionState)}
+        {(transitionState) => buildNav(transitionState, props.compact)}
       </Transition>
       <div
         style={{

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -171,7 +171,7 @@ export const TopBar = (props: TopBarProps): ReactNode => {
     document.body.classList.remove('overlayOpen', 'overHeight');
   };
 
-  const buildNav = (transitionState) => {
+  const buildNav = (transitionState: string) => {
     const { signInStatus } = authState;
     const {
       profile: { firstName = 'Loading...', lastName = '' },

--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -104,6 +104,9 @@ export interface BrandConfiguration {
     /** Card body */
     body: string;
   };
+
+  /** Optional flag to use the compact the sidebar with login/logout only */
+  compactSidebar?: boolean;
 }
 
 export const landingPageCardsDefault = [
@@ -427,6 +430,7 @@ export const brands: Record<string, BrandConfiguration> = {
     welcomeHeader: undefined,
     description: <ScientificServicesLandingPage />,
     hostName: 'app.terra.bio', // TODO
+    compactSidebar: true,
     docLinks: [],
     landingPageCards: [],
     logos: {

--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -105,7 +105,7 @@ export interface BrandConfiguration {
     body: string;
   };
 
-  /** Optional flag to use the compact the TopBar with login/logout only */
+  /** Optional flag to use the compact TopBar with login/logout only */
   compactTopBar?: boolean;
 }
 

--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -105,8 +105,8 @@ export interface BrandConfiguration {
     body: string;
   };
 
-  /** Optional flag to use the compact the sidebar with login/logout only */
-  compactSidebar?: boolean;
+  /** Optional flag to use the compact the TopBar with login/logout only */
+  compactTopBar?: boolean;
 }
 
 export const landingPageCardsDefault = [
@@ -430,7 +430,7 @@ export const brands: Record<string, BrandConfiguration> = {
     welcomeHeader: undefined,
     description: <ScientificServicesLandingPage />,
     hostName: 'app.terra.bio', // TODO
-    compactSidebar: true,
+    compactTopBar: true,
     docLinks: [],
     landingPageCards: [],
     logos: {

--- a/src/pages/scientificServices/imputation/common/scientific-services-common.tsx
+++ b/src/pages/scientificServices/imputation/common/scientific-services-common.tsx
@@ -13,8 +13,7 @@ const TAB_LINKS = {
 export const imputationTopBar = (activeTab: string) => {
   return (
     <>
-      {/* TODO: TSPS-486 TopBar.showMenu should be false */}
-      <TopBar title='' href={Nav.getLink('root')} />
+      <TopBar title='' href={Nav.getLink('root')} compact />
       <TabBar
         aria-label='imputation menu'
         activeTab={activeTab}

--- a/src/pages/scientificServices/imputation/common/scientific-services-common.tsx
+++ b/src/pages/scientificServices/imputation/common/scientific-services-common.tsx
@@ -13,7 +13,7 @@ const TAB_LINKS = {
 export const imputationTopBar = (activeTab: string) => {
   return (
     <>
-      <TopBar title='' href={Nav.getLink('root')} compact />
+      <TopBar title='' href={Nav.getLink('root')} />
       <TabBar
         aria-label='imputation menu'
         activeTab={activeTab}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

This deviates very slightly from the UX mocks due to the fact that we _need_ a way to allow the user to sign in and sign out. The solution here is to show a TopBar with limited options that don't allow the user to navigate to Terra.

Signed out view before:
![Screenshot 2025-05-28 at 11 32 17 AM](https://github.com/user-attachments/assets/7572c930-eac2-4cd7-b42a-46082ebaaedf)

Signed out view after:
![Screenshot 2025-05-28 at 11 32 35 AM](https://github.com/user-attachments/assets/ff5496d1-09cb-4871-bb7b-100a128bcbcd)

Signed in view before:
![Screenshot 2025-05-28 at 11 33 03 AM](https://github.com/user-attachments/assets/a6e2dfa6-974a-41e0-8ed5-3e1b457a30b2)

Signed in view after:
![Screenshot 2025-05-28 at 11 32 48 AM](https://github.com/user-attachments/assets/754c5f65-e225-4b20-a450-11571a07ca6e)


<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
