### PR TITLE
[CORE-584] Show Linked NIH eRA Commons ID and Settings Link in Terra

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -25,5 +25,6 @@
   "terraDockerImageBucket": "terra-docker-image-documentation-dev",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_dev",
   "terraDeploymentEnv": "dev",
-  "cwdsUrlRoot": "https://cwds.dsde-dev.broadinstitute.org"
+  "cwdsUrlRoot": "https://cwds.dsde-dev.broadinstitute.org",
+  "nihAuthRoot": "https://authtest.nih.gov"
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -24,5 +24,6 @@
   "terraDockerImageBucket": "terra-docker-image-documentation-prod",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_prod",
   "terraDeploymentEnv": "prod",
-  "cwdsUrlRoot": "https://cwds.dsde-prod.broadinstitute.org"
+  "cwdsUrlRoot": "https://cwds.dsde-prod.broadinstitute.org",
+  "nihAuthRoot": "https://auth.nih.gov"
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -25,5 +25,6 @@
   "terraDockerImageBucket": "terra-docker-image-documentation-staging",
   "b2cBillingPolicy": "b2c_1a_signup_signin_billing_staging",
   "terraDeploymentEnv": "staging",
-  "cwdsUrlRoot": "https://cwds.dsde-staging.broadinstitute.org"
+  "cwdsUrlRoot": "https://cwds.dsde-staging.broadinstitute.org",
+  "nihAuthRoot": "https://authtest.nih.gov"
 }

--- a/src/libs/ajax/ExternalCredentials.ts
+++ b/src/libs/ajax/ExternalCredentials.ts
@@ -8,6 +8,7 @@ export interface EcmLinkAccountResponse {
   externalUserId: string;
   expirationTimestamp: Date;
   authenticated: boolean;
+  additionalProperties?: Record<string, string>;
 }
 export const ExternalCredentials = (signal?: AbortSignal) => (oAuth2Provider: OAuth2Provider) => {
   const { key: providerKey, queryParams, supportsAccessToken, supportsIdToken } = oAuth2Provider;
@@ -23,6 +24,7 @@ export const ExternalCredentials = (signal?: AbortSignal) => (oAuth2Provider: OA
           externalUserId: json.externalUserId,
           expirationTimestamp: new Date(json.expirationTimestamp),
           authenticated: json.authenticated,
+          additionalProperties: json.additionalProperties,
         };
       } catch (error: unknown) {
         if (error instanceof Response && error.status === 404) {
@@ -55,6 +57,7 @@ export const ExternalCredentials = (signal?: AbortSignal) => (oAuth2Provider: OA
         externalUserId: json.externalUserId,
         expirationTimestamp: new Date(json.expirationTimestamp),
         authenticated: json.authenticated,
+        additionalProperties: json.additionalProperties,
       };
     },
     unlinkAccount: async (): Promise<void> => {

--- a/src/profile/external-identities/OAuth2Account.test.tsx
+++ b/src/profile/external-identities/OAuth2Account.test.tsx
@@ -46,6 +46,14 @@ jest.mock(
   })
 );
 
