### PR TITLE
[CORE-566] Add option to get workspace by Google Project Id to the support page

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -96,6 +96,11 @@ export const Workspaces = (signal?: AbortSignal) => ({
     return res.json();
   },
 
+  adminGetByGoogleProjectId: async (googleProjectId: string): Promise<SupportSummary> => {
+    const res = await fetchRawls(`admin/workspaces/googleProject/${googleProjectId}`, _.merge(authOpts(), { signal }));
+    return res.json();
+  },
+
   adminGetId: async (namespace: string, name: string): Promise<string> => {
     const res = await fetchRawls(`admin/workspaces/${namespace}/${name}/id`, _.merge(authOpts(), { signal }));
     return res.json();

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -24,6 +24,7 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
   React.useEffect(() => {
     setResourceId('');
     setLookupValue('');
+    setGoogleProjectId('');
   }, [props.fqResourceId.resourceTypeName]);
 
   // the resourceType may be configured to skip policy retrieval/display
@@ -143,13 +144,13 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
           </ButtonPrimary>
         </div>
 
-        {currentResourceType?.loadSupportSummaryByGoogleProjectId && (
+        {currentResourceType?.lookupByGoogleProjectPlaceHolder && (
           <div style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1, marginBottom: '0.5rem' }}>
             <div style={{ fontWeight: 500 }}>or</div>
           </div>
         )}
 
-        {currentResourceType?.loadSupportSummaryByGoogleProjectId && (
+        {currentResourceType?.lookupByGoogleProjectPlaceHolder && (
           <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
             <TextInput
               style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1 }}
@@ -159,7 +160,7 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
                 if (e.key === 'Enter') {
                   setIsGoogleProjectLookup(true);
 
-                  submit();
+                  submit(googleProjectId);
                 }
               }}
               value={googleProjectId}
@@ -168,7 +169,7 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
               onClick={() => {
                 setIsGoogleProjectLookup(true);
 
-                submit();
+                submit(googleProjectId);
               }}
             >
               Load By {currentResourceType.lookupByGoogleProjectPlaceHolder}

--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -13,6 +13,8 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
   const { query } = Nav.useRoute();
   const [resourceId, setResourceId] = useState<string>(props.fqResourceId.resourceId);
   const [lookupValue, setLookupValue] = useState<string>('');
+  const [googleProjectId, setGoogleProjectId] = useState<string>('');
+  const [isGoogleProjectLookup, setIsGoogleProjectLookup] = useState<boolean>(false);
 
   function submit(overrideResourceId?: string) {
     Nav.updateSearch({ ...query, resourceId: overrideResourceId || resourceId || undefined });
@@ -33,6 +35,31 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
     (res) => res.resourceType === props.fqResourceId.resourceTypeName,
     supportResources
   );
+
+  const supportSummaryProps: ResourceTypeSummaryProps = React.useMemo(() => {
+    if (isGoogleProjectLookup && googleProjectId) {
+      // Override loadSupportSummaryFn to use Google Project ID lookup
+      return {
+        ...props,
+        fqResourceId: { resourceId: googleProjectId, resourceTypeName: props.fqResourceId.resourceTypeName },
+        loadSupportSummaryFn: currentResourceType?.loadSupportSummaryByGoogleProjectId
+          ? () => currentResourceType.loadSupportSummaryByGoogleProjectId!(googleProjectId)
+          : undefined,
+      };
+    }
+    // Default behavior for workspace ID lookup
+    return {
+      ...props,
+      fqResourceId: { resourceId, resourceTypeName: props.fqResourceId.resourceTypeName },
+    };
+  }, [props, resourceId, googleProjectId, isGoogleProjectLookup, currentResourceType]);
+
+  // event hook to clear the resourceId when resourceType changes
+  React.useEffect(() => {
+    setResourceId('');
+    setLookupValue('');
+    setGoogleProjectId('');
+  }, [props.fqResourceId.resourceTypeName]);
 
   // Handle lookup when the resource type has a lookupResourceId function
   const handleLookup = async () => {
@@ -100,15 +127,56 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
+                setIsGoogleProjectLookup(false);
                 submit();
               }
             }}
             value={resourceId}
           />
