### PR TITLE
[TSPS-520] Pre-select pipeline if there's only one + update job history table styling

### DIFF
--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -51,7 +51,7 @@ export const JobHistory = () => {
           <div>
             For support, email{' '}
             <a
-              style={{ color: '#46A3E9', textDecoration: 'underline' }}
+              style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
               href='mailto:scientific-services-support@broadinstitute.org'
             >
               scientific-services-support@broadinstitute.org
@@ -76,6 +76,7 @@ export const JobHistory = () => {
                   noContentMessage={pipelineRunsResponse.totalResults > 0 ? ' ' : 'Nothing to display'}
                   tabIndex={-1}
                   variant={undefined}
+                  styleHeader={() => ({ backgroundColor: '#eff0f1' })}
                 />
               )}
             </AutoSizer>

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -69,6 +69,11 @@ export const RunJob = () => {
       setPipelinesList(response.results);
       setPipelineVersionOptions(options);
 
+      // Automatically select the first pipeline if there's only one available
+      if (response.results.length === 1) {
+        setSelectedPipeline(response.results[0]);
+      }
+
       response.results.map(async (pipeline) => {
         const pipelineName = pipeline.pipelineName;
         const pipelineVersion = pipeline.pipelineVersion;


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-520

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Auto-selects a pipeline from the dropdown if only one is available.

Also includes 2 styling tweaks to the Job History page to get it in line with the mocks:

Before
![screencapture-localhost-3000-2025-06-09-22_01_30](https://github.com/user-attachments/assets/8763a15e-5343-439e-9119-ab94edb2803b)

After
![screencapture-localhost-3000-2025-06-09-22_01_14](https://github.com/user-attachments/assets/b637fc5a-f813-4c1c-bd8d-ea6ff9da00a7)

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