+jest.mock('src/libs/ajax/User', () => ({
+  User: jest.fn(() => ({
+    getNihResources: jest.fn().mockResolvedValue({
+      datasetPermissions: [],
+    }),
+  })),
+}));
+
 const testAccessTokenProvider: OAuth2Provider = {
   key: 'github',
   name: 'Test Provider',
@@ -226,6 +234,100 @@ describe('OAuth2Account', () => {
       });
 
       expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+  describe('When the provider is a RAS provider', () => {
+    const rasProvider: OAuth2Provider = {
+      key: 'ras',
+      name: 'RAS Provider',
+      short: 'RAS',
+      queryParams: {
+        redirectUri: 'localhost/oauth_callback',
+      },
+      supportsAccessToken: true,
+      supportsIdToken: false,
+      isFence: false,
+    };
+
+    it('shows the eRA Commons ID when linked to RAS provider', async () => {
+      // Arrange
+      const linkStatus = {
+        externalUserId: 'testUser',
+        expirationTimestamp: new Date('2025-07-25T19:49:45.736+00:00'),
+        authenticated: true,
+        additionalProperties: {
+          era_user_id: 'testEraUser123',
+        },
+      };
+
+      authStore.update((state) => ({ ...state, oAuth2AccountStatus: { [rasProvider.key]: linkStatus } }));
+
+      // Act
+      await act(() => render(<OAuth2Account queryParams={{}} provider={rasProvider} />));
+
+      // Assert
+      screen.getByText('eRA Commons ID:');
+      screen.getByText('testEraUser123');
+      screen.getByText('Manage your linked identities');
+    });
+
+    it('shows "none" when eRA Commons ID is not available for RAS provider', async () => {
+      // Arrange
+      const linkStatus = {
+        externalUserId: 'testUser',
+        expirationTimestamp: new Date('2025-07-25T19:49:45.736+00:00'),
+        authenticated: true,
+        additionalProperties: {},
+      };
+
+      authStore.update((state) => ({ ...state, oAuth2AccountStatus: { [rasProvider.key]: linkStatus } }));
+
+      // Act
+      await act(() => render(<OAuth2Account queryParams={{}} provider={rasProvider} />));
+
+      // Assert
+      screen.getByText('eRA Commons ID:');
+      screen.getByText('none');
+    });
+
+    it('shows the external link to manage linked identities for RAS provider', async () => {
+      // Arrange
+      const linkStatus = {
+        externalUserId: 'testUser',
+        expirationTimestamp: new Date('2025-07-25T19:49:45.736+00:00'),
+        authenticated: true,
+        additionalProperties: {
+          era_user_id: 'testEraUser123',
+        },
+      };
+
+      authStore.update((state) => ({ ...state, oAuth2AccountStatus: { [rasProvider.key]: linkStatus } }));
+
+      // Act
+      await act(() => render(<OAuth2Account queryParams={{}} provider={rasProvider} />));
+
+      // Assert
+      const manageLink = screen.getByRole('link', { name: 'Manage your linked identities' });
+      expect(manageLink).toHaveAttribute('href', expect.stringContaining('/settings/profile/loadIdentities'));
+      expect(manageLink).toHaveAttribute('target', '_blank');
+    });
+
+    it('does not show the manage linked identities link for non-RAS providers', async () => {
+      // Arrange
+      const linkStatus = {
+        externalUserId: 'testUser',
+        expirationTimestamp: new Date('2025-07-25T19:49:45.736+00:00'),
+        authenticated: true,
+      };
+
+      authStore.update((state) => ({ ...state, oAuth2AccountStatus: { [testAccessTokenProvider.key]: linkStatus } }));
+
+      // Act
+      await act(() => render(<OAuth2Account queryParams={{}} provider={testAccessTokenProvider} />));
+
+      // Assert
+      expect(screen.queryByText('Manage your linked identities')).not.toBeInTheDocument();
+      expect(screen.queryByText('eRA Commons ID:')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -1,4 +1,4 @@
-import { InfoBox } from '@terra-ui-packages/components';
+import { ExternalLink, InfoBox } from '@terra-ui-packages/components';
 import _ from 'lodash/fp';
 import React, { useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
@@ -6,6 +6,7 @@ import { ExternalCredentials } from 'src/libs/ajax/ExternalCredentials';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { NihDatasetPermission, User } from 'src/libs/ajax/User';
 import colors from 'src/libs/colors';
+import { getConfig } from 'src/libs/config';
 import { withErrorReporting } from 'src/libs/error';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
@@ -68,10 +69,14 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
 
   const { oAuth2AccountStatus: storedOAuth2AccountStatus } = useStore(authStore);
 
-  const { externalUserId, expirationTimestamp } = storedOAuth2AccountStatus[provider.key] ?? {
+  const { externalUserId, expirationTimestamp, additionalProperties } = storedOAuth2AccountStatus[provider.key] ?? {
     externalUserId: undefined,
     expirationTimestamp: undefined,
+    additionalProperties: undefined,
   };
+  const eraUserId = additionalProperties?.era_user_id ?? 'none';
+  const nihSettingsPage = `${getConfig().nihAuthRoot}/settings/profile/loadIdentities`;
+
   const signal = useCancellation();
   const callbacks: Array<OAuth2Callback['name']> = ['oauth-callback', 'ecm-callback', 'fence-callback']; // ecm-callback is deprecated, but still needs to be supported
   const [isLinking, setIsLinking] = useState(
@@ -129,6 +134,15 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
               <span style={styles.idLink.linkDetailLabel}>Username:</span>
               {externalUserId}
             </div>
+            {isRASProvider && (
+              <div>
+                <span style={styles.idLink.linkDetailLabel}>eRA Commons ID:</span>
+                {eraUserId}
+                <span style={{ marginLeft: '0.5rem' }}>
+                  <ExternalLink href={nihSettingsPage}>Manage your linked identities</ExternalLink>
+                </span>
+              </div>
+            )}
             <div>
               <span style={styles.idLink.linkDetailLabel}>Link Expiration:</span>
               <span>{Utils.makeCompleteDate(expirationTimestamp)}</span>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-584

### What
- After this PR merges: https://github.com/DataBiosphere/terra-external-credentials-manager/pull/290
- Display the user’s linked eRA Commons ID in the Terra UI, under their preferred email.
- If no eRA Commons ID is linked, show "none".
- Add a direct link in Terra to the NIH “Linked Identities” settings page for easier account management.

### Why
- Users currently have no clear way to see if their NIH identity is linked or how to fix it. This update helps users check their linked identity directly in Terra and easily access the NIH page to manage their connections. It makes the process faster and reduces confusion.

### Testing strategy
- Unit Testing
  - Added Unit tests to cover the use-cases
- Manual Testing
  - Check that the eRA Commons ID shows up if it’s linked, or displays "none" if not.
  - Make sure the link goes to the correct NIH settings page (different URLs for dev/staging and prod).

### Screens

**Before**
<img width="1797" height="947" alt="Before" src="https://github.com/user-attachments/assets/fe6eb0b3-3247-4e2d-8a90-20e7d2c9d0ab" />

**After**
<img width="1797" height="947" alt="After" src="https://github.com/user-attachments/assets/79aef89e-4c5d-46a6-83f5-6907f2c4580b" />
