### PR TITLE
[TSPS-491] Imputation UI: Home -> About + page updates

### DIFF
--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -1,12 +1,12 @@
-import { Home } from 'src/pages/scientificServices/pipelines/views/Home';
+import { About } from 'src/pages/scientificServices/pipelines/views/About';
 import { JobHistory } from 'src/pages/scientificServices/pipelines/views/JobHistory';
 import { RunJob } from 'src/pages/scientificServices/pipelines/views/RunJob';
 
 export const navPaths = [
   {
-    name: 'pipelines-home',
+    name: 'pipelines-about',
     path: '/services/pipelines',
-    component: Home,
+    component: About,
     title: 'Home',
   },
   {

--- a/src/pages/scientificServices/landingPage/ScientificServicesDescription.tsx
+++ b/src/pages/scientificServices/landingPage/ScientificServicesDescription.tsx
@@ -22,7 +22,7 @@ export const ScientificServicesDescription = () => {
         <ButtonPrimary
           height={100}
           style={{ marginTop: '0.25rem', marginBottom: '0.5rem', width: '9.4rem', height: '3.2rem', fontSize: '1rem' }}
-          href='#services/pipelines'
+          href='#services/pipelines/run'
           onClick={() => setButtonVisible(false)}
         >
           Get started

--- a/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
+++ b/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
@@ -5,9 +5,9 @@ import { TopBar } from 'src/components/TopBar';
 import * as Nav from 'src/libs/nav';
 
 const TAB_LINKS = {
-  home: 'pipelines-home',
   'run job': 'pipelines-run',
   'job history': 'pipelines-history',
+  about: 'pipelines-about',
 };
 
 export const pipelinesTopBar = (activeTab: string) => {

--- a/src/pages/scientificServices/pipelines/utils/text-utils.tsx
+++ b/src/pages/scientificServices/pipelines/utils/text-utils.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-// This component is used to render the "All of Us" name in italics
-// Useful for text that's returned by the backend
-export const BrandedDiv: React.FC<{ children: string }> = ({ children }) => {
-  const parts = children.split(/(All of Us)/g);
-  return <div>{parts.map((part) => (part === 'All of Us' ? <i>All of Us</i> : part))}</div>;
-};

--- a/src/pages/scientificServices/pipelines/utils/text-utils.tsx
+++ b/src/pages/scientificServices/pipelines/utils/text-utils.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// This component is used to render the "All of Us" name in italics
+// Useful for text that's returned by the backend
+export const BrandedDiv: React.FC<{ children: string }> = ({ children }) => {
+  const parts = children.split(/(All of Us)/g);
+  return <div>{parts.map((part) => (part === 'All of Us' ? <i>All of Us</i> : part))}</div>;
+};

--- a/src/pages/scientificServices/pipelines/views/About.tsx
+++ b/src/pages/scientificServices/pipelines/views/About.tsx
@@ -1,25 +1,58 @@
-import React from 'react';
+import { Spinner } from '@terra-ui-packages/components';
+import React, { useEffect, useState } from 'react';
 import FooterWrapper from 'src/components/FooterWrapper';
+import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
+import { PipelineList } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { BrandedDiv } from 'src/pages/scientificServices/pipelines/utils/text-utils';
 
 export const About = () => {
+  const [pipelines, setPipelines] = useState<PipelineList | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchPipelines = async () => {
+      try {
+        const pipelineData = await Teaspoons().getPipelines();
+        setPipelines(pipelineData);
+        setLoading(false);
+      } catch (e) {
+        setError('Failed to load pipeline information');
+        setLoading(false);
+      }
+    };
+
+    fetchPipelines();
+  }, []);
+
   return (
     <FooterWrapper alwaysShow>
       {pipelinesTopBar('about')}
       <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
         <h1>Scientific Services from the Broad Data Sciences Platform</h1>
-        <h2>Reference Panel</h2>
-        <div style={{ width: '50%' }}>
-          The imputation service leverages the <i>All of Us</i> + AnVIL reference panel of genomes from more than
-          515,000 All of Us Research Program and AnVIL participants, including more than 250,000 genomes from
-          non-European inferred genetic ancestries.
-        </div>
         <h2 style={{ marginTop: '2rem' }}>Pipelines</h2>
-        <h3>Array Imputation</h3>
-        <div style={{ width: '50%' }}>
-          Phase and impute genotypes using Beagle 5.4 with the <i>All of Us</i> + AnVIL reference panel of 515,579
-          samples.
-        </div>
+
+        {loading && <Spinner />}
+
+        {error && <div style={{ color: 'red' }}>{error}</div>}
+
+        {pipelines &&
+          pipelines.results.map((pipeline) => (
+            <div key={pipeline.pipelineName}>
+              <h3>
+                <BrandedDiv>{pipeline.displayName}</BrandedDiv>
+              </h3>
+              <div style={{ width: '50%' }}>
+                {pipeline.description ? (
+                  <BrandedDiv>{pipeline.description}</BrandedDiv>
+                ) : (
+                  <em>No description available</em>
+                )}
+              </div>
+            </div>
+          ))}
+
         <h2 style={{ marginTop: '2rem' }}>User Documentation</h2>
         <div style={{ marginTop: '1rem' }}>
           <a href='services/pipelines' style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}>

--- a/src/pages/scientificServices/pipelines/views/About.tsx
+++ b/src/pages/scientificServices/pipelines/views/About.tsx
@@ -4,7 +4,6 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineList } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
-import { BrandedDiv } from 'src/pages/scientificServices/pipelines/utils/text-utils';
 
 export const About = () => {
   const [pipelines, setPipelines] = useState<PipelineList | null>(null);
@@ -40,15 +39,9 @@ export const About = () => {
         {pipelines &&
           pipelines.results.map((pipeline) => (
             <div key={pipeline.pipelineName}>
-              <h3>
-                <BrandedDiv>{pipeline.displayName}</BrandedDiv>
-              </h3>
+              <h3>{pipeline.displayName}</h3>
               <div style={{ width: '50%' }}>
-                {pipeline.description ? (
-                  <BrandedDiv>{pipeline.description}</BrandedDiv>
-                ) : (
-                  <em>No description available</em>
-                )}
+                {pipeline.description ? pipeline.description : <em>No description available</em>}
               </div>
             </div>
           ))}

--- a/src/pages/scientificServices/pipelines/views/About.tsx
+++ b/src/pages/scientificServices/pipelines/views/About.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 
-export const Home = () => {
+export const About = () => {
   return (
     <FooterWrapper alwaysShow>
-      {pipelinesTopBar('home')}
+      {pipelinesTopBar('about')}
       <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
-        <h1>Imputation from the Broad Data Science Services</h1>
+        <h1>Scientific Services from the Broad Data Sciences Platform</h1>
         <h2>Reference Panel</h2>
         <div style={{ width: '50%' }}>
           The imputation service leverages the <i>All of Us</i> + AnVIL reference panel of genomes from more than

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -9,6 +9,7 @@ import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { useCancellation } from 'src/libs/react-utils';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { HelpfulTipsWidget } from 'src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget';
+import { QuotaRemainingWidget } from 'src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget';
 
 async function uploadFileWithSignedUrl(inputFile, signedUrl) {
   return await fetch(signedUrl, {
@@ -194,8 +195,7 @@ export const RunJob = () => {
           </ButtonPrimary>
         </div>
         <div>
-          {/* Uncomment below when dev API is updated to version >= 1.0.14 */}
-          {/* <QuotaRemainingWidget selectedPipeline={selectedPipeline} /> */}
+          <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
           <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
         </div>
       </div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-491

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Renames Home -> About and moves it to the third position in the tab bar
- Starts users in the Run Job tab
- Populates the descriptions on backend response rather than hardcoding

Before:
![screencapture-localhost-3000-2025-06-12-12_13_15](https://github.com/user-attachments/assets/6b589a57-15e7-4808-90e4-e5e05a0373d0)


After:
![screencapture-localhost-3000-2025-06-12-12_12_05](https://github.com/user-attachments/assets/bb3d14bc-bfd1-4c03-9d73-f68b672872e2)


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
