### PR TITLE
[CORE-571] Add Private Preview for RAS Identity Provider

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -9,7 +9,7 @@
   "drsHubUrlRoot": "https://drshub.dsde-dev.broadinstitute.org",
   "duosUrlRoot": "https://duos-k8s.dsde-dev.broadinstitute.org",
   "externalCreds": {
-    "providers": ["ras", "fence", "dcf-fence", "kids-first", "github", "sage"],
+    "providers": ["ras", "era-commons", "fence", "dcf-fence", "kids-first", "github", "sage"],
     "urlRoot": "https://externalcreds.dsde-dev.broadinstitute.org"
   },
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-dev",

--- a/config/prod.json
+++ b/config/prod.json
@@ -9,7 +9,7 @@
   "duosUrlRoot": "https://duos.org",
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts",
   "externalCreds": {
-    "providers": ["fence", "dcf-fence", "kids-first", "github", "sage"],
+    "providers": ["ras", "era-commons", "fence", "dcf-fence", "kids-first", "github", "sage"],
     "urlRoot": "https://externalcreds.dsde-prod.broadinstitute.org"
   },
   "isProd": true,

--- a/config/staging.json
+++ b/config/staging.json
@@ -9,7 +9,7 @@
   "drsHubUrlRoot": "https://drshub.dsde-staging.broadinstitute.org",
   "duosUrlRoot": "https://duos-k8s.dsde-staging.broadinstitute.org",
   "externalCreds": {
-    "providers": ["ras", "fence", "dcf-fence", "kids-first", "github", "sage"],
+    "providers": ["ras", "era-commons", "fence", "dcf-fence", "kids-first", "github", "sage"],
     "urlRoot": "https://externalcreds.dsde-staging.broadinstitute.org"
   },
   "firecloudBucketRoot": "https://storage.googleapis.com/firecloud-alerts-staging",

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -1,6 +1,7 @@
 export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp';
 export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const COHORT_BUILDER_CARD = 'cohortBuilderCard';
+export const RAS_PROVIDER = 'rasProvider';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -63,6 +64,14 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Feedback on Cohort Builder Card'
     )}`,
     lastUpdated: '7/25/2024',
+  },
+  {
+    id: RAS_PROVIDER,
+    title: 'RAS Integration with Terra',
+    description: 'Enables the NIH Researcher Authentication Service (RAS) as an external identity provider.',
+    groups: ['preview-ras-provider'],
+    feedbackUrl: 'https://support.terra.bio/hc/en-us/articles/32634034451099',
+    lastUpdated: '6/26/2025',
   },
 ];
 

--- a/src/profile/external-identities/ExternalIdentities.test.tsx
+++ b/src/profile/external-identities/ExternalIdentities.test.tsx
@@ -2,6 +2,7 @@ import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { act, screen } from '@testing-library/react';
 import React from 'react';
 import { AppConfigSettings, getConfig } from 'src/libs/config';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { TerraUserState, userStore } from 'src/libs/state';
 import { ExternalIdentities } from 'src/profile/external-identities/ExternalIdentities';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
@@ -71,10 +72,11 @@ describe('ExternalIdentities', () => {
     asMockedFn(getConfig).mockReturnValue(
       partial<AppConfigSettings>({
         externalCreds: partial<AppConfigSettings['externalCreds']>({
-          providers: ['ras', 'fence', 'dcf-fence', 'kids-first', 'anvil', 'sage'],
+          providers: ['ras', 'era-commons', 'fence', 'dcf-fence', 'kids-first', 'anvil', 'sage'],
         }),
       })
     );
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true); // Mock RAS_PROVIDER as enabled
 
     // Act
     render(<ExternalIdentities queryParams={{}} />);
@@ -82,8 +84,8 @@ describe('ExternalIdentities', () => {
     // Assert
     const providerElements = Array.from(screen.getByRole('main').querySelectorAll('div')).map((div) => div.textContent);
     expect(providerElements).toStrictEqual([
-      'Nih Account',
       'NIH Researcher Auth Service (RAS)',
+      'Nih Account',
       'NHLBI BioData Catalyst Framework Services',
       'NCI CRDC Framework Services',
       'Kids First DRC Framework Services',

--- a/src/profile/external-identities/ExternalIdentities.tsx
+++ b/src/profile/external-identities/ExternalIdentities.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from 'react';
 import { PageBox, PageBoxVariants } from 'src/components/PageBox';
 import { userHasAccessToEnterpriseFeature } from 'src/enterprise-features/features';
 import { getConfig } from 'src/libs/config';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { RAS_PROVIDER } from 'src/libs/feature-previews-config';
 import { NihAccount } from 'src/profile/external-identities/NihAccount';
 import { OAuth2Account } from 'src/profile/external-identities/OAuth2Account';
 import { oauth2Provider, OAuth2ProviderKey } from 'src/profile/external-identities/OAuth2Providers';
@@ -14,19 +16,26 @@ export const ExternalIdentities = (props: ExternalIdentitiesProps): ReactNode =>
   const { queryParams } = props;
   const providers = (getConfig().externalCreds?.providers || []) as OAuth2ProviderKey[];
   const filteredProviders = providers.filter(
-    (p: any) => p !== 'github' || userHasAccessToEnterpriseFeature('github-account-linking')
+    (p: any) =>
+      (p !== 'github' || userHasAccessToEnterpriseFeature('github-account-linking')) &&
+      (p !== 'ras' || isFeaturePreviewEnabled(RAS_PROVIDER))
   );
 
   return (
-    <PageBox role='main' style={{ flexGrow: 1 }} variant={PageBoxVariants.light}>
-      <NihAccount nihToken={queryParams?.['nih-username-token']} />
-      {filteredProviders.map((providerKey: OAuth2ProviderKey) => (
-        <OAuth2Account
-          key={`oauth2link-${providerKey}`}
-          queryParams={queryParams}
-          provider={oauth2Provider(providerKey)}
-        />
-      ))}
+    <PageBox as='main' role='main' style={{ flexGrow: 1 }} variant={PageBoxVariants.light}>
+      {filteredProviders.map((providerKey: OAuth2ProviderKey) =>
+        providerKey === 'era-commons' ? (
+          <React.Fragment key='nih-account'>
+            <NihAccount nihToken={queryParams?.['nih-username-token']} />
+          </React.Fragment>
+        ) : (
+          <OAuth2Account
+            key={`oauth2link-${providerKey}`}
+            queryParams={queryParams}
+            provider={oauth2Provider(providerKey)}
+          />
+        )
+      )}
     </PageBox>
   );
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-571

### What
- Adds a private feature flag: "RAS Integration with Terra", for members of the group `preview-ras-provider`
- Makes RAS the first item in the external identity provider list.

### Why
- Due to the volatility with RAS, it should be temporarily gated behind a private feature flag to validate that production is working as expected before being released to all users. 

### Testing strategy
- Unit Testing: Updated tests to include feature flag and verify provider order
- Manual Testing: Ensured ordering and visibility of RAS provider when feature flag is enabled

### Screens

**Feature Preview**
<img width="1731" alt="External Identities" src="https://github.com/user-attachments/assets/e2a12bf4-00ab-400b-867f-04f0f282e561" />

**External Identities**
<img width="1731" alt="Screenshot 2025-06-24 at 4 07 27 PM" src="https://github.com/user-attachments/assets/3dda5914-2094-4852-a093-b39c5a7d312d" />
