### PR TITLE
CORE-588: disable snapshot-by-reference import

### DIFF
--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -127,14 +127,12 @@ const setup = async (opts: SetupOptions) => {
     jobId: 'new-job',
   }));
   const importJSON: MockedFn<WorkspaceContract['importJSON']> = jest.fn();
-  const importSnapshot: MockedFn<WorkspaceContract['importSnapshot']> = jest.fn();
 
   const getWorkspaceApi: WorkspacesAjaxContract['workspace'] = jest.fn((_namespace, _name) =>
     partial<WorkspaceContract>({
       importBagit,
       importJob,
       importJSON,
-      importSnapshot,
     })
   );
 

--- a/src/import-data/ImportData.test.ts
+++ b/src/import-data/ImportData.test.ts
@@ -193,7 +193,6 @@ const setup = async (opts: SetupOptions) => {
     importBagit,
     importJob,
     importJSON,
-    importSnapshot,
     startImportJob,
     wdsProxyUrl,
   };
@@ -325,30 +324,6 @@ describe('ImportData', () => {
         );
 
         expect(importJob).toHaveBeenCalledWith(queryParams.tdrmanifest, 'tdrexport', { tdrSyncPermissions: true });
-      });
-    });
-
-    describe('snapshot references', () => {
-      it('imports a snapshot by reference', async () => {
-        // Arrange
-        const user = userEvent.setup();
-
-        const queryParams = {
-          format: 'snapshot',
-          snapshotId: googleSnapshotFixture.id,
-        };
-        const { getWorkspaceApi, importSnapshot } = await setup({ queryParams });
-
-        // Act
-        await importIntoExistingWorkspace(user, defaultGoogleWorkspace.workspace.name);
-
-        // Assert
-        expect(getWorkspaceApi).toHaveBeenCalledWith(
-          defaultGoogleWorkspace.workspace.namespace,
-          defaultGoogleWorkspace.workspace.name
-        );
-
-        expect(importSnapshot).toHaveBeenCalledWith(queryParams.snapshotId, googleSnapshotFixture.name);
       });
     });
   });

--- a/src/import-data/ImportData.ts
+++ b/src/import-data/ImportData.ts
@@ -28,7 +28,6 @@ import {
   ImportRequest,
   PFBImportRequest,
   TDRSnapshotExportImportRequest,
-  TDRSnapshotReferenceImportRequest,
   TemplateWorkspaceInfo,
 } from './import-types';
 import { ImportDataDestination } from './ImportDataDestination';
@@ -47,12 +46,6 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
   const [templateWorkspaces, setTemplateWorkspaces] = useState<{ [key: string]: TemplateWorkspaceInfo[] }>();
   const [userHasBillingProjects, setUserHasBillingProjects] = useState(true);
   const [isImporting, setIsImporting] = useState(false);
