### PR TITLE
[CORE-561] Fix displaying NIH Resources for RAS Provider

### DIFF
--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -146,7 +146,7 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
           </>
         )}
       </div>
-      {isRASProvider && (
+      {externalUserId && isRASProvider && (
         <NihResources authorizedDatasets={authorizedDatasets} unauthorizedDatasets={unauthorizedDatasets} />
       )}
     </div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-561

### What 
- Fix displaying NIH Resources for RAS Provider when logged out

### Why
- Resources should only be displayed when users have been authenticated

### Testing Strategies
- Manual Testing: Ensured resources are only displayed when authenticated.

### Screens

**Before**
<img width="1660" height="947" alt="Before" src="https://github.com/user-attachments/assets/edfb5657-764f-4968-b314-76c28f867b15" />

**After**
<img width="1660" height="947" alt="After-Logged Out" src="https://github.com/user-attachments/assets/04111f26-4024-4d02-9c48-95a54fb4fca4" />

