### PR TITLE
[CORE-558] Wrap long EntityNames for better readability

### DIFF
--- a/packages/components/src/TooltipTrigger.tsx
+++ b/packages/components/src/TooltipTrigger.tsx
@@ -19,6 +19,8 @@ const styles = {
     boxShadow: '0 1px 3px 2px rgba(0,0,0,0.3)',
     lineHeight: 1.5,
     pointerEvents: 'none',
+    whiteSpace: 'pre-line',
+    wordBreak: 'break-word',
   },
   notch: {
     position: 'absolute',

--- a/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
+++ b/src/pages/workspaces/workspace/submissionHistory/SubmissionDetails.js
@@ -468,6 +468,9 @@ const SubmissionDetails = _.flow(
    */
   const hasWorkflowCostEstimates = _.some((w) => !('costType' in w) || w.costType === 'Estimated', workflows);
 
+  // Style for text wrapping
+  const wrapStyle = { whiteSpace: 'normal', overflowWrap: 'break-word' };
+
   /*
    * Page render
    */
@@ -553,7 +556,7 @@ const SubmissionDetails = _.flow(
               makeSection('Total Run Cost', [
                 typeof cost === 'number' ? `${Utils.formatUSD(cost)} ${hasWorkflowCostEstimates ? 'Estimated' : 'Actual'} cost` : 'N/A',
               ]),
-              makeSection('Data Entity', [div([entityName]), div([entityType])]),
+              makeSection('Data Entity', [div({ style: wrapStyle }, [entityName]), div({ style: wrapStyle }, [entityType])]),
               makeSection('Submission ID', [
                 h(Link, { href: bucketBrowserUrl(submissionRoot.replace('gs://', '')), ...Utils.newTabLinkProps }, submissionId),
                 h(ClipboardButton, {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-558

### What
- This update ensures long EntityNames wrap instead of getting cut off in the following areas:
  - Submission Details > Data Entity field
  - Submission Details > Data Entity tooltip
  - Data Tab > Table Name tooltip

### Why
- Long names were being truncated, making it hard to read and troubleshoot. Wrapping the text improves visibility and usability.

### Testing strategy
- Manual Testing: 
  - Manually verified wrapping behavior in all affected UI areas
  - Checked that normal-length names still display correctly

### Screens

<table>
<tr><td>**Before**</td><td>**After**</td></tr>
<tr>
<td>
<img width="1013" height="551" alt="Before-Data" src="https://github.com/user-attachments/assets/c9eb57bb-a315-4685-b32b-db699612b7e9" />
</td>
<td>
<img width="1770" height="960" alt="After-Data" src="https://github.com/user-attachments/assets/5f6b4603-f6fe-479f-8880-b66085330a02" />
</td>
</tr>
<tr>
<td>
<img width="1772" height="961" alt="Before-SubmissionDetail" src="https://github.com/user-attachments/assets/cca3e6bc-da4f-4485-9bbf-794e10fd81a8" />
</td>
<td>
<img width="1772" height="961" alt="After-SubmissionDetail" src="https://github.com/user-attachments/assets/004c3e60-3e23-4b42-a702-8b4982907da5" />
</td>
</tr>
<tr>
<td>
<img width="1038" height="556" alt="Before-SubmissionPopup" src="https://github.com/user-attachments/assets/d6a7bf3b-5a04-4fc8-ad2e-2ec5e7505778" />
</td>
<td>
<img width="1038" height="556" alt="After-SubmissionPopup" src="https://github.com/user-attachments/assets/918b6f01-e4fd-4e18-9d4b-0e0d97657265" />
</td>
</tr>
</table>