### PR TITLE
[TSPS-493] Enable prepare-upload-start for Imputation UI

### DIFF
--- a/src/libs/ajax/teaspoons/Teaspoons.ts
+++ b/src/libs/ajax/teaspoons/Teaspoons.ts
@@ -7,7 +7,7 @@ import {
   PipelineList,
   PipelineWithDetails,
   PreparePipelineRunResponse,
-  // StartPipelineRunResponse,
+  StartPipelineResponse,
   UserPipelineQuotaDetails,
 } from 'src/libs/ajax/teaspoons/teaspoons-models';
 
@@ -64,7 +64,7 @@ export const Teaspoons = (signal?: AbortSignal) => ({
     return res.json();
   },
 
-  startPipelineRun: async (jobId: string): Promise<Record<string, any>> => {
+  startPipelineRun: async (jobId: string): Promise<StartPipelineResponse> => {
     const res = await fetchTeaspoons(
       'pipelineruns/v1/start',
       _.mergeAll([

--- a/src/libs/ajax/teaspoons/Teaspoons.ts
+++ b/src/libs/ajax/teaspoons/Teaspoons.ts
@@ -6,6 +6,8 @@ import {
   GetPipelineRunsResponse,
   PipelineList,
   PipelineWithDetails,
+  PreparePipelineRunResponse,
+  // StartPipelineRunResponse,
   UserPipelineQuotaDetails,
 } from 'src/libs/ajax/teaspoons/teaspoons-models';
 
@@ -35,6 +37,44 @@ export const Teaspoons = (signal?: AbortSignal) => ({
   getAllPipelineRuns: async (pageSize: number, pageToken?: string): Promise<GetPipelineRunsResponse> => {
     const queryString = `?limit=${pageSize}${pageToken ? `&pageToken=${pageToken}` : ''}`;
     const res = await fetchTeaspoons(`pipelineruns/v1/pipelineruns${queryString}`, _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
+  preparePipelineRun: async (
+    jobId: string,
+    pipelineName: string,
+    pipelineVersion: number,
+    pipelineInputs: Record<string, any>,
+    description: string
+  ): Promise<PreparePipelineRunResponse> => {
+    const res = await fetchTeaspoons(
+      'pipelineruns/v1/prepare',
+      _.mergeAll([
+        authOpts(),
+        jsonBody({
+          jobId,
+          pipelineName,
+          pipelineVersion,
+          pipelineInputs,
+          description,
+        }),
+        { signal, method: 'POST' },
+      ])
+    );
+    return res.json();
+  },
+
+  startPipelineRun: async (jobId: string): Promise<Record<string, any>> => {
+    const res = await fetchTeaspoons(
+      'pipelineruns/v1/start',
+      _.mergeAll([
+        authOpts(),
+        jsonBody({
+          jobControl: { id: jobId },
+        }),
+        { signal, method: 'POST' },
+      ])
+    );
     return res.json();
   },
 });

--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -5,6 +5,13 @@ export interface Pipeline {
   description: string;
 }
 
+export interface PipelineInput {
+  name: string;
+  type: 'FILE' | 'STRING';
+  isRequired: boolean;
+  fileSuffix?: string; // Only present for FILE types
+}
+
 /* Represents the quota settings for a particular pipeline */
 export interface PipelineQuota {
   pipelineName: string;
@@ -13,8 +20,16 @@ export interface PipelineQuota {
   quotaUnits: string;
 }
 
+/**
+ * Interface for POST endpoint /api/pipelines/v1/{pipelineName}
+ *
+ * API reference:
+ * https://teaspoons.dsde-dev.broadinstitute.org/#/pipelines/getPipelineDetails
+ */
 export interface PipelineWithDetails extends Pipeline {
-  pipelineQuota: PipelineQuota;
+  type: string; // e.g. "imputation"
+  inputs: PipelineInput[];
+  pipelineQuota?: PipelineQuota;
 }
 
 export interface PipelineList {
@@ -43,6 +58,27 @@ export interface GetPipelineRunsResponse {
   totalResults: number;
   pageToken: string;
   results: PipelineRun[];
+}
+
+export interface PreparePipelineRunResponse {
+  fileInputUploadUrls: Record<string, Record<string, string>>;
+  jobId: string;
+}
+
+export interface StartPipelineResponse {
+  jobReport: {
+    id: string; // UUIDv4 job ID
+    description: string;
+    status: PipelineRunStatus;
+    statusCode: number; // HTTP status code
+    submitted: string; // ISO 8601 datetime
+    resultURL: string;
+  };
+  pipelineRunReport: {
+    pipelineName: string;
+    pipelineVersion: number;
+    toolVersion: string;
+  };
 }
 
 export type PipelineRunStatus = 'PREPARING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';

--- a/src/pages/scientificServices/pipelines/utils/mock-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/mock-utils.ts
@@ -1,4 +1,9 @@
-import { Pipeline, PipelineWithDetails, UserPipelineQuotaDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import {
+  Pipeline,
+  PipelineInput,
+  PipelineWithDetails,
+  UserPipelineQuotaDetails,
+} from 'src/libs/ajax/teaspoons/teaspoons-models';
 
 export function mockPipeline(name: string): Pipeline {
   return {
@@ -12,6 +17,15 @@ export function mockPipeline(name: string): Pipeline {
 export function mockPipelineWithDetails(name: string): PipelineWithDetails {
   return {
     ...mockPipeline(name),
+    type: 'test-type',
+    inputs: [
+      {
+        name: 'testInput',
+        type: 'FILE',
+        isRequired: true,
+        fileSuffix: '.vcf.gz',
+      },
+    ] as PipelineInput[],
     pipelineQuota: {
       pipelineName: name,
       defaultQuota: 2500,

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { Pipeline, PipelineInput, PipelineList, PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -1,0 +1,270 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
+import { Pipeline, PipelineInput, PipelineList, PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { prepareUploadStartPipelineRun, RunJob } from './RunJob';
+
+// Mock dependencies
+jest.mock('src/libs/ajax/teaspoons/Teaspoons');
+
+// Mock page navigation functions
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getPath: jest.fn(() => '/test/'),
+  getLink: jest.fn(() => '/'),
+}));
+
+// Mock global fetch for file upload testing
+global.fetch = jest.fn();
+
+// Mock crypto.randomUUID, so we can control the job ID generation in tests
+Object.defineProperty(global, 'crypto', {
+  value: {
+    randomUUID: jest.fn(() => 'mock-uuid-1234'),
+  },
+});
+
+describe('RunJob Component', () => {
+  const mockPipeline: Pipeline = {
+    pipelineName: 'array_imputation',
+    displayName: 'Array Imputation',
+    pipelineVersion: 1,
+    description: 'Test pipeline for array imputation',
+  };
+
+  const mockPipelineInputs: PipelineInput[] = [
+    {
+      name: 'multiSampleVcf',
+      type: 'FILE',
+      isRequired: true,
+      fileSuffix: '.vcf.gz',
+    },
+    {
+      name: 'outputBasename',
+      type: 'STRING',
+      isRequired: true,
+    },
+  ];
+
+  const mockPipelineDetails: PipelineWithDetails = {
+    ...mockPipeline,
+    type: 'imputation',
+    inputs: mockPipelineInputs,
+  };
+
+  const mockPipelineList: PipelineList = {
+    results: [mockPipeline],
+  };
+
+  const mockTeaspoonsContract = partial<TeaspoonsContract>({
+    getPipelines: jest.fn().mockResolvedValue(mockPipelineList),
+    getPipelineDetails: jest.fn().mockResolvedValue(mockPipelineDetails),
+    preparePipelineRun: jest.fn().mockResolvedValue({
+      fileInputUploadUrls: {
+        multiSampleVcf: {
+          signedUrl: 'https://mock-signed-url.com/upload',
+        },
+      },
+      jobId: 'mock-job-id',
+    }),
+    startPipelineRun: jest.fn().mockResolvedValue({ success: true }),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMockedFn(Teaspoons).mockReturnValue(mockTeaspoonsContract);
+    asMockedFn(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    // Reset the crypto mock
+    (global.crypto.randomUUID as jest.Mock).mockReturnValue('mock-uuid-1234');
+  });
+
+  it('renders the RunJob component with expected elements', async () => {
+    render(<RunJob />);
+
+    // Check for main headings and form elements
+    expect(screen.getByText('Select a pipeline version')).toBeInTheDocument();
+    expect(screen.getByText('Enter prefix for output file *')).toBeInTheDocument();
+    expect(screen.getByText(/Enter description/)).toBeInTheDocument();
+    expect(screen.getByText('Upload file *')).toBeInTheDocument();
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+
+    // Wait for pipeline options to load
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+    });
+  });
+
+  it('loads and displays pipeline options', async () => {
+    render(<RunJob />);
+
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+    });
+
+    // Check that pipeline details are fetched for each pipeline
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+    });
+  });
+
+  it('allows user to select a pipeline and enter form data', async () => {
+    const user = userEvent.setup();
+    render(<RunJob />);
+
+    // Wait for pipelines to load
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+    });
+
+    // Wait for pipeline details to load
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalled();
+    });
+
+    // Enter output file prefix
+    const outputPrefixInput = screen.getByLabelText('output file prefix');
+    await user.type(outputPrefixInput, 'test_output');
+
+    expect(outputPrefixInput).toHaveValue('test_output');
+
+    // Enter description
+    const descriptionTextArea = screen.getByLabelText('description');
+    await user.type(descriptionTextArea, 'Test description for pipeline run');
+
+    expect(descriptionTextArea).toHaveValue('Test description for pipeline run');
+  });
+
+  it('handles file selection and triggers upload process', async () => {
+    render(<RunJob />);
+
+    // Wait for pipelines to load
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+    });
+
+    // Wait for pipeline details to be loaded
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalled();
+    });
+
+    // Get the file input directly (it should be present even without pipeline selected)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+
+    // The test just verifies the file input exists and can be interacted with
+    // Full integration testing would require more complex Select component mocking
+  });
+
+  it('validates required fields before allowing submission', async () => {
+    render(<RunJob />);
+
+    const submitButton = screen.getByText('Submit');
+    expect(submitButton).toBeInTheDocument();
+
+    // Wait for async operations to complete to avoid act() warnings
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('prepareUploadStartPipelineRun function', () => {
+  const mockFile = new File(['test content'], 'test.vcf', { type: 'text/plain' });
+  const mockPipelineInputs = { multiSampleVcf: 'test.vcf', outputBasename: 'test_output' };
+
+  const mockTeaspoonsContract = partial<TeaspoonsContract>({
+    preparePipelineRun: jest.fn().mockResolvedValue({
+      fileInputUploadUrls: {
+        multiSampleVcf: {
+          signedUrl: 'https://mock-signed-url.com/upload',
+        },
+      },
+      jobId: 'mock-job-id',
+    }),
+    startPipelineRun: jest.fn().mockResolvedValue({ success: true }),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    asMockedFn(Teaspoons).mockReturnValue(mockTeaspoonsContract);
+    asMockedFn(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+    // Reset the crypto mock
+    (global.crypto.randomUUID as jest.Mock).mockReturnValue('mock-uuid-1234');
+  });
+
+  it('successfully uploads file and starts pipeline run', async () => {
+    const jobId = await prepareUploadStartPipelineRun(
+      mockFile,
+      'array_imputation',
+      1,
+      mockPipelineInputs,
+      'Test description'
+    );
+
+    // Verify that preparePipelineRun was called with correct parameters
+    expect(mockTeaspoonsContract.preparePipelineRun).toHaveBeenCalledWith(
+      'mock-uuid-1234',
+      'array_imputation',
+      1,
+      mockPipelineInputs,
+      'Test description'
+    );
+
+    // Verify that file upload was attempted
+    expect(fetch).toHaveBeenCalledWith('https://mock-signed-url.com/upload', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: mockFile,
+    });
+
+    // Verify that pipeline run was started
+    expect(mockTeaspoonsContract.startPipelineRun).toHaveBeenCalledWith('mock-uuid-1234');
+
+    // Verify that the function returns the expected job ID
+    expect(jobId).toBe('mock-uuid-1234');
+  });
+
+  it('handles errors during pipeline preparation', async () => {
+    const errorMessage = 'Failed to prepare pipeline run';
+    asMockedFn(mockTeaspoonsContract.preparePipelineRun).mockRejectedValue(new Error(errorMessage));
+
+    await expect(
+      prepareUploadStartPipelineRun(mockFile, 'array_imputation', 1, mockPipelineInputs, 'Test description')
+    ).rejects.toThrow(errorMessage);
+  });
+
+  it('handles errors during file upload', async () => {
+    // Ensure preparePipelineRun succeeds so we can test file upload failure
+    asMockedFn(mockTeaspoonsContract.preparePipelineRun).mockResolvedValue({
+      fileInputUploadUrls: {
+        multiSampleVcf: {
+          signedUrl: 'https://mock-signed-url.com/upload',
+        },
+      },
+      jobId: 'mock-job-id',
+    });
+
+    asMockedFn(fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      prepareUploadStartPipelineRun(mockFile, 'array_imputation', 1, mockPipelineInputs, 'Test description')
+    ).rejects.toThrow('Network error');
+  });
+
+  it('handles errors during pipeline run start', async () => {
+    asMockedFn(mockTeaspoonsContract.startPipelineRun).mockRejectedValue(new Error('Failed to start pipeline'));
+
+    await expect(
+      prepareUploadStartPipelineRun(mockFile, 'array_imputation', 1, mockPipelineInputs, 'Test description')
+    ).rejects.toThrow('Failed to start pipeline');
+  });
+});

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -9,13 +9,48 @@ import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { useCancellation } from 'src/libs/react-utils';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { HelpfulTipsWidget } from 'src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget';
-import { QuotaRemainingWidget } from 'src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget';
+
+async function uploadFileWithSignedUrl(inputFile, signedUrl) {
+  return await fetch(signedUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: inputFile,
+  });
+}
+
+export async function prepareUploadStartPipelineRun(
+  file: File,
+  pipelineName: string,
+  pipelineVersion: number,
+  pipelineInputs: Record<string, any>,
+  description: string
+): Promise<string> {
+  const jobId = crypto.randomUUID();
+
+  const { fileInputUploadUrls } = await Teaspoons().preparePipelineRun(
+    jobId,
+    pipelineName,
+    pipelineVersion,
+    pipelineInputs,
+    description
+  );
+
+  const signedUrl = fileInputUploadUrls.multiSampleVcf.signedUrl;
+
+  await uploadFileWithSignedUrl(file, signedUrl);
+
+  await Teaspoons().startPipelineRun(jobId);
+  return jobId;
+}
 
 export const RunJob = () => {
   const signal = useCancellation();
 
   const [pipelinesList, setPipelinesList] = useState<Pipeline[]>([]);
   const [pipelineVersionOptions, setPipelineVersionOptions] = useState<{ value: Pipeline; label: string }[]>([]);
+
+  // Input parameter names by pipeline name and version
+  const [pipelineInputs, setPipelineInputs] = useState<Record<string, any>>({});
 
   // User inputs for the run
   const [selectedPipeline, setSelectedPipeline] = useState<Pipeline>();
@@ -33,9 +68,19 @@ export const RunJob = () => {
 
       setPipelinesList(response.results);
       setPipelineVersionOptions(options);
+
+      response.results.map(async (pipeline) => {
+        const pipelineName = pipeline.pipelineName;
+        const pipelineVersion = pipeline.pipelineVersion;
+        const { inputs } = await Teaspoons(signal).getPipelineDetails(pipelineName, pipelineVersion);
+        const pipelineNameVersion = `${pipelineName}${pipelineVersion}`;
+        const newInputs = {};
+        newInputs[pipelineNameVersion] = inputs;
+        setPipelineInputs(Object.assign(pipelineInputs, newInputs));
+      });
     }
     fetchData();
-  }, [signal]);
+  }, [signal, pipelineInputs]);
 
   return (
     <FooterWrapper alwaysShow>
@@ -100,10 +145,47 @@ export const RunJob = () => {
             <input
               type='file'
               onChange={(e) => {
+                // TODO: Handle multiple files
                 const file = e.target.files?.[0];
                 if (file) {
+                  // console.log(file); // TODO TSPS-493: support file upload
+                  const pipeline = pipelinesList?.find(
+                    (pipeline) => pipeline?.pipelineVersion === selectedPipeline?.pipelineVersion
+                  );
+                  const pipelineName = pipeline?.pipelineName;
+                  const pipelineVersion = selectedPipeline?.pipelineVersion || 0;
+
+                  // Only proceed if we have a valid pipeline name
+                  if (!pipelineName) {
+                    console.error('No pipeline selected or pipeline name not found');
+                    return;
+                  }
+
+                  const pipelineInputsForVersion = pipelineInputs[`${pipelineName}${pipelineVersion}`];
+
+                  const selectedPipelineInputs = {};
+
+                  // E.g. "multiSampleVcf" for array_imputation v1
+                  const fileNameParam = pipelineInputsForVersion.find(
+                    (input) => input.type === 'FILE' && input.isRequired
+                  )?.name;
+                  selectedPipelineInputs[fileNameParam] = file.name;
+
+                  // E.g. "outputBasename" for array_imputation v1
+                  const outputPrefixParamName = pipelineInputsForVersion.find(
+                    (input) => input.type === 'STRING' && input.isRequired
+                  )?.name;
+
+                  selectedPipelineInputs[outputPrefixParamName] = runOutputFilePrefix;
+
                   // eslint-disable-next-line no-console
-                  console.log(file); // TODO TSPS-493: support file upload
+                  prepareUploadStartPipelineRun(
+                    file,
+                    pipelineName,
+                    pipelineVersion,
+                    selectedPipelineInputs,
+                    runDescription
+                  );
                 }
               }}
             />
@@ -113,7 +195,8 @@ export const RunJob = () => {
           </ButtonPrimary>
         </div>
         <div>
-          <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
+          {/* Uncomment below when dev API is updated to version >= 1.0.14 */}
+          {/* <QuotaRemainingWidget selectedPipeline={selectedPipeline} /> */}
           <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
         </div>
       </div>

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -148,7 +148,6 @@ export const RunJob = () => {
                 // TODO: Handle multiple files
                 const file = e.target.files?.[0];
                 if (file) {
-                  // console.log(file); // TODO TSPS-493: support file upload
                   const pipeline = pipelinesList?.find(
                     (pipeline) => pipeline?.pipelineVersion === selectedPipeline?.pipelineVersion
                   );

--- a/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
@@ -62,7 +62,7 @@ export const QuotaRemainingWidget = ({ selectedPipeline }: { selectedPipeline?: 
                 {pipelineDetails && (
                   <div style={{ marginTop: '1rem' }}>
                     <span style={{ fontWeight: 'bold' }}>
-                      {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
+                      {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-493

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
This enables users to upload a compressed VCF file and run the imputation pipeline on it.  Here's how it looks.

https://github.com/user-attachments/assets/2764ed1c-ff67-4414-88b0-9b670c845a9a

Upon selecting a file, the frontend now:

1.  Gets a signed URL for it from the Terra Scientific Pipeline Services (Teaspoons) API's "prepare" endpoint
2.  Uploads the .vcf.gz to a Google bucket using the signed URL
3.  Initiates the pipeline job by calling the Teaspoons API's "start" endpoint

Next steps include:
* Move this prepare-upload-start bundle to trigger on clicking "Submit", rather than file selection
* Refine upload UI to more closely align with mocks
* Handle and display errors returned from API in upload UI

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
New automated tests verify this new behavior.  To manually test:

1.  Go to "Run Job" page in Teaspoons Pipelines UI, e.g. http://localhost:3000/#services/pipelines/run
2.  Open Chrome DevTools
3.  Click "Choose File"
4.  Select a .vcf.gz file, e.g. [synthetic_public.vcf.gz](https://github.com/user-attachments/files/20656075/synthetic_public.vcf.gz)
5.  In Network panel in DevTools, confirm new requests to "prepare", then Google to upload, then "start"
6.  Go to "Job History" page, e.g. http://localhost:3000/#services/pipelines/history
7.  Confirm new row appears atop table

The [test failure](https://app.circleci.com/pipelines/github/DataBiosphere/terra-ui/27909/workflows/99f5d910-c4ca-494d-b969-d73e3108af8c/jobs/89072) is a false positive insofar as these changes are concerned, because the same failure appears in the most recent prior test test jobs in CircleCI.

```
  ● import-tdr-snapshot

    TimeoutError: Waiting for selector `//*[contains(normalize-space(.),"Data imported successfully")]` failed: Waiting failed: 180000ms exceeded
```

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
