### PR TITLE
CORE-527 Support lookup ws by name

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -96,6 +96,11 @@ export const Workspaces = (signal?: AbortSignal) => ({
     return res.json();
   },
 
+  adminGetId: async (namespace: string, name: string): Promise<string> => {
+    const res = await fetchRawls(`admin/workspaces/${namespace}/${name}/id`, _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
   workspaceV2: (namespace: string, name: string) => {
     const root = `workspaces/v2/${namespace}/${name}`;
 

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -42,7 +42,7 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
         setResourceId(result.resourceId);
         // specify the resourceId to avoid waiting for state to update
         submit(result.resourceId);
-      } catch (error) {
+      } catch (error: any) {
         const errorMessage = error.status === 404 ? `${lookupValue} not found` : `Error looking up id: ${error}`;
         await reportError(errorMessage);
       }

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -14,8 +14,8 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
   const [resourceId, setResourceId] = useState<string>(props.fqResourceId.resourceId);
   const [lookupValue, setLookupValue] = useState<string>('');
 
-  function submit() {
-    Nav.updateSearch({ ...query, resourceId: resourceId || undefined });
+  function submit(overrideResourceId?: string) {
+    Nav.updateSearch({ ...query, resourceId: overrideResourceId || resourceId || undefined });
   }
 
   // event hook to clear the resourceId when resourceType changes
@@ -40,7 +40,8 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
       try {
         const result = await currentResourceType.lookupResourceIdFn(lookupValue);
         setResourceId(result.resourceId);
-        submit();
+        // specify the resourceId to avoid waiting for state to update
+        submit(result.resourceId);
       } catch (error) {
         await reportError('Error looking up id', error);
       }

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -43,7 +43,8 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
         // specify the resourceId to avoid waiting for state to update
         submit(result.resourceId);
       } catch (error) {
-        await reportError('Error looking up id', error);
+        const errorMessage = error.status === 404 ? `${lookupValue} not found` : `Error looking up id: ${error}`;
+        await reportError(errorMessage);
       }
     }
   };

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -3,6 +3,7 @@ import _ from 'lodash/fp';
 import React, { useState } from 'react';
 import { TextInput } from 'src/components/input';
 import colors from 'src/libs/colors';
+import { reportError } from 'src/libs/error';
 import * as Nav from 'src/libs/nav';
 import { ResourcePolicies } from 'src/support/ResourcePolicies';
 import { ResourceTypeSummaryProps, supportResources } from 'src/support/SupportResourceType';
@@ -11,6 +12,7 @@ import { SupportSummary } from 'src/support/SupportSummary';
 export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
   const { query } = Nav.useRoute();
   const [resourceId, setResourceId] = useState<string>(props.fqResourceId.resourceId);
+  const [lookupValue, setLookupValue] = useState<string>('');
 
   function submit() {
     Nav.updateSearch({ ...query, resourceId: resourceId || undefined });
@@ -19,15 +21,35 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
   // event hook to clear the resourceId when resourceType changes
   React.useEffect(() => {
     setResourceId('');
+    setLookupValue('');
   }, [props.fqResourceId.resourceTypeName]);
 
   // the resourceType may be configured to skip policy retrieval/display
   const displayPolicies = !_.find((res) => res.resourceType === props.fqResourceId.resourceTypeName, supportResources)
     ?.skipPolicies;
 
+  // Get the current resource type configuration
+  const currentResourceType = _.find(
+    (res) => res.resourceType === props.fqResourceId.resourceTypeName,
+    supportResources
+  );
+
+  // Handle lookup when the resource type has a lookupResourceId function
+  const handleLookup = async () => {
+    if (currentResourceType?.lookupResourceIdFn && lookupValue) {
+      try {
+        const result = await currentResourceType.lookupResourceIdFn(lookupValue);
+        setResourceId(result.resourceId);
+        submit();
+      } catch (error) {
+        await reportError('Error looking up id', error);
+      }
+    }
+  };
+
   return (
     <>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', marginBottom: '1rem' }}>
         <div
           style={{
             color: colors.dark(),
@@ -36,24 +58,53 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
             display: 'flex',
             alignItems: 'center',
             marginLeft: '1rem',
+            marginBottom: '0.5rem',
           }}
         >
           {props.displayName}
         </div>
-        <TextInput
-          style={{ marginRight: '1rem', marginLeft: '1rem' }}
-          placeholder={`Enter ${props.displayName} ID`}
-          onChange={(newResourceId) => {
-            setResourceId(newResourceId);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              submit();
-            }
-          }}
-          value={resourceId}
-        />
-        <ButtonPrimary onClick={() => submit()}>Load</ButtonPrimary>
+
+        {currentResourceType?.lookupResourceIdFn && (
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+            <TextInput
+              style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1 }}
+              placeholder={`Enter ${currentResourceType.lookupResourceIdBoxPlaceholder}`}
+              onChange={setLookupValue}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleLookup();
+                }
+              }}
+              value={lookupValue}
+            />
+            <ButtonPrimary onClick={handleLookup}>
+              Load By {currentResourceType.lookupResourceIdBoxPlaceholder}
+            </ButtonPrimary>
+          </div>
+        )}
+
+        {currentResourceType?.lookupResourceIdFn && (
+          <div style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1, marginBottom: '0.5rem' }}>
+            <div style={{ fontWeight: 500 }}>or</div>
+          </div>
+        )}
+
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <TextInput
+            style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1 }}
+            placeholder={`Enter ${props.displayName} ID`}
+            onChange={(newResourceId) => {
+              setResourceId(newResourceId);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                submit();
+              }
+            }}
+            value={resourceId}
+          />
+          <ButtonPrimary onClick={() => submit()}>Load By ID</ButtonPrimary>
+        </div>
       </div>
       {!!props.loadSupportSummaryFn && <SupportSummary {...props} />}
       {displayPolicies && <ResourcePolicies {...props} />}

