### PR TITLE
AN-659 Temporarily disable memory retry

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -786,6 +786,8 @@ export const WorkflowView = _.flow(
         useCallCache,
         deleteIntermediateOutputFiles,
         useReferenceDisks,
+        // Memory Retry will return
+        // https://broadworkbench.atlassian.net/browse/AN-539
         // retryWithMoreMemory,
         // retryMemoryFactor,
         ignoreEmptyOutputs,

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -786,8 +786,8 @@ export const WorkflowView = _.flow(
         useCallCache,
         deleteIntermediateOutputFiles,
         useReferenceDisks,
-        retryWithMoreMemory,
-        retryMemoryFactor,
+        // retryWithMoreMemory,
+        // retryMemoryFactor,
         ignoreEmptyOutputs,
         enableResourceMonitoring,
         monitoringScript,
@@ -1102,60 +1102,63 @@ export const WorkflowView = _.flow(
                       h(Link, { href: this.getSupportLink('360056384631'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
                     ]),
                   ]),
-                  div([
-                    span({ style: styles.checkBoxSpanMargins }, [
-                      h(
-                        LabeledCheckbox,
-                        {
-                          checked: retryWithMoreMemory,
-                          onChange: (v) => this.setState({ retryWithMoreMemory: v }),
-                          style: styles.checkBoxLeftMargin,
-                        },
-                        [' Retry with more memory']
-                      ),
-                    ]),
-                    // We show either an info message or a warning, based on whether increasing memory on retries is
-                    // enabled and the value of the retry multiplier.
-                    retryWithMoreMemory && retryMemoryFactor > 2
-                      ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
-                          'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
-                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
-                        ])
-                      : h(InfoBox, [
-                          'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
-                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
-                        ]),
-                  ]),
-                  div([
-                    retryWithMoreMemory &&
-                      span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
-                        h(IdContainer, [
-                          (id) =>
-                            h(Fragment, [
-                              label(
-                                {
-                                  htmlFor: id,
-                                  style: { ...styles.label, verticalAlign: 'middle', marginLeft: '1.5rem' },
-                                },
-                                ['Memory factor:']
-                              ),
-                              div({ style: { display: 'inline-block', marginLeft: '0.5rem', height: '1.75rem', marginTop: '0.5rem' } }, [
-                                h(NumberInput, {
-                                  id,
-                                  min: 1.1,
-                                  max: 10,
-                                  step: 0.1,
-                                  isClearable: false,
-                                  onlyInteger: false,
-                                  value: retryMemoryFactor,
-                                  style: { fontSize: 12, width: '5rem' },
-                                  onChange: (v) => this.setState({ retryMemoryFactor: v }),
-                                }),
-                              ]),
-                            ]),
-                        ]),
-                      ]),
-                  ]),
+                  // Memory Retry will return
+                  // https://broadworkbench.atlassian.net/browse/AN-539
+                  //
+                  // div([
+                  //   span({ style: styles.checkBoxSpanMargins }, [
+                  //     h(
+                  //       LabeledCheckbox,
+                  //       {
+                  //         checked: retryWithMoreMemory,
+                  //         onChange: (v) => this.setState({ retryWithMoreMemory: v }),
+                  //         style: styles.checkBoxLeftMargin,
+                  //       },
+                  //       [' Retry with more memory']
+                  //     ),
+                  //   ]),
+                  //   // We show either an info message or a warning, based on whether increasing memory on retries is
+                  //   // enabled and the value of the retry multiplier.
+                  //   retryWithMoreMemory && retryMemoryFactor > 2
+                  //     ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
+                  //         'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
+                  //         h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                  //       ])
+                  //     : h(InfoBox, [
+                  //         'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
+                  //         h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                  //       ]),
+                  // ]),
+                  // div([
+                  //   retryWithMoreMemory &&
+                  //     span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
+                  //       h(IdContainer, [
+                  //         (id) =>
+                  //           h(Fragment, [
+                  //             label(
+                  //               {
+                  //                 htmlFor: id,
+                  //                 style: { ...styles.label, verticalAlign: 'middle', marginLeft: '1.5rem' },
+                  //               },
+                  //               ['Memory factor:']
+                  //             ),
+                  //             div({ style: { display: 'inline-block', marginLeft: '0.5rem', height: '1.75rem', marginTop: '0.5rem' } }, [
+                  //               h(NumberInput, {
+                  //                 id,
+                  //                 min: 1.1,
+                  //                 max: 10,
+                  //                 step: 0.1,
+                  //                 isClearable: false,
+                  //                 onlyInteger: false,
+                  //                 value: retryMemoryFactor,
+                  //                 style: { fontSize: 12, width: '5rem' },
+                  //                 onChange: (v) => this.setState({ retryMemoryFactor: v }),
+                  //               }),
+                  //             ]),
+                  //           ]),
+                  //       ]),
+                  //     ]),
+                  // ]),
                 ]),
                 span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
                   div([

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -786,7 +786,7 @@ export const WorkflowView = _.flow(
         useCallCache,
         deleteIntermediateOutputFiles,
         useReferenceDisks,
-        // Memory Retry will return
+        // Memory Retry may return
         // https://broadworkbench.atlassian.net/browse/AN-539
         // retryWithMoreMemory,
         // retryMemoryFactor,
@@ -1104,7 +1104,7 @@ export const WorkflowView = _.flow(
                       h(Link, { href: this.getSupportLink('360056384631'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
                     ]),
                   ]),
-                  // Memory Retry will return
+                  // Memory Retry may return
                   // https://broadworkbench.atlassian.net/browse/AN-539
                   //
                   // div([


### PR DESCRIPTION
Disable the memory retry control with a view to re-enable it in the future.

~Bike shedding~ Discussion opportunities:

- Comment out or delete the code
  - Normally I'm on team delete, but we do seem committed to bringing it back soon
- Leave an empty grid square or rearrange the checkboxes
  - Leave looks a bit silly [0] but I think it's better for muscle memory
- Leave or delete memory retry value in submission history
  - I went with leave [1], because users may still want to look at pre-disablement workflows

[0]
<img width="500" height="162" alt="Screenshot 2025-07-14 at 15 12 08" src="https://github.com/user-attachments/assets/333e48d4-ba72-44a9-ade1-1c3d118ce1ed" />

[1]
<img width="500" height="294" alt="Screenshot 2025-07-14 at 15 22 48" src="https://github.com/user-attachments/assets/f9c31ad9-86a3-463c-a3d0-740428c183a2" />


