### PR TITLE
[CORE-538] Add authuser param to "Open project in Google Cloud Console" Link

### DIFF
--- a/src/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.tsx
+++ b/src/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GCPBillingProjectWizard.test.tsx
@@ -180,7 +180,7 @@ describe('GCPBillingProjectWizard Steps', () => {
     });
     it('has Step 1 buttons enabled', () => {
       verifyEnabled(getStep1Button());
-      expect(getStep1Button().getAttribute('href')).toBe('https://console.cloud.google.com');
+      expect(getStep1Button().getAttribute('href')).toBe('https://console.cloud.google.com?authuser=undefined');
     });
     it('has Step 2 buttons enabled and unchecked', () => {
       testStep2ButtonsEnabled();

--- a/src/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GoToGCPConsoleStep.tsx
+++ b/src/billing/NewBillingProjectWizard/GCPBillingProjectWizard/GoToGCPConsoleStep.tsx
@@ -5,6 +5,7 @@ import { StepHeader } from 'src/billing/NewBillingProjectWizard/StepWizard/StepH
 import { ButtonOutline } from 'src/components/common';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import Events from 'src/libs/events';
+import { getTerraUser } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 
 interface GoToGCPConsoleStepProps {
@@ -22,7 +23,7 @@ export const GoToGCPConsoleStep = ({ isActive, ...props }: GoToGCPConsoleStepPro
         </StepInfo>
         <ButtonOutline
           disabled={false}
-          href='https://console.cloud.google.com'
+          href={`https://console.cloud.google.com?authuser=${getTerraUser().email}`}
           {...Utils.newTabLinkProps}
           onClick={() => {
             void Metrics().captureEvent(Events.billingGCPCreationStep1);

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -232,4 +232,46 @@ describe('CloudInformation', () => {
     expect(screen.getByText('50 B')).not.toBeNull();
     expect(mockStorageCostEstimateV2).toHaveBeenCalled();
   });
+
+  it('emits an event when the Open project in Google Cloud Console link is clicked', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const captureEvent = jest.fn();
+    const mockStorageCostEstimateV2 = jest.fn();
+
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () =>
+          partial<WorkspaceContract>({
+            storageCostEstimateV2: mockStorageCostEstimateV2,
+          }),
+      })
+    );
+    asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent }));
+
+    // Act
+    render(
+      h(CloudInformation, { workspace: { ...defaultGoogleWorkspace, workspaceInitialized: false }, storageDetails })
+    );
+    const consoleLink = screen.getByText('Open project in Google Cloud Console');
+    expect(consoleLink).toBeInTheDocument();
+
+    // Check the href attribute has the correct URL format
+    const linkElement = consoleLink.closest('a');
+    expect(linkElement).toHaveAttribute(
+      'href',
+      expect.stringMatching(
+        `https://console.cloud.google.com/welcome\\?project=${defaultGoogleWorkspace.workspace.googleProject}&authuser=.*`
+      )
+    );
+
+    // Simulate clicking the link
+    await user.click(consoleLink);
+
+    // Assert
+    expect(captureEvent).toHaveBeenCalledWith(
+      Events.workspaceOpenedProjectInConsole,
+      extractWorkspaceDetails(defaultGoogleWorkspace)
+    );
+  });
 });

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -12,6 +12,7 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
+import { getTerraUser } from 'src/libs/state';
 import { formatBytes, newTabLinkProps } from 'src/libs/utils';
 import * as Utils from 'src/libs/utils';
 import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/workspaces/common/state/useWorkspace';
@@ -240,7 +241,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               ...extractWorkspaceDetails(workspace),
             });
           },
-          href: `https://console.cloud.google.com/welcome?project=${googleProject}`,
+          href: `https://console.cloud.google.com/welcome?project=${googleProject}&authuser=${getTerraUser().email}`,
         },
         ['Open project in Google Cloud Console', icon('pop-out', { size: 12, style: { marginLeft: '0.25rem' } })]
       ),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-538

### What
- This PR updates the cloud console links in Terra to include the `authuser=<user_email>` parameter. Previously, some links were missing, causing issues for users who had multiple Google accounts.

### Why
- Without the authuser parameter, the browser defaults to the user’s primary Google account, which may not match the one used to log in to Terra. This led to IAM errors and confusion when opening links. Adding `authuser` ensures the correct identity is used consistently.

### Testing strategy
- Unit Testing: Added Unit test to validate that `authuser` was being included
- Manual Testing: Tested  cloud console links to confirm they use the correct email and avoid IAM errors
