### PR TITLE
[CORE-550] Remove Cloud Platform Filter from Workspaces List Page

### DIFF
--- a/src/workspaces/list/WorkspaceFilters.test.ts
+++ b/src/workspaces/list/WorkspaceFilters.test.ts
@@ -45,12 +45,6 @@ describe('WorkspaceFilters', () => {
       eventData: { filter: 'billingProject', option: defaultGoogleWorkspace.workspace.namespace },
       filterParam: { projectsFilter: defaultGoogleWorkspace.workspace.namespace },
     },
-    {
-      label: 'Filter by cloud platform',
-      item: 'Microsoft Azure',
-      eventData: { filter: 'cloudPlatform', option: 'AZURE' },
-      filterParam: { cloudPlatform: 'AZURE' },
-    },
   ] as { label: string; item: string; eventData: object; filterParam: object }[])(
     'can update the filter for "$label" and emit an event',
     async ({ label, item, eventData, filterParam }) => {

--- a/src/workspaces/list/WorkspaceFilters.ts
+++ b/src/workspaces/list/WorkspaceFilters.ts
@@ -11,12 +11,7 @@ import { useInstance } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { WorkspaceTagSelect } from 'src/workspaces/common/WorkspaceTagSelect';
 import { CategorizedWorkspaces } from 'src/workspaces/list/CategorizedWorkspaces';
-import {
-  cloudProviderLabels,
-  cloudProviderTypes,
-  workspaceAccessLevels,
-  WorkspaceWrapper as Workspace,
-} from 'src/workspaces/utils';
+import { workspaceAccessLevels, WorkspaceWrapper as Workspace } from 'src/workspaces/utils';
 
 const styles = {
   filter: { marginRight: '1rem', flex: '1 1 0', minWidth: 'max-content' },
@@ -103,23 +98,6 @@ export const WorkspaceFilters = (props: WorkspaceFiltersProps): ReactNode => {
         options: _.flow(_.map('workspace.namespace'), _.uniq, _.sortBy(_.identity))(workspaces),
       }),
     ]),
-    div({ style: { ...styles.filter, marginRight: 0 } }, [
-      h(Select<string | undefined>, {
-        isClearable: true,
-        isMulti: false,
-        placeholder: 'Cloud platform',
-        'aria-label': 'Filter by cloud platform',
-        value: filters.cloudPlatform,
-        hideSelectedOptions: true,
-        onChange: (data) => {
-          const option = data?.value || undefined;
-          void Metrics().captureEvent(Events.workspaceListFilter, { filter: 'cloudPlatform', option });
-          Nav.updateSearch({ ...query, cloudPlatform: option });
-        },
-        options: _.sortBy((cloudProvider) => cloudProviderLabels[cloudProvider], _.keys(cloudProviderTypes)),
-        getOptionLabel: ({ value }) => (value ? cloudProviderLabels[value] : undefined),
-      }),
-    ]),
   ]);
 };
 
@@ -136,7 +114,6 @@ export const getWorkspaceFiltersFromQuery = (query: any): WorkspaceFilterValues 
   keywordFilter: query.filter || '',
   accessLevels: query.accessLevelsFilter || EMPTY_LIST,
   projects: query.projectsFilter || undefined,
-  cloudPlatform: query.cloudPlatform || undefined,
   tab: query.tab || 'myWorkspaces',
   tags: query.tagsFilter || EMPTY_LIST,
 });

--- a/src/workspaces/list/WorkspacesListTabs.test.ts
+++ b/src/workspaces/list/WorkspacesListTabs.test.ts
@@ -13,7 +13,7 @@ import {
 import { CategorizedWorkspaces } from 'src/workspaces/list/CategorizedWorkspaces';
 import { getWorkspaceFiltersFromQuery } from 'src/workspaces/list/WorkspaceFilters';
 import { filterWorkspaces, WorkspacesListTabs } from 'src/workspaces/list/WorkspacesListTabs';
-import { AzureWorkspace, cloudProviderTypes } from 'src/workspaces/utils';
+import { AzureWorkspace } from 'src/workspaces/utils';
 
 // the FlexTable uses react-virtualized's AutoSizer to size the table.
 // This makes the virtualized window large enough for all rows/columns to be rendered in tests.
@@ -164,22 +164,6 @@ describe('The filterWorkspaces method', () => {
     // Assert
     expect(defaultGoogleWorkspace.workspace.namespace).toEqual(defaultInitializedGoogleWorkspace.workspace.namespace);
     expect(filteredWorkspaces.myWorkspaces).toEqual([defaultGoogleWorkspace, defaultInitializedGoogleWorkspace]);
-  });
-
-  it('should filter based on cloudPlatform', () => {
-    // Arrange
-    const workspaces: CategorizedWorkspaces = {
-      myWorkspaces: [defaultAzureWorkspace, defaultGoogleWorkspace],
-      public: [],
-      featured: [],
-    };
-    const filters = getWorkspaceFiltersFromQuery({ cloudPlatform: cloudProviderTypes.GCP });
-
-    // Act
-    const filteredWorkspaces = filterWorkspaces(workspaces, filters);
-
-    // Assert
-    expect(filteredWorkspaces.myWorkspaces).toEqual([defaultGoogleWorkspace]);
   });
 
   it('should filter based on access level', () => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-550

### What
- This PR removes the Cloud Platform filter from the workspaces list page.

### Why
- Now that https://broadworkbench.atlassian.net/browse/CORE-13 is complete, there are no longer any Azure workspaces. As a result, the Cloud Platform filter is no longer needed.

### Testing strategy
- Unit Testing: Updated Unit Tests
- Manual Testing: Verified Cloud Platform filter is no longer shown on the workspace list page.

### Screens

**Before**
<img width="1767" alt="Before" src="https://github.com/user-attachments/assets/dd81f0ba-6051-4244-94f7-4a68938b2ede" />

**After**
<img width="1767" alt="After" src="https://github.com/user-attachments/assets/4235b835-2ae8-44f0-ac16-1584756d4f0f" />