-          <ButtonPrimary onClick={() => submit()}>Load By ID</ButtonPrimary>
+          <ButtonPrimary
+            onClick={() => {
+              setIsGoogleProjectLookup(false);
+              submit();
+            }}
+          >
+            Load By ID
+          </ButtonPrimary>
         </div>
+
+        {currentResourceType?.loadSupportSummaryByGoogleProjectId && (
+          <div style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1, marginBottom: '0.5rem' }}>
+            <div style={{ fontWeight: 500 }}>or</div>
+          </div>
+        )}
+
+        {currentResourceType?.loadSupportSummaryByGoogleProjectId && (
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.5rem' }}>
+            <TextInput
+              style={{ marginRight: '0.5rem', marginLeft: '1rem', flex: 1 }}
+              placeholder={`Enter ${currentResourceType.lookupByGoogleProjectPlaceHolder}`}
+              onChange={setGoogleProjectId}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  setIsGoogleProjectLookup(true);
+
+                  submit();
+                }
+              }}
+              value={googleProjectId}
+            />
+            <ButtonPrimary
+              onClick={() => {
+                setIsGoogleProjectLookup(true);
+
+                submit();
+              }}
+            >
+              Load By {currentResourceType.lookupByGoogleProjectPlaceHolder}
+            </ButtonPrimary>
+          </div>
+        )}
       </div>
-      {!!props.loadSupportSummaryFn && <SupportSummary {...props} />}
+      {!!supportSummaryProps.loadSupportSummaryFn && <SupportSummary {...supportSummaryProps} />}
       {displayPolicies && <ResourcePolicies {...props} />}
     </>
   );

--- a/src/support/SupportResourceType.ts
+++ b/src/support/SupportResourceType.ts
@@ -20,6 +20,7 @@ export interface SupportResourceType {
   skipPolicies?: boolean;
   lookupResourceIdFn?: (value: string) => Promise<FullyQualifiedResourceId>;
   lookupResourceIdBoxPlaceholder?: string;
+  lookupByGoogleProjectPlaceHolder?: string;
 }
 
 // Define the supported resources, add your own here
@@ -43,6 +44,7 @@ export const supportResources: SupportResourceType[] = [
       return fqResourceId;
     },
     lookupResourceIdBoxPlaceholder: 'Namespace/Name',
+    lookupByGoogleProjectPlaceHolder: 'Google Project Id',
   },
   {
     displayName: 'Billing Project',

--- a/src/support/SupportResourceType.ts
+++ b/src/support/SupportResourceType.ts
@@ -21,6 +21,7 @@ export interface SupportResourceType {
   lookupResourceIdFn?: (value: string) => Promise<FullyQualifiedResourceId>;
   lookupResourceIdBoxPlaceholder?: string;
   lookupByGoogleProjectPlaceHolder?: string;
+  loadSupportSummaryByGoogleProjectId?: (id: string) => Promise<SupportSummary>;
 }
 
 // Define the supported resources, add your own here
@@ -45,6 +46,7 @@ export const supportResources: SupportResourceType[] = [
     },
     lookupResourceIdBoxPlaceholder: 'Namespace/Name',
     lookupByGoogleProjectPlaceHolder: 'Google Project Id',
+    loadSupportSummaryByGoogleProjectId: (id: string) => Workspaces().adminGetByGoogleProjectId(id),
   },
   {
     displayName: 'Billing Project',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-566

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Uses the new rawls `getWorkspaceByGoogleProjectId` admin API to allow support to search for workspaces by GoogleProjectId.  Adds a third option on the workspace page.  Now support can search by workspace id, namespace/name OR google project id.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