-
-  // Normalize the snapshot name:
-  // Importing snapshot will throw an "enum" error if the name has any spaces or special characters
-  // Replace all whitespace characters with _
-  // Then replace all non alphanumeric characters with nothing
-  const normalizeSnapshotName = (input) => _.flow(_.replace(/\s/g, '_'), _.replace(/[^A-Za-z0-9-_]/g, ''))(input);
 
   useOnMount(() => {
     const loadTemplateWorkspaces = _.flow(
@@ -138,14 +131,6 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
     }
   };
 
-  const importSnapshot = async (importRequest: TDRSnapshotReferenceImportRequest, workspace: WorkspaceInfo) => {
-    const { namespace, name } = workspace;
-    await Workspaces()
-      .workspace(namespace, name)
-      .importSnapshot(importRequest.snapshot.id, normalizeSnapshotName(importRequest.snapshot.name));
-    notify('success', 'Snapshot imported successfully.', { timeout: 3000 });
-  };
-
   const onImport = _.flow(
     Utils.withBusyState(setIsImporting),
     withErrorReporting('Import Error')
@@ -162,9 +147,6 @@ export const ImportData = (props: ImportDataProps): ReactNode => {
         break;
       case 'tdr-snapshot-export':
         await importTdrExport(importRequest, workspace);
-        break;
-      case 'tdr-snapshot-reference':
-        await importSnapshot(importRequest, workspace);
         break;
       default:
         // Use TypeScript to verify that this switch handles all possible values.

--- a/src/import-data/ImportDataDestination.test.ts
+++ b/src/import-data/ImportDataDestination.test.ts
@@ -16,7 +16,6 @@ import {
   anvilPfbImportRequests,
   azureTdrSnapshotImportRequest,
   gcpTdrSnapshotImportRequest,
-  gcpTdrSnapshotReferenceImportRequest,
   genericPfbImportRequest,
 } from './__fixtures__/import-request-fixtures';
 import { ImportRequest } from './import-types';
@@ -258,10 +257,6 @@ describe('ImportDataDestination', () => {
     {
       importRequest: gcpTdrSnapshotImportRequest,
       shouldShowNotice: true,
-    },
-    {
-      importRequest: gcpTdrSnapshotReferenceImportRequest,
-      shouldShowNotice: false,
     },
   ] as {
     importRequest: ImportRequest;

--- a/src/import-data/ImportDataDestination.ts
+++ b/src/import-data/ImportDataDestination.ts
@@ -118,7 +118,7 @@ export const ImportDataDestination = (props: ImportDataDestinationProps): ReactN
 
   // Some import types are finished in a single request.
   // For most though, the import request starts a background task that takes time to complete.
-  const immediateImportTypes: ImportRequest['type'][] = ['tdr-snapshot-reference'];
+  const immediateImportTypes: ImportRequest['type'][] = [];
   const importMayTakeTime = !immediateImportTypes.includes(importRequest.type);
 
   const {

--- a/src/import-data/ImportDataOverview.ts
+++ b/src/import-data/ImportDataOverview.ts
@@ -35,8 +35,6 @@ const getTitleForImportRequest = (importRequest: ImportRequest): string => {
   switch (importRequest.type) {
     case 'tdr-snapshot-export':
       return `Import snapshot ${importRequest.snapshot.name}`;
-    case 'tdr-snapshot-reference':
-      return 'Link data to a workspace';
     default:
       return 'Import data to a workspace';
   }

--- a/src/import-data/__fixtures__/import-request-fixtures.ts
+++ b/src/import-data/__fixtures__/import-request-fixtures.ts
@@ -1,6 +1,6 @@
 import { Snapshot } from 'src/libs/ajax/DataRepo';
 
-import { PFBImportRequest, TDRSnapshotExportImportRequest, TDRSnapshotReferenceImportRequest } from '../import-types';
+import { PFBImportRequest, TDRSnapshotExportImportRequest } from '../import-types';
 
 /**
  * TDR import requests
@@ -45,24 +45,12 @@ export const gcpTdrSnapshotImportRequest: TDRSnapshotExportImportRequest = {
   syncPermissions: false,
 };
 
-export const gcpTdrSnapshotReferenceImportRequest: TDRSnapshotReferenceImportRequest = {
-  type: 'tdr-snapshot-reference',
-  snapshot: getSnapshot({ cloudPlatform: 'gcp' }),
-  snapshotAccessControls: [],
-};
-
 export const protectedGcpTdrSnapshotImportRequest: TDRSnapshotExportImportRequest = {
   type: 'tdr-snapshot-export',
   manifestUrl: new URL('https://example.com/path/to/manifest.json'),
   snapshot: getSnapshot({ cloudPlatform: 'gcp', secureMonitoringEnabled: true }),
   snapshotAccessControls: [],
   syncPermissions: false,
-};
-
-export const protectedGcpTdrSnapshotReferenceImportRequest: TDRSnapshotReferenceImportRequest = {
-  type: 'tdr-snapshot-reference',
-  snapshot: getSnapshot({ cloudPlatform: 'gcp', secureMonitoringEnabled: true }),
-  snapshotAccessControls: [],
 };
 
 /**

--- a/src/import-data/import-requirements.test.ts
+++ b/src/import-data/import-requirements.test.ts
@@ -5,10 +5,8 @@ import {
   anvilPfbImportRequests,
   biodataCatalystPfbImportRequests,
   gcpTdrSnapshotImportRequest,
-  gcpTdrSnapshotReferenceImportRequest,
   genericPfbImportRequest,
   protectedGcpTdrSnapshotImportRequest,
-  protectedGcpTdrSnapshotReferenceImportRequest,
 } from './__fixtures__/import-request-fixtures';
 import {
   getRequiredCloudPlatform,
@@ -50,14 +48,12 @@ describe('security monitoring requirements', () => {
     ...biodataCatalystPfbImportRequests,
     // Protected TDR snapshots
     protectedGcpTdrSnapshotImportRequest,
-    protectedGcpTdrSnapshotReferenceImportRequest,
   ];
 
   const importsExpectedToNotRequireSecurityMonitoring: ImportRequest[] = [
     genericPfbImportRequest,
     { type: 'entities', url: new URL('https://example.com/file.json') },
     gcpTdrSnapshotImportRequest,
-    gcpTdrSnapshotReferenceImportRequest,
   ];
 
   describe('isProtectedSource', () => {
@@ -103,7 +99,7 @@ describe('access control requirements', () => {
       expect(hasAccessControl).toBe(undefined);
     });
 
-    it.each([genericPfbImportRequest, gcpTdrSnapshotImportRequest, gcpTdrSnapshotReferenceImportRequest])(
+    it.each([genericPfbImportRequest, gcpTdrSnapshotImportRequest])(
       'returns false for data without access controls',
       (importRequest: ImportRequest) => {
         // Act
@@ -162,7 +158,7 @@ describe('access control requirements', () => {
       expect(willUpdateAccessControl).toBe(undefined);
     });
 
-    it.each([genericPfbImportRequest, gcpTdrSnapshotImportRequest, gcpTdrSnapshotReferenceImportRequest])(
+    it.each([genericPfbImportRequest, gcpTdrSnapshotImportRequest])(
       'returns false for data without access controls',
       (importRequest: ImportRequest) => {
         // Act

--- a/src/import-data/import-requirements.ts
+++ b/src/import-data/import-requirements.ts
@@ -6,6 +6,7 @@ import { ImportRequest } from './import-types';
 export const getRequiredCloudPlatform = (importRequest: ImportRequest): CloudProvider | undefined => {
   switch (importRequest.type) {
     case 'tdr-snapshot-export':
+      return importRequest.snapshot.cloudPlatform === 'gcp' ? 'GCP' : undefined;
     case 'pfb':
       // restrict PFB imports to GCP unless the user has the right feature flag enabled
       return 'GCP';
@@ -36,6 +37,13 @@ const pfbRequiresSecurityMonitoring = (pfbUrl: URL): boolean => {
 };
 
 /**
+ * Determine if a TDR snapshot requires security monitoring.
+ */
+const snapshotRequiresSecurityMonitoring = (snapshot: Snapshot): boolean => {
+  return snapshot.source.some((source) => source.dataset.secureMonitoringEnabled);
+};
+
+/**
  * Determine whether an import requires security monitoring.
  */
 export const requiresSecurityMonitoring = (importRequest: ImportRequest): boolean => {
@@ -43,6 +51,7 @@ export const requiresSecurityMonitoring = (importRequest: ImportRequest): boolea
     case 'pfb':
       return pfbRequiresSecurityMonitoring(importRequest.url);
     case 'tdr-snapshot-export':
+      return snapshotRequiresSecurityMonitoring(importRequest.snapshot);
     default:
       return false;
   }
@@ -66,6 +75,8 @@ export const sourceHasAccessControl = (importRequest: ImportRequest): boolean | 
       // Currently, only PFBs from AnVIL are expected to reference snapshots.
       return isAnvilImport(importRequest) ? undefined : false;
     case 'tdr-snapshot-export':
+      // The snapshot has access controls if it has an auth domain.
+      return importRequest.snapshotAccessControls.length !== 0;
     default:
       return false;
   }
@@ -84,7 +95,7 @@ export const sourceHasAccessControl = (importRequest: ImportRequest): boolean | 
  */
 export const importWillUpdateAccessControl = (
   importRequest: ImportRequest,
-  _workspace: WorkspaceWrapper
+  workspace: WorkspaceWrapper
 ): boolean | undefined => {
   switch (importRequest.type) {
     case 'pfb':
@@ -93,6 +104,10 @@ export const importWillUpdateAccessControl = (
       // Currently, only PFBs from AnVIL are expected to reference snapshots.
       return isAnvilImport(importRequest) ? undefined : false;
     case 'tdr-snapshot-export':
+      // TDR snapshot imports require an access control update if the snapshot requires an auth do main
+      // that the workspace does not already have.
+      const workspaceAuthDomainGroups = workspace.workspace.authorizationDomain.map((ad) => ad.membersGroupName);
+      return _.difference(importRequest.snapshotAccessControls, workspaceAuthDomainGroups).length !== 0;
     default:
       return false;
   }

--- a/src/import-data/import-requirements.ts
+++ b/src/import-data/import-requirements.ts
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+import { Snapshot } from 'src/libs/ajax/DataRepo';
 import { CloudProvider, WorkspaceWrapper } from 'src/workspaces/utils';
 
 import { anvilSources, biodatacatalystSources, isAnvilImport, urlMatchesSource, UrlSource } from './import-sources';
@@ -104,7 +106,7 @@ export const importWillUpdateAccessControl = (
       // Currently, only PFBs from AnVIL are expected to reference snapshots.
       return isAnvilImport(importRequest) ? undefined : false;
     case 'tdr-snapshot-export':
-      // TDR snapshot imports require an access control update if the snapshot requires an auth do main
+      // TDR snapshot imports require an access control update if the snapshot requires an auth domain
       // that the workspace does not already have.
       const workspaceAuthDomainGroups = workspace.workspace.authorizationDomain.map((ad) => ad.membersGroupName);
       return _.difference(importRequest.snapshotAccessControls, workspaceAuthDomainGroups).length !== 0;

--- a/src/import-data/import-requirements.ts
+++ b/src/import-data/import-requirements.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-import { Snapshot } from 'src/libs/ajax/DataRepo';
 import { CloudProvider, WorkspaceWrapper } from 'src/workspaces/utils';
 
 import { anvilSources, biodatacatalystSources, isAnvilImport, urlMatchesSource, UrlSource } from './import-sources';
@@ -8,8 +6,6 @@ import { ImportRequest } from './import-types';
 export const getRequiredCloudPlatform = (importRequest: ImportRequest): CloudProvider | undefined => {
   switch (importRequest.type) {
     case 'tdr-snapshot-export':
-    case 'tdr-snapshot-reference':
-      return importRequest.snapshot.cloudPlatform === 'gcp' ? 'GCP' : undefined;
     case 'pfb':
       // restrict PFB imports to GCP unless the user has the right feature flag enabled
       return 'GCP';
@@ -40,13 +36,6 @@ const pfbRequiresSecurityMonitoring = (pfbUrl: URL): boolean => {
 };
 
 /**
- * Determine if a TDR snapshot requires security monitoring.
- */
-const snapshotRequiresSecurityMonitoring = (snapshot: Snapshot): boolean => {
-  return snapshot.source.some((source) => source.dataset.secureMonitoringEnabled);
-};
-
-/**
  * Determine whether an import requires security monitoring.
  */
 export const requiresSecurityMonitoring = (importRequest: ImportRequest): boolean => {
@@ -54,8 +43,6 @@ export const requiresSecurityMonitoring = (importRequest: ImportRequest): boolea
     case 'pfb':
       return pfbRequiresSecurityMonitoring(importRequest.url);
     case 'tdr-snapshot-export':
-    case 'tdr-snapshot-reference':
-      return snapshotRequiresSecurityMonitoring(importRequest.snapshot);
     default:
       return false;
   }
@@ -79,9 +66,6 @@ export const sourceHasAccessControl = (importRequest: ImportRequest): boolean | 
       // Currently, only PFBs from AnVIL are expected to reference snapshots.
       return isAnvilImport(importRequest) ? undefined : false;
     case 'tdr-snapshot-export':
-    case 'tdr-snapshot-reference':
-      // The snapshot has access controls if it has an auth domain.
-      return importRequest.snapshotAccessControls.length !== 0;
     default:
       return false;
   }
@@ -100,7 +84,7 @@ export const sourceHasAccessControl = (importRequest: ImportRequest): boolean | 
  */
 export const importWillUpdateAccessControl = (
   importRequest: ImportRequest,
-  workspace: WorkspaceWrapper
+  _workspace: WorkspaceWrapper
 ): boolean | undefined => {
   switch (importRequest.type) {
     case 'pfb':
@@ -109,11 +93,6 @@ export const importWillUpdateAccessControl = (
       // Currently, only PFBs from AnVIL are expected to reference snapshots.
       return isAnvilImport(importRequest) ? undefined : false;
     case 'tdr-snapshot-export':
-    case 'tdr-snapshot-reference':
-      // TDR snapshot imports require an access control update if the snapshot requires an auth domain
-      // that the workspace does not already have.
-      const workspaceAuthDomainGroups = workspace.workspace.authorizationDomain.map((ad) => ad.membersGroupName);
-      return _.difference(importRequest.snapshotAccessControls, workspaceAuthDomainGroups).length !== 0;
     default:
       return false;
   }

--- a/src/import-data/import-types.ts
+++ b/src/import-data/import-types.ts
@@ -25,18 +25,11 @@ export interface TDRSnapshotExportImportRequest {
   syncPermissions: boolean;
 }
 
-export interface TDRSnapshotReferenceImportRequest {
-  type: 'tdr-snapshot-reference';
-  snapshot: Snapshot;
-  snapshotAccessControls: string[];
-}
-
 export type ImportRequest =
   | PFBImportRequest
   | BagItImportRequest
   | EntitiesImportRequest
-  | TDRSnapshotExportImportRequest
-  | TDRSnapshotReferenceImportRequest;
+  | TDRSnapshotExportImportRequest;
 
 export interface TemplateWorkspaceInfo {
   name: string;

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -9,7 +9,6 @@ import {
   ImportRequest,
   PFBImportRequest,
   TDRSnapshotExportImportRequest,
-  TDRSnapshotReferenceImportRequest,
 } from './import-types';
 import { getImportRequest } from './useImportRequest';
 
@@ -110,19 +109,6 @@ describe('getImportRequest', () => {
         snapshotAccessControls: [],
         syncPermissions: true,
       } satisfies TDRSnapshotExportImportRequest,
-    },
-    // TDR snapshot by reference
-    {
-      queryParams: {
-        format: 'snapshot',
-        snapshotId: googleSnapshotFixture.id,
-        snapshotName: 'test-snapshot',
-      },
-      expectedResult: {
-        type: 'tdr-snapshot-reference',
-        snapshot: googleSnapshotFixture,
-        snapshotAccessControls: [],
-      } satisfies TDRSnapshotReferenceImportRequest,
     },
   ];
 

--- a/src/import-data/useImportRequest.test.ts
+++ b/src/import-data/useImportRequest.test.ts
@@ -158,13 +158,6 @@ describe('getImportRequest', () => {
           url: 'https://data.terra.bio',
         },
       },
-      // Snapshot reference
-      {
-        queryParams: {
-          format: 'snapshot',
-          snapshotId: '00001111-2222-3333-xxxx-yyyyyyzzzzzz',
-        },
-      },
     ] as { queryParams: Record<string, any> }[])(
       'throws an error if unable to load the snapshot',
       async ({ queryParams }) => {
@@ -185,14 +178,6 @@ describe('getImportRequest', () => {
           tdrmanifest: 'https://example.com/path/to/manifest.json',
           tdrSyncPermissions: 'true',
           url: 'https://data.terra.bio',
-        },
-      },
-      // Snapshot by reference
-      {
-        queryParams: {
-          format: 'snapshot',
-          snapshotId: googleSnapshotFixture.id,
-          snapshotName: 'test-snapshot',
         },
       },
     ] as { queryParams: Record<string, any> }[])(

--- a/src/import-data/useImportRequest.ts
+++ b/src/import-data/useImportRequest.ts
@@ -4,12 +4,7 @@ import { DataRepo, Snapshot } from 'src/libs/ajax/DataRepo';
 import { SamResources } from 'src/libs/ajax/SamResources';
 import { useRoute } from 'src/libs/nav';
 
-import {
-  FileImportRequest,
-  ImportRequest,
-  TDRSnapshotExportImportRequest,
-  TDRSnapshotReferenceImportRequest,
-} from './import-types';
+import { FileImportRequest, ImportRequest, TDRSnapshotExportImportRequest } from './import-types';
 
 type QueryParams = { [key: string]: unknown };
 
@@ -131,31 +126,6 @@ const getTDRSnapshotExportImportRequest = async (queryParams: QueryParams): Prom
   };
 };
 
-const getTDRSnapshotReferenceImportRequest = async (
-  queryParams: QueryParams
-): Promise<TDRSnapshotReferenceImportRequest> => {
-  const snapshotId = requireString(queryParams.snapshotId, 'snapshot ID');
-
-  let snapshot: Snapshot;
-  let snapshotAccessControls: string[];
-  try {
-    [snapshot, snapshotAccessControls] = await Promise.all([
-      DataRepo().snapshot(snapshotId).details(),
-      SamResources().getAuthDomains({ resourceTypeName: 'datasnapshot', resourceId: snapshotId }),
-    ]);
-  } catch (err: unknown) {
-    throw new Error('Unable to load snapshot.');
-  }
-
-  validateGcpSnapshot(snapshot);
-
-  return {
-    type: 'tdr-snapshot-reference',
-    snapshot,
-    snapshotAccessControls,
-  };
-};
-
 export const getImportRequest = (queryParams: QueryParams): Promise<ImportRequest> => {
   const format = getFormat(queryParams);
 
@@ -168,8 +138,6 @@ export const getImportRequest = (queryParams: QueryParams): Promise<ImportReques
       return Promise.resolve(getFileImportRequest(queryParams, 'entities'));
     case 'tdrexport':
       return getTDRSnapshotExportImportRequest(queryParams);
-    case 'snapshot':
-      return getTDRSnapshotReferenceImportRequest(queryParams);
     default:
       throw new Error(`Invalid format: ${format}`);
   }

--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -547,14 +547,6 @@ export const Workspaces = (signal?: AbortSignal) => ({
         return res.json();
       },
 
-      importSnapshot: async (snapshotId: string, name: string, description?: string) => {
-        const res = await fetchRawls(
-          `${root}/snapshots/v2`,
-          _.mergeAll([authOpts(), jsonBody({ snapshotId, name, description }), { signal, method: 'POST' }])
-        );
-        return res.json();
-      },
-
       importAttributes: (file: File) => {
         const formData = new FormData();
         formData.set('attributes', file);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-588

## Summary of changes:
Disables snapshot-by-reference imports in the `#import-data` flow.

### Why
We are removing the v2 snapshot APIs as part of decommissioning Workspace Manager.

### Testing strategy
Tested running locally