--- a/src/support/SupportResourceType.ts
+++ b/src/support/SupportResourceType.ts
@@ -18,6 +18,8 @@ export interface SupportResourceType {
   resourceType: string;
   loadSupportSummaryFn: ((id: FullyQualifiedResourceId) => Promise<SupportSummary>) | undefined;
   skipPolicies?: boolean;
+  lookupResourceIdFn?: (value: string) => Promise<FullyQualifiedResourceId>;
+  lookupResourceIdBoxPlaceholder?: string;
 }
 
 // Define the supported resources, add your own here
@@ -31,6 +33,16 @@ export const supportResources: SupportResourceType[] = [
     displayName: 'Workspace',
     resourceType: 'workspace',
     loadSupportSummaryFn: (id: FullyQualifiedResourceId) => Workspaces().adminGetById(id.resourceId),
+    lookupResourceIdFn: async (namespaceSlashName: string) => {
+      const nameParts = namespaceSlashName.split('/');
+      if (nameParts.length !== 2) {
+        return Promise.reject('enter namespace and name separated by a /');
+      }
+      const id = await Workspaces().adminGetId(nameParts[0], nameParts[1]);
+      const fqResourceId: FullyQualifiedResourceId = { resourceId: id, resourceTypeName: 'workspace' };
+      return fqResourceId;
+    },
+    lookupResourceIdBoxPlaceholder: 'Namespace/Name',
   },
   {
     displayName: 'Billing Project',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-527

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add a new input box to the support page for workspaces to load by name in addition to the box to load by id. The new feature looks up the id from rawls, populates the id input box then triggers the load just like the user entered the id manually.

![Screenshot 2025-06-09 at 11 30 43 AM](https://github.com/user-attachments/assets/1c927bfd-5e7c-41b8-97eb-b083fdb6f141)


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
