### PR TITLE
CORE-586: remove list-snapshot-references on Data tab

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -276,20 +276,6 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return res.json();
       },
 
-      listSnapshots: async (limit: number, offset: number) => {
-        const res = await fetchRawls(
-          `${root}/snapshots/v2?offset=${offset}&limit=${limit}`,
-          _.merge(authOpts(), { signal })
-        );
-        // The list snapshots endpoint returns a "snapshot" field that should really be named "snapshotId". Ideally, this should be fixed in the
-        // backend, but we've sequestered it here for now.
-        return _.update(
-          'gcpDataRepoSnapshots',
-          _.map(_.update('attributes', (a) => ({ ...a, snapshotId: a.snapshot }))),
-          await res.json()
-        );
-      },
-
       submission: (submissionId: string) => {
         const submissionPath = `${root}/submissions/${submissionId}`;
 

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -530,13 +530,11 @@ export const WorkspaceData = _.flow(
     const forceRefresh = () => setRefreshKey(_.add(1));
     const [selectedData, setSelectedData] = useState(() => StateHistory.get().selectedData);
     const [entityMetadata, setEntityMetadata] = useState(() => StateHistory.get().entityMetadata);
-    const [snapshotDetails, setSnapshotDetails] = useState(() => StateHistory.get().snapshotDetails);
     const [importingReference, setImportingReference] = useState(false);
     const [deletingReference, setDeletingReference] = useState(undefined);
     const [uploadingFile, setUploadingFile] = useState(false);
     const [uploadingWDSFile, setUploadingWDSFile] = useState(false);
     const [entityMetadataError, setEntityMetadataError] = useState();
-    const [snapshotMetadataError, setSnapshotMetadataError] = useState();
     const [sidebarWidth, setSidebarWidth] = useState(280);
     const [activeCrossTableTextFilter, setActiveCrossTableTextFilter] = useState('');
     const [crossTableResultCounts, setCrossTableResultCounts] = useState({});
@@ -575,36 +573,8 @@ export const WorkspaceData = _.flow(
       }
     };
 
-    const loadSnapshotMetadata = async () => {
-      try {
-        setSnapshotMetadataError(false);
-        const { gcpDataRepoSnapshots: snapshotBody } = await Workspaces(signal).workspace(namespace, name).listSnapshots(1000, 0);
-
-        const snapshots = _.reduce(
-          (acc, { metadata: { name, ...metadata }, attributes }) => {
-            return _.set([name, 'resource'], _.merge(metadata, attributes), acc);
-          },
-          _.pick(_.map('name', _.map('metadata', snapshotBody)), snapshotDetails) || {}, // retain entities if loaded from state history, but only for snapshots that exist
-          _.filter((snapshot) => {
-            // Do not display snapshot references that are only created for linking policies.
-            const isForPolicy = snapshot.metadata.properties.some((p) => p.key === 'purpose' && p.value === 'policy');
-            return !isForPolicy;
-          }, snapshotBody)
-        );
-
-        setSnapshotDetails(snapshots);
-      } catch (error) {
-        reportError('Error loading workspace snapshot data', error);
-        setSnapshotMetadataError(true);
-        setSelectedData(undefined);
-        setSnapshotDetails({});
-      }
-    };
-
     const loadMetadata = () =>
-      isAzureWorkspace
-        ? Promise.all([refreshRunningImportJobs(), loadWdsData()])
-        : Promise.all([loadEntityMetadata(), loadSnapshotMetadata(), refreshRunningImportJobs()]);
+      isAzureWorkspace ? Promise.all([refreshRunningImportJobs(), loadWdsData()]) : Promise.all([loadEntityMetadata(), refreshRunningImportJobs()]);
 
     const toSortedPairs = _.flow(_.toPairs, _.sortBy(_.first));
 
@@ -638,8 +608,8 @@ export const WorkspaceData = _.flow(
     });
 
     useEffect(() => {
-      StateHistory.update({ entityMetadata, selectedData, snapshotDetails });
-    }, [entityMetadata, selectedData, snapshotDetails]);
+      StateHistory.update({ entityMetadata, selectedData });
+    }, [entityMetadata, selectedData]);
 
     useImperativeHandle(ref, () => ({
       refresh: () => {
@@ -651,7 +621,6 @@ export const WorkspaceData = _.flow(
     // Render
     const referenceData = getReferenceData(attributes);
     const sortedEntityPairs = toSortedPairs(entityMetadata);
-    const sortedSnapshotPairs = toSortedPairs(snapshotDetails);
 
     const { value: canEditWorkspace, message: editWorkspaceErrorMessage } = WorkspaceUtils.canEditWorkspace(workspace);
 
@@ -664,7 +633,6 @@ export const WorkspaceData = _.flow(
     useEffect(() => {
       if (isAzureWorkspace) {
         // These aren't needed for Azure workspaces; just set them to empty objects
-        setSnapshotMetadataError(false);
         setEntityMetadata({});
 
         if (!wdsReady && !wdsError && !pollWdsInterval.current) {
@@ -906,26 +874,6 @@ export const WorkspaceData = _.flow(
                               }),
                             ]);
                           }, wdsTypes.state),
-                      ]
-                    ),
-                  (!_.isEmpty(sortedSnapshotPairs) || snapshotMetadataError) &&
-                    isGoogleWorkspace &&
-                    h(
-                      DataTypeSection,
-                      {
-                        title: 'Snapshots',
-                        error: snapshotMetadataError,
-                        retryFunction: loadSnapshotMetadata,
-                      },
-                      [
-                        div(
-                          // File Browser Banner
-                          { style: { padding: '1rem', margin: '0.75rem', backgroundColor: colors.dark(0.1), borderRadius: '0.5rem' } },
-                          [
-                            span({ style: { fontWeight: 'bold' } }, ['Looking for your snapshots?']),
-                            div(['Snapshots of this type are no longer supported in this workspace. Please contact support for assistance.']),
-                          ]
-                        ),
                       ]
                     ),
                   isGoogleWorkspace &&

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -152,7 +152,6 @@ describe('WorkspaceData', () => {
       mockGetSchema,
       mockListAppsV2,
       mockEntityMetadata,
-      mockListSnapshots,
     };
   }
 
@@ -170,21 +169,5 @@ describe('WorkspaceData', () => {
 
     // Assert
     expect(mockEntityMetadata).not.toHaveBeenCalled();
-  });
-
-  it('does not call Rawls for snapshot metadata on loading an azure workspace', async () => {
-    // Arrange
-    const { workspaceDataProps, mockListSnapshots } = setup({
-      workspace: defaultAzureWorkspace,
-      status: 'RUNNING',
-    });
-
-    // Act
-    await act(async () => {
-      render(h(WorkspaceData, workspaceDataProps));
-    });
-
-    // Assert
-    expect(mockListSnapshots).not.toHaveBeenCalled();
   });
 });

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -84,7 +84,6 @@ describe('WorkspaceData', () => {
     mockGetSchema: MockedFn<WorkspaceDataAjaxContract['getSchema']>;
     mockListAppsV2: MockedFn<AppsAjaxContract['listAppsV2']>;
     mockEntityMetadata: MockedFn<WorkspaceContract['entityMetadata']>;
-    mockListSnapshots: MockedFn<WorkspaceContract['listSnapshots']>;
   };
 
   const populatedAzureStorageOptions = {
@@ -116,14 +115,12 @@ describe('WorkspaceData', () => {
     const mockListAppsV2: MockedFn<AppsAjaxContract['listAppsV2']> = jest.fn();
     const mockDetails: MockedFn<WorkspaceContract['details']> = jest.fn();
     const mockEntityMetadata: MockedFn<WorkspaceContract['entityMetadata']> = jest.fn();
-    const mockListSnapshots: MockedFn<WorkspaceContract['listSnapshots']> = jest.fn();
 
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: (_namespace, _name) =>
           partial<WorkspaceContract>({
             details: mockDetails.mockResolvedValue(workspace),
-            listSnapshots: mockListSnapshots.mockRejectedValue({}),
             entityMetadata: mockEntityMetadata.mockRejectedValue([]),
           }),
       })


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-586

## Summary of changes:
On the Data tab, remove the call to list snapshot references. Also remove the help text about pre-existing snapshot references.

### Why
We are removing the v2 snapshot APIs as part of decommissioning Workspace Manager.

### Testing strategy
Tested running locally.


_before_
![Screenshot 27-06-2025 at 11 43](https://github.com/user-attachments/assets/8b16aece-1ba5-4396-af94-7fb60b3c72ca)

_after_
![Screenshot 27-06-2025 at 11 43 (1)](https://github.com/user-attachments/assets/60e9df3f-663b-40d1-a036-a95effb6f111)

