### PR TITLE
CORE-564: workspace bucket size shows live vs. soft-deleted values

### DIFF
--- a/packages/components/src/InfoBox.tsx
+++ b/packages/components/src/InfoBox.tsx
@@ -12,16 +12,17 @@ export interface InfoBoxProps {
   size?: number;
   style?: CSSProperties;
   tooltip?: ReactNode;
+  label?: string;
 }
 
 export const InfoBox = (props: InfoBoxProps): ReactNode => {
-  const { children, icon = 'info-circle', side, size, style, tooltip } = props;
+  const { children, icon = 'info-circle', side, size, style, tooltip, label = 'More info' } = props;
 
   const { colors } = useThemeFromContext();
 
   return (
     <PopupTrigger content={<div style={{ padding: '0.5rem', width: 300 }}>{children}</div>} side={side}>
-      <Clickable aria-label='More info' tagName='span' tooltip={tooltip}>
+      <Clickable aria-label={label} tagName='span' tooltip={tooltip}>
         <Icon icon={icon} size={size} style={{ color: colors.accent(), cursor: 'pointer', ...style }} />
       </Clickable>
     </PopupTrigger>

--- a/packages/components/src/InfoBox.tsx
+++ b/packages/components/src/InfoBox.tsx
@@ -12,17 +12,16 @@ export interface InfoBoxProps {
   size?: number;
   style?: CSSProperties;
   tooltip?: ReactNode;
-  label?: string;
 }
 
 export const InfoBox = (props: InfoBoxProps): ReactNode => {
-  const { children, icon = 'info-circle', side, size, style, tooltip, label = 'More info' } = props;
+  const { children, icon = 'info-circle', side, size, style, tooltip } = props;
 
   const { colors } = useThemeFromContext();
 
   return (
     <PopupTrigger content={<div style={{ padding: '0.5rem', width: 300 }}>{children}</div>} side={side}>
-      <Clickable aria-label={label} tagName='span' tooltip={tooltip}>
+      <Clickable aria-label='More info' tagName='span' tooltip={tooltip}>
         <Icon icon={icon} size={size} style={{ color: colors.accent(), cursor: 'pointer', ...style }} />
       </Clickable>
     </PopupTrigger>

--- a/src/libs/ajax/workspaces/workspace-models.ts
+++ b/src/libs/ajax/workspaces/workspace-models.ts
@@ -234,6 +234,7 @@ export interface AttributeEntityReference {
 export interface StorageCostEstimate {
   estimate: number;
   usageInBytes: number;
+  usage: { [key: string]: number };
   lastUpdated?: string;
 }
 

--- a/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
+++ b/src/workspaces/DeleteWorkspaceModal/state/useDeleteWorkspaceState.test.ts
@@ -75,7 +75,7 @@ describe('useDeleteWorkspaceState', () => {
     asMockedFn(getAcl).mockResolvedValue({ acl: { 'example1@example.com': partial<RawAccessEntry>({}) } });
 
     const storageCostEstimateV2: WorkspaceContract['storageCostEstimateV2'] = jest.fn();
-    asMockedFn(storageCostEstimateV2).mockResolvedValue({ estimate: 0.02, usageInBytes: 1234 });
+    asMockedFn(storageCostEstimateV2).mockResolvedValue({ estimate: 0.02, usageInBytes: 1234, usage: {} });
 
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -87,6 +87,7 @@ describe('CloudInformation', () => {
     const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
       estimate: 1000000,
       usageInBytes: 100,
+      usage: {},
       lastUpdated: '2023-12-01',
     });
     asMockedFn(Workspaces).mockReturnValue(
@@ -178,6 +179,7 @@ describe('CloudInformation', () => {
     const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
       estimate: 2.0,
       usageInBytes: 15,
+      usage: {},
       lastUpdated: '2024-07-15',
     });
     asMockedFn(Workspaces).mockReturnValue(
@@ -210,7 +212,7 @@ describe('CloudInformation', () => {
     // Arrange
     const mockStorageCostEstimateV2 = jest
       .fn()
-      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, lastUpdated: '2024-07-26' });
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: {}, lastUpdated: '2024-07-26' });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -235,6 +235,106 @@ describe('CloudInformation', () => {
     expect(mockStorageCostEstimateV2).toHaveBeenCalled();
   });
 
+  it('displays an info button when the bucket has soft-deleted objects', async () => {
+    // Arrange
+    const usageByState = {
+      'live-object': 40,
+      'soft-deleted-object': 10,
+    };
+    const mockStorageCostEstimateV2 = jest
+      .fn()
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
+      })
+    );
+
+    // Act
+    await act(() =>
+      render(
+        h(CloudInformation, {
+          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
+          storageDetails,
+        })
+      )
+    );
+
+    // Assert
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Bucket Size Details/i)).toBeInTheDocument();
+  });
+
+  it('does not display an info button when the bucket does not have soft-deleted objects', async () => {
+    // Arrange
+    const usageByState = {
+      'live-object': 50,
+    };
+    const mockStorageCostEstimateV2 = jest
+      .fn()
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
+      })
+    );
+
+    // Act
+    await act(() =>
+      render(
+        h(CloudInformation, {
+          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
+          storageDetails,
+        })
+      )
+    );
+
+    // Assert
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Bucket Size Details/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the bucket size by storage state', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const usageByState = {
+      'live-object': 40,
+      'soft-deleted-object': 10,
+    };
+    const mockStorageCostEstimateV2 = jest
+      .fn()
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
+      })
+    );
+
+    // Act
+    await act(() =>
+      render(
+        h(CloudInformation, {
+          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
+          storageDetails,
+        })
+      )
+    );
+
+    // Assert
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
+    expect(screen.queryByLabelText(/Bucket Size Details/i)).toBeInTheDocument();
+
+    expect(screen.queryByText(/Live/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/40 B/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Soft Deleted/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/10 B/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Bucket Size Details'));
+
+    expect(screen.queryByLabelText(/Live: 40 B/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Soft Deleted: 10 B/i)).toBeInTheDocument();
+  });
+
   it('emits an event when the Open project in Google Cloud Console link is clicked', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -87,7 +87,9 @@ describe('CloudInformation', () => {
     const mockStorageCostEstimateV2 = jest.fn().mockResolvedValue({
       estimate: 1000000,
       usageInBytes: 100,
-      usage: {},
+      usage: {
+        'live-object': 100,
+      },
       lastUpdated: '2023-12-01',
     });
     asMockedFn(Workspaces).mockReturnValue(
@@ -113,7 +115,7 @@ describe('CloudInformation', () => {
     expect(screen.getAllByText('Updated on 12/1/2023')).not.toBeNull();
     expect(screen.getByText('$1,000,000.00')).not.toBeNull();
     // Bucket usage
-    expect(screen.getByText('100 B')).not.toBeNull();
+    expect(screen.getByText('100 B Live')).not.toBeNull();
 
     expect(mockStorageCostEstimateV2).toHaveBeenCalled();
   });
@@ -212,7 +214,7 @@ describe('CloudInformation', () => {
     // Arrange
     const mockStorageCostEstimateV2 = jest
       .fn()
-      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: {}, lastUpdated: '2024-07-26' });
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: { 'live-object': 50 }, lastUpdated: '2024-07-26' });
     asMockedFn(Workspaces).mockReturnValue(
       partial<WorkspacesAjaxContract>({
         workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
@@ -231,72 +233,12 @@ describe('CloudInformation', () => {
 
     // Assert
     expect(screen.getByText('Updated on 7/26/2024')).not.toBeNull();
-    expect(screen.getByText('50 B')).not.toBeNull();
+    expect(screen.getByText('50 B Live')).not.toBeNull();
     expect(mockStorageCostEstimateV2).toHaveBeenCalled();
-  });
-
-  it('displays an info button when the bucket has soft-deleted objects', async () => {
-    // Arrange
-    const usageByState = {
-      'live-object': 40,
-      'soft-deleted-object': 10,
-    };
-    const mockStorageCostEstimateV2 = jest
-      .fn()
-      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
-      })
-    );
-
-    // Act
-    await act(() =>
-      render(
-        h(CloudInformation, {
-          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
-          storageDetails,
-        })
-      )
-    );
-
-    // Assert
-    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
-    expect(screen.queryByLabelText(/Bucket Size Details/i)).toBeInTheDocument();
-  });
-
-  it('does not display an info button when the bucket does not have soft-deleted objects', async () => {
-    // Arrange
-    const usageByState = {
-      'live-object': 50,
-    };
-    const mockStorageCostEstimateV2 = jest
-      .fn()
-      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
-    asMockedFn(Workspaces).mockReturnValue(
-      partial<WorkspacesAjaxContract>({
-        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
-      })
-    );
-
-    // Act
-    await act(() =>
-      render(
-        h(CloudInformation, {
-          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
-          storageDetails,
-        })
-      )
-    );
-
-    // Assert
-    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
-    expect(screen.queryByLabelText(/Bucket Size Details/i)).not.toBeInTheDocument();
   });
 
   it('renders the bucket size by storage state', async () => {
     // Arrange
-    const user = userEvent.setup();
     const usageByState = {
       'live-object': 40,
       'soft-deleted-object': 10,
@@ -322,17 +264,8 @@ describe('CloudInformation', () => {
 
     // Assert
     expect(mockStorageCostEstimateV2).toHaveBeenCalled();
-    expect(screen.queryByLabelText(/Bucket Size Details/i)).toBeInTheDocument();
-
-    expect(screen.queryByText(/Live/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/40 B/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Soft Deleted/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/10 B/i)).not.toBeInTheDocument();
-
-    await user.click(screen.getByLabelText('Bucket Size Details'));
-
-    expect(screen.queryByLabelText(/Live: 40 B/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/Soft Deleted: 10 B/i)).toBeInTheDocument();
+    expect(screen.queryByText(/40 B Live/i)).toBeInTheDocument();
+    expect(screen.queryByText(/10 B Soft Deleted/i)).toBeInTheDocument();
   });
 
   it('emits an event when the Open project in Google Cloud Console link is clicked', async () => {

--- a/src/workspaces/dashboard/CloudInformation.test.ts
+++ b/src/workspaces/dashboard/CloudInformation.test.ts
@@ -268,6 +268,36 @@ describe('CloudInformation', () => {
     expect(screen.queryByText(/10 B Soft Deleted/i)).toBeInTheDocument();
   });
 
+  it('hides soft-deleted bucket size when no soft-deleted objects exist', async () => {
+    // Arrange
+    const usageByState = {
+      'live-object': 50,
+    };
+    const mockStorageCostEstimateV2 = jest
+      .fn()
+      .mockResolvedValue({ estimate: 1.23, usageInBytes: 50, usage: usageByState, lastUpdated: '2024-07-26' });
+    asMockedFn(Workspaces).mockReturnValue(
+      partial<WorkspacesAjaxContract>({
+        workspace: () => partial<WorkspaceContract>({ storageCostEstimateV2: mockStorageCostEstimateV2 }),
+      })
+    );
+
+    // Act
+    await act(() =>
+      render(
+        h(CloudInformation, {
+          workspace: { ...defaultGoogleWorkspace, workspaceInitialized: true, accessLevel: 'READER' },
+          storageDetails,
+        })
+      )
+    );
+
+    // Assert
+    expect(mockStorageCostEstimateV2).toHaveBeenCalled();
+    expect(screen.queryByText(/50 B Live/i)).toBeInTheDocument();
+    expect(screen.queryByText(/.*Soft Deleted/i)).not.toBeInTheDocument();
+  });
+
   it('emits an event when the Open project in Google Cloud Console link is clicked', async () => {
     // Arrange
     const user = userEvent.setup();

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -247,10 +247,23 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           [
             bucketSize?.usageInBytes,
             bucketSizeByState !== undefined &&
-              h(InfoBox, { style: { marginLeft: '1ch' }, side: 'top' }, [
-                'Here is some intro text to explain storage states:',
-                Object.entries(bucketSizeByState).map(([key, value]) => h(InfoRow, { title: key }, [value])),
-              ]),
+              h(
+                InfoBox,
+                {
+                  key: 'bucketSizeInfoBox',
+                  style: { marginLeft: '1ch' },
+                  side: 'top',
+                  label: 'Bucket Size Details',
+                },
+                [
+                  Object.entries(bucketSizeByState).map(([key, value]) =>
+                    h(InfoRow, { title: key }, [span({ 'aria-label': `${key}: ${value}` }, [value])])
+                  ),
+                  div({ style: { padding: '0.5rem', fontStyle: 'italic' } }, [
+                    'Data storage fees apply to objects during their retention period.',
+                  ]),
+                ]
+              ),
           ]
         ),
     ]),

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -250,14 +250,13 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               h(
                 InfoBox,
                 {
-                  key: 'bucketSizeInfoBox',
                   style: { marginLeft: '1ch' },
                   side: 'top',
                   label: 'Bucket Size Details',
                 },
                 [
                   Object.entries(bucketSizeByState).map(([key, value]) =>
-                    h(InfoRow, { title: key }, [span({ 'aria-label': `${key}: ${value}` }, [value])])
+                    h(InfoRow, { key, title: key }, [span({ 'aria-label': `${key}: ${value}` }, [value])])
                   ),
                   div({ style: { padding: '0.5rem', fontStyle: 'italic' } }, [
                     'Data storage fees apply to objects during their retention period.',

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -91,22 +91,39 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
   const signal = useCancellation();
 
   const [storageCost, setStorageCost] = useState<{ isSuccess: boolean; estimate: string; lastUpdated?: string }>();
-  const [bucketSize, setBucketSize] = useState<{ isSuccess: boolean; usageInBytes: string; lastUpdated?: string }>();
+  const [bucketSize, setBucketSize] = useState<{
+    isSuccess: boolean;
+    usageInBytes: string;
+    usage: { [key: string]: number };
+    lastUpdated?: string;
+  }>();
+  const [bucketSizeByState, setBucketSizeByState] = useState<{ [key: string]: string }>();
 
   useEffect(() => {
     const { namespace, name } = workspace.workspace;
 
     const loadStorageCost = withErrorReporting('Error loading storage cost data')(async () => {
       try {
-        const { estimate, usageInBytes, lastUpdated } = await Workspaces(signal)
+        const { estimate, usageInBytes, usage, lastUpdated } = await Workspaces(signal)
           .workspace(namespace, name)
           .storageCostEstimateV2();
         setStorageCost({ isSuccess: true, estimate: formatUSD(estimate), lastUpdated });
-        setBucketSize({ isSuccess: true, usageInBytes: formatBytes(usageInBytes), lastUpdated });
+        setBucketSize({ isSuccess: true, usageInBytes: formatBytes(usageInBytes), usage, lastUpdated });
+        // We will only display the sizes-by-state if the usage contains any state other than "live-object"
+        const showStates = Object.keys(usage).filter((key) => key !== 'live-object').length > 0;
+        // Format the sizes-by-state for display
+        const sizesByState = !showStates
+          ? undefined
+          : (Object.fromEntries(
+              Object.entries(usage).map(([key, value]) => {
+                return [key, formatBytes(value)];
+              })
+            ) as { [key: string]: string });
+        setBucketSizeByState(sizesByState);
       } catch (error) {
         if (error instanceof Response && error.status === 404) {
           setStorageCost({ isSuccess: false, estimate: 'Not available' });
-          setBucketSize({ isSuccess: false, usageInBytes: 'Not available' });
+          setBucketSize({ isSuccess: false, usageInBytes: 'Not available', usage: {} });
         } else {
           throw error;
         }
@@ -211,7 +228,15 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               ]
             ),
           },
-          [bucketSize?.usageInBytes]
+          [
+            bucketSize?.usageInBytes,
+            bucketSizeByState !== undefined &&
+              h(
+                InfoBox,
+                { style: { marginLeft: '1ch' }, side: 'top' },
+                Object.entries(bucketSizeByState).map(([key, value]) => [`${key}: ${value}`, h(br)])
+              ),
+          ]
         ),
     ]),
     div({ style: { paddingBottom: '0.5rem' } }, [

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -13,8 +13,8 @@ import { withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
 import { getTerraUser } from 'src/libs/state';
-import { formatBytes, newTabLinkProps } from 'src/libs/utils';
 import * as Utils from 'src/libs/utils';
+import { formatBytes, newTabLinkProps } from 'src/libs/utils';
 import { InitializedWorkspaceWrapper as Workspace, StorageDetails } from 'src/workspaces/common/state/useWorkspace';
 import { AzureStorageDetails } from 'src/workspaces/dashboard/AzureStorageDetails';
 import { BucketLocation } from 'src/workspaces/dashboard/BucketLocation';
@@ -91,7 +91,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
   const signal = useCancellation();
 
   const [storageCost, setStorageCost] = useState<{ isSuccess: boolean; estimate: string; lastUpdated?: string }>();
-  const [bucketSize, setBucketSize] = useState<{ isSuccess: boolean; usage: string; lastUpdated?: string }>();
+  const [bucketSize, setBucketSize] = useState<{ isSuccess: boolean; usageInBytes: string; lastUpdated?: string }>();
 
   useEffect(() => {
     const { namespace, name } = workspace.workspace;
@@ -102,11 +102,11 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           .workspace(namespace, name)
           .storageCostEstimateV2();
         setStorageCost({ isSuccess: true, estimate: formatUSD(estimate), lastUpdated });
-        setBucketSize({ isSuccess: true, usage: formatBytes(usageInBytes), lastUpdated });
+        setBucketSize({ isSuccess: true, usageInBytes: formatBytes(usageInBytes), lastUpdated });
       } catch (error) {
         if (error instanceof Response && error.status === 404) {
           setStorageCost({ isSuccess: false, estimate: 'Not available' });
-          setBucketSize({ isSuccess: false, usage: 'Not available' });
+          setBucketSize({ isSuccess: false, usageInBytes: 'Not available' });
         } else {
           throw error;
         }
@@ -211,7 +211,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               ]
             ),
           },
-          [bucketSize?.usage]
+          [bucketSize?.usageInBytes]
         ),
     ]),
     div({ style: { paddingBottom: '0.5rem' } }, [

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -83,6 +83,22 @@ const AzureCloudInformation = (props: AzureCloudInformationProps): ReactNode => 
   ]);
 };
 
+const storageStateDisplayName = (rawState: string): string => {
+  switch (rawState) {
+    case 'live-object':
+      return 'Live';
+    case 'soft-deleted-object':
+      return 'Soft Deleted';
+    // we do not expect to see noncurrent-object or multipart-upload in Terra
+    case 'noncurrent-object':
+      return 'Object Version';
+    case 'multipart-upload':
+      return 'Multipart Upload';
+    default:
+      return rawState;
+  }
+};
+
 const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode => {
   const { workspace, storageDetails } = props;
   const { accessLevel } = workspace;
@@ -116,7 +132,7 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           ? undefined
           : (Object.fromEntries(
               Object.entries(usage).map(([key, value]) => {
-                return [key, formatBytes(value)];
+                return [storageStateDisplayName(key), formatBytes(value)];
               })
             ) as { [key: string]: string });
         setBucketSizeByState(sizesByState);
@@ -231,11 +247,10 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
           [
             bucketSize?.usageInBytes,
             bucketSizeByState !== undefined &&
-              h(
-                InfoBox,
-                { style: { marginLeft: '1ch' }, side: 'top' },
-                Object.entries(bucketSizeByState).map(([key, value]) => [`${key}: ${value}`, h(br)])
-              ),
+              h(InfoBox, { style: { marginLeft: '1ch' }, side: 'top' }, [
+                'Here is some intro text to explain storage states:',
+                Object.entries(bucketSizeByState).map(([key, value]) => h(InfoRow, { title: key }, [value])),
+              ]),
           ]
         ),
     ]),

--- a/src/workspaces/dashboard/CloudInformation.ts
+++ b/src/workspaces/dashboard/CloudInformation.ts
@@ -109,37 +109,32 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
   const [storageCost, setStorageCost] = useState<{ isSuccess: boolean; estimate: string; lastUpdated?: string }>();
   const [bucketSize, setBucketSize] = useState<{
     isSuccess: boolean;
-    usageInBytes: string;
-    usage: { [key: string]: number };
+    usageByState: { [key: string]: string };
     lastUpdated?: string;
   }>();
-  const [bucketSizeByState, setBucketSizeByState] = useState<{ [key: string]: string }>();
 
   useEffect(() => {
     const { namespace, name } = workspace.workspace;
 
     const loadStorageCost = withErrorReporting('Error loading storage cost data')(async () => {
       try {
-        const { estimate, usageInBytes, usage, lastUpdated } = await Workspaces(signal)
+        const { estimate, usage, lastUpdated } = await Workspaces(signal)
           .workspace(namespace, name)
           .storageCostEstimateV2();
-        setStorageCost({ isSuccess: true, estimate: formatUSD(estimate), lastUpdated });
-        setBucketSize({ isSuccess: true, usageInBytes: formatBytes(usageInBytes), usage, lastUpdated });
-        // We will only display the sizes-by-state if the usage contains any state other than "live-object"
-        const showStates = Object.keys(usage).filter((key) => key !== 'live-object').length > 0;
+
         // Format the sizes-by-state for display
-        const sizesByState = !showStates
-          ? undefined
-          : (Object.fromEntries(
-              Object.entries(usage).map(([key, value]) => {
-                return [storageStateDisplayName(key), formatBytes(value)];
-              })
-            ) as { [key: string]: string });
-        setBucketSizeByState(sizesByState);
+        const sizesByState = Object.fromEntries(
+          Object.entries(usage).map(([key, value]) => {
+            return [storageStateDisplayName(key), formatBytes(value)];
+          })
+        ) as { [key: string]: string };
+
+        setStorageCost({ isSuccess: true, estimate: formatUSD(estimate), lastUpdated });
+        setBucketSize({ isSuccess: true, usageByState: sizesByState, lastUpdated });
       } catch (error) {
         if (error instanceof Response && error.status === 404) {
           setStorageCost({ isSuccess: false, estimate: 'Not available' });
-          setBucketSize({ isSuccess: false, usageInBytes: 'Not available', usage: {} });
+          setBucketSize({ isSuccess: false, usageByState: { 'Not available': '' } });
         } else {
           throw error;
         }
@@ -244,26 +239,9 @@ const GoogleCloudInformation = (props: GoogleCloudInformationProps): ReactNode =
               ]
             ),
           },
-          [
-            bucketSize?.usageInBytes,
-            bucketSizeByState !== undefined &&
-              h(
-                InfoBox,
-                {
-                  style: { marginLeft: '1ch' },
-                  side: 'top',
-                  label: 'Bucket Size Details',
-                },
-                [
-                  Object.entries(bucketSizeByState).map(([key, value]) =>
-                    h(InfoRow, { key, title: key }, [span({ 'aria-label': `${key}: ${value}` }, [value])])
-                  ),
-                  div({ style: { padding: '0.5rem', fontStyle: 'italic' } }, [
-                    'Data storage fees apply to objects during their retention period.',
-                  ]),
-                ]
-              ),
-          ]
+          !bucketSize?.usageByState
+            ? []
+            : Object.entries(bucketSize.usageByState).map(([key, value]) => [`${value} ${key}`, br({ key })])
         ),
     ]),
     div({ style: { paddingBottom: '0.5rem' } }, [

--- a/src/workspaces/migration/WorkspaceItem.test.ts
+++ b/src/workspaces/migration/WorkspaceItem.test.ts
@@ -46,7 +46,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234, usage: {} }),
           }),
       })
     );
@@ -72,7 +72,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234, usage: {} }),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({
@@ -112,7 +112,7 @@ describe('WorkspaceItem', () => {
       partial<WorkspacesAjaxContract>({
         workspace: () =>
           partial<WorkspaceContract>({
-            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234 }),
+            storageCostEstimateV2: async () => ({ estimate: 1.23, usageInBytes: 1234, usage: {} }),
           }),
         workspaceV2: () =>
           partial<WorkspaceV2Contract>({


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-564

## Summary of changes:
The "Cloud Information" section of the workspace dashboard now displays the size of data in the bucket by live vs. soft-deleted objects.

### Why
Previously, the bucket size display was a single value: the total of live + soft-deleted objects. This was confusing for users who had a significant amount of soft-deleted data, as the total reported by Terra did not match what they saw in their bucket (since soft-deleted objects are hidden by default)

### Testing strategy
- [ ] Tested running locally

### Visual Aids

A workspace with no soft-deleted objects (only displays live objects):
<img width="1044" height="718" alt="Screenshot 24-07-2025 at 10 00" src="https://github.com/user-attachments/assets/243c47d3-fec8-4f56-a576-2ce05299b680" />

A workspace with soft-deleted objects (displays both live and soft-deleted):
<img width="1048" height="720" alt="Screenshot 24-07-2025 at 10 00 (1)" src="https://github.com/user-attachments/assets/6446324a-0f25-4ef9-b7c4-28e5d1dbc8cb" />






