### PR TITLE
AN-703 Re-release "retry with more memory" behind a feature flag

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -88,7 +88,8 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
   {
     id: WORKFLOW_RETRY_WITH_MORE_MEMORY,
     title: 'Retry Workflow Tasks with More Memory',
-    description: 'Opt-in to enable access to the Retry with More Memory workflow submission setting.',
+    description:
+      'Opt-in to enable access to the Retry with More Memory workflow submission setting. This setting currently works best for Java tasks that are killed by the JVM when using too much memory, see the documentation for more details.',
     feedbackUrl: `mailto:dsp-analysis@broadinstitute.org?subject=${encodeURIComponent(
       'Retry with More Memory Feedback'
     )}`,

--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -3,6 +3,7 @@ export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const COHORT_BUILDER_CARD = 'cohortBuilderCard';
 export const RAS_PROVIDER = 'rasProvider';
 export const IMPROVED_DATA_TABLES = 'improvedDataTables';
+export const WORKFLOW_RETRY_WITH_MORE_MEMORY = 'retryWithMoreMemory';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -83,6 +84,17 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Support for Improved Data Table Performance'
     )}`,
     lastUpdated: '7/10/2025',
+  },
+  {
+    id: WORKFLOW_RETRY_WITH_MORE_MEMORY,
+    title: 'Retry Workflow Tasks with More Memory',
+    description: 'Opt-in to enable access to the Retry with More Memory workflow submission setting.',
+    feedbackUrl: `mailto:dsp-analysis@broadinstitute.org?subject=${encodeURIComponent(
+      'Retry with More Memory Feedback'
+    )}`,
+    documentationUrl:
+      'https://support.terra.bio/hc/en-us/articles/39412460844699-Automatically-retrying-workflows-with-more-memory',
+    lastUpdated: '8/8/2025',
   },
 ];
 

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -786,10 +786,8 @@ export const WorkflowView = _.flow(
         useCallCache,
         deleteIntermediateOutputFiles,
         useReferenceDisks,
-        // Memory Retry may return
-        // https://broadworkbench.atlassian.net/browse/AN-539
-        // retryWithMoreMemory,
-        // retryMemoryFactor,
+        retryWithMoreMemory,
+        retryMemoryFactor,
         ignoreEmptyOutputs,
         enableResourceMonitoring,
         monitoringScript,
@@ -1104,63 +1102,60 @@ export const WorkflowView = _.flow(
                       h(Link, { href: this.getSupportLink('360056384631'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
                     ]),
                   ]),
-                  // Memory Retry may return
-                  // https://broadworkbench.atlassian.net/browse/AN-539
-                  //
-                  // div([
-                  //   span({ style: styles.checkBoxSpanMargins }, [
-                  //     h(
-                  //       LabeledCheckbox,
-                  //       {
-                  //         checked: retryWithMoreMemory,
-                  //         onChange: (v) => this.setState({ retryWithMoreMemory: v }),
-                  //         style: styles.checkBoxLeftMargin,
-                  //       },
-                  //       [' Retry with more memory']
-                  //     ),
-                  //   ]),
-                  //   // We show either an info message or a warning, based on whether increasing memory on retries is
-                  //   // enabled and the value of the retry multiplier.
-                  //   retryWithMoreMemory && retryMemoryFactor > 2
-                  //     ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
-                  //         'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
-                  //         h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
-                  //       ])
-                  //     : h(InfoBox, [
-                  //         'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
-                  //         h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
-                  //       ]),
-                  // ]),
-                  // div([
-                  //   retryWithMoreMemory &&
-                  //     span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
-                  //       h(IdContainer, [
-                  //         (id) =>
-                  //           h(Fragment, [
-                  //             label(
-                  //               {
-                  //                 htmlFor: id,
-                  //                 style: { ...styles.label, verticalAlign: 'middle', marginLeft: '1.5rem' },
-                  //               },
-                  //               ['Memory factor:']
-                  //             ),
-                  //             div({ style: { display: 'inline-block', marginLeft: '0.5rem', height: '1.75rem', marginTop: '0.5rem' } }, [
-                  //               h(NumberInput, {
-                  //                 id,
-                  //                 min: 1.1,
-                  //                 max: 10,
-                  //                 step: 0.1,
-                  //                 isClearable: false,
-                  //                 onlyInteger: false,
-                  //                 value: retryMemoryFactor,
-                  //                 style: { fontSize: 12, width: '5rem' },
-                  //                 onChange: (v) => this.setState({ retryMemoryFactor: v }),
-                  //               }),
-                  //             ]),
-                  //           ]),
-                  //       ]),
-                  //     ]),
-                  // ]),
+                  div([
+                    span({ style: styles.checkBoxSpanMargins }, [
+                      h(
+                        LabeledCheckbox,
+                        {
+                          checked: retryWithMoreMemory,
+                          onChange: (v) => this.setState({ retryWithMoreMemory: v }),
+                          style: styles.checkBoxLeftMargin,
+                        },
+                        [' Retry with more memory']
+                      ),
+                    ]),
+                    // We show either an info message or a warning, based on whether increasing memory on retries is
+                    // enabled and the value of the retry multiplier.
+                    retryWithMoreMemory && retryMemoryFactor > 2
+                      ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
+                          'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
+                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                        ])
+                      : h(InfoBox, [
+                          'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
+                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                        ]),
+                  ]),
+                  div([
+                    retryWithMoreMemory &&
+                      span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
+                        h(IdContainer, [
+                          (id) =>
+                            h(Fragment, [
+                              label(
+                                {
+                                  htmlFor: id,
+                                  style: { ...styles.label, verticalAlign: 'middle', marginLeft: '1.5rem' },
+                                },
+                                ['Memory factor:']
+                              ),
+                              div({ style: { display: 'inline-block', marginLeft: '0.5rem', height: '1.75rem', marginTop: '0.5rem' } }, [
+                                h(NumberInput, {
+                                  id,
+                                  min: 1.1,
+                                  max: 10,
+                                  step: 0.1,
+                                  isClearable: false,
+                                  onlyInteger: false,
+                                  value: retryMemoryFactor,
+                                  style: { fontSize: 12, width: '5rem' },
+                                  onChange: (v) => this.setState({ retryMemoryFactor: v }),
+                                }),
+                              ]),
+                            ]),
+                        ]),
+                      ]),
+                  ]),
                 ]),
                 span({ style: { marginTop: '0.5rem', marginBottom: '0.5rem' } }, [
                   div([

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -36,6 +36,8 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import colors, { terraSpecial } from 'src/libs/colors';
 import { reportError, withErrorReporting } from 'src/libs/error';
 import Events, { extractWorkspaceDetails } from 'src/libs/events';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { WORKFLOW_RETRY_WITH_MORE_MEMORY } from 'src/libs/feature-previews-config';
 import { HiddenLabel } from 'src/libs/forms';
 import * as Nav from 'src/libs/nav';
 import { getLocalPref, setLocalPref } from 'src/libs/prefs';
@@ -373,14 +375,17 @@ export const WorkflowView = _.flow(
       const resourceMonitoringPref = workflowOptionsPref?.resourceMonitoring;
       const resourceMonitoringEnabledPref = resourceMonitoringPref?.enabled;
 
+      const retryWithMoreMemorySettingEnabledFlag = isFeaturePreviewEnabled(WORKFLOW_RETRY_WITH_MORE_MEMORY);
+
       this.state = {
         activeTab: 'inputs',
         entitySelectionModel: { selectedEntities: {} },
         useCallCache: workflowOptionsPref && 'useCallCache' in workflowOptionsPref ? workflowOptionsPref.useCallCache : true,
         deleteIntermediateOutputFiles: workflowOptionsPref?.deleteIntermediateOutputFiles || false,
         useReferenceDisks: workflowOptionsPref?.useReferenceDisks || false,
-        retryWithMoreMemory: retryWithMoreMemoryPref?.enabled || false,
-        retryMemoryFactor: retryWithMoreMemoryPref?.enabled ? retryWithMoreMemoryPref?.factor : 1.2,
+        retryWithMoreMemorySettingEnabled: retryWithMoreMemorySettingEnabledFlag,
+        retryWithMoreMemory: (retryWithMoreMemorySettingEnabledFlag && retryWithMoreMemoryPref?.enabled) || false,
+        retryMemoryFactor: retryWithMoreMemorySettingEnabledFlag && retryWithMoreMemoryPref?.enabled ? retryWithMoreMemoryPref?.factor : 1.2,
         ignoreEmptyOutputs: workflowOptionsPref?.ignoreEmptyOutputs || false,
         enableResourceMonitoring: resourceMonitoringEnabledPref || false,
         monitoringScript: resourceMonitoringEnabledPref ? resourceMonitoringPref?.script : '',
@@ -786,6 +791,7 @@ export const WorkflowView = _.flow(
         useCallCache,
         deleteIntermediateOutputFiles,
         useReferenceDisks,
+        retryWithMoreMemorySettingEnabled,
         retryWithMoreMemory,
         retryMemoryFactor,
         ignoreEmptyOutputs,
@@ -1103,31 +1109,35 @@ export const WorkflowView = _.flow(
                     ]),
                   ]),
                   div([
-                    span({ style: styles.checkBoxSpanMargins }, [
-                      h(
-                        LabeledCheckbox,
-                        {
-                          checked: retryWithMoreMemory,
-                          onChange: (v) => this.setState({ retryWithMoreMemory: v }),
-                          style: styles.checkBoxLeftMargin,
-                        },
-                        [' Retry with more memory']
-                      ),
-                    ]),
-                    // We show either an info message or a warning, based on whether increasing memory on retries is
-                    // enabled and the value of the retry multiplier.
-                    retryWithMoreMemory && retryMemoryFactor > 2
-                      ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
-                          'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
-                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
-                        ])
-                      : h(InfoBox, [
-                          'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
-                          h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                    retryWithMoreMemorySettingEnabled &&
+                      span([
+                        span({ style: styles.checkBoxSpanMargins }, [
+                          h(
+                            LabeledCheckbox,
+                            {
+                              checked: retryWithMoreMemory,
+                              onChange: (v) => this.setState({ retryWithMoreMemory: v }),
+                              style: styles.checkBoxLeftMargin,
+                            },
+                            [' Retry with more memory']
+                          ),
                         ]),
+                        // We show either an info message or a warning, based on whether increasing memory on retries is
+                        // enabled and the value of the retry multiplier.
+                        retryWithMoreMemory && retryMemoryFactor > 2
+                          ? h(InfoBox, { style: { color: colors.warning() }, icon: 'warning-standard' }, [
+                              'Retry factors above 2 are not recommended. The retry factor compounds and may substantially increase costs. ',
+                              h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                            ])
+                          : h(InfoBox, [
+                              'If a task has a maxRetries value greater than zero and fails because it ran out of memory, retry it with more memory. ',
+                              h(Link, { href: this.getSupportLink('4403215299355'), ...Utils.newTabLinkProps }, [clickToLearnMore]),
+                            ]),
+                      ]),
                   ]),
                   div([
-                    retryWithMoreMemory &&
+                    retryWithMoreMemorySettingEnabled &&
+                      retryWithMoreMemory &&
                       span({ style: { margin: '0 0.5rem 0 0.5rem' } }, [
                         h(IdContainer, [
                           (id) =>

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -288,6 +288,9 @@ describe('Workflow View (GCP)', () => {
           }),
         }),
       }),
+      workspaceV2: (_namespace, _name) => ({
+        getSettings: jest.fn().mockReturnValue([]),
+      }),
     });
     Apps.mockReturnValue({ list: jest.fn().mockReturnValue([]) });
     Runtimes.mockReturnValue({ listV2: jest.fn() });
@@ -567,6 +570,125 @@ describe('Workflow View (GCP)', () => {
     expect(setLocalPref).toHaveBeenCalledWith(`${namespace}/${name}/workflow_options`, undefined);
   });
 
+  it('renders the retry with more memory checkbox and factor text box when the feature flag is set', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const namespace = 'gatk';
+    const name = 'echo_to_file-configured';
+
+    getLocalPref.mockReturnValue(undefined);
+
+    mockDefaultAjax();
+
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true); // Mock WORKFLOW_RETRY_WITH_MORE_MEMORY as enabled
+
+    // Act
+    await act(async () => {
+      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
+    });
+
+    // Assert
+    // check that the retry with more memory checkbox is rendered and the factor test box is not
+    const retryWithMoreMemoryCheckbox = screen.getByRole('checkbox', { name: 'Retry with more memory' });
+    expect(retryWithMoreMemoryCheckbox).toBeInTheDocument();
+    const missingRetryMemoryFactorInput = screen.queryByText('Memory factor:');
+    expect(missingRetryMemoryFactorInput).not.toBeInTheDocument();
+
+    // Act
+    // enable the checkbox
+    await user.click(retryWithMoreMemoryCheckbox);
+
+    // Assert
+    // check that the retry memory factor text box is rendered
+    const retryMemoryFactorInput = screen.getByText('Memory factor:');
+    expect(retryMemoryFactorInput).toBeInTheDocument();
+  });
+
+  it('does not render the retry with more memory checkbox when the feature flag is not set', async () => {
+    // Arrange
+    const namespace = 'gatk';
+    const name = 'echo_to_file-configured';
+
+    getLocalPref.mockReturnValue(undefined);
+
+    mockDefaultAjax();
+
+    // Mock WORKFLOW_RETRY_WITH_MORE_MEMORY as disabled
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+
+    // Act
+    await act(async () => {
+      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
+    });
+
+    // Assert
+    // check that the retry with more memory checkbox is rendered and the factor test box is not
+    const retryWithMoreMemoryCheckbox = screen.queryByRole('checkbox', { name: 'Retry with more memory' });
+    expect(retryWithMoreMemoryCheckbox).not.toBeInTheDocument();
+  });
+
+  it('disables retry with more memory when the feature flag is OFF and the workflow option preference is ON', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const namespace = 'gatk';
+    const name = 'echo_to_file-configured';
+
+    mockDefaultAjax();
+
+    const currentMock = Workspaces.getMockImplementation()();
+    Workspaces.mockReturnValue({
+      ...currentMock,
+      workspace: (ns, nm) => ({
+        ...currentMock.workspace(ns, nm),
+        checkBucketAccess: jest.fn().mockResolvedValue({}),
+        checkBucketLocation: jest.fn().mockResolvedValue(mockStorageDetails),
+        createEntity: jest.fn().mockResolvedValue(mockCreateEntity),
+        methodConfig: () => ({
+          ...currentMock.workspace(ns, nm).methodConfig(),
+          launch: jest.fn(mockLaunchResponse),
+        }),
+      }),
+    });
+
+    getLocalPref.mockReturnValue({ retryWithMoreMemory: true });
+
+    // Mock WORKFLOW_RETRY_WITH_MORE_MEMORY as disabled
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+
+    // Act
+    await act(async () => {
+      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
+    });
+
+    // Lots of clicking around to launch submission
+    const fileInputsRadioButton = screen.getByRole('radio', { name: 'Run workflow with inputs defined by file paths' });
+    await user.click(fileInputsRadioButton);
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    const launchButton = screen.getByRole('button', { name: 'Launch' });
+    await user.click(launchButton);
+
+    const launchModalHeader = screen.getByText('Confirm launch');
+    expect(launchModalHeader).toBeInTheDocument;
+
+    const secondLaunchButton = screen.getAllByRole('button').filter((button) => button.textContent.includes('Launch'))[0];
+    await user.click(secondLaunchButton);
+
+    // Assert
+    // Check that submission is launched
+    expect(mockLaunchResponse).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Launching analysis...')).toBeInTheDocument;
+
+    // check that retry factor is undefined
+    expect(mockLaunchResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memoryRetryMultiplier: undefined,
+      })
+    );
+  });
+
   it('renders run analysis modal and check workflow option expectations', async () => {
     // Arrange
     const user = userEvent.setup();
@@ -595,19 +717,22 @@ describe('Workflow View (GCP)', () => {
       },
     };
 
-    Workspaces.mockImplementation(() => ({
-      workspace: (_namespace, _name) => ({
+    mockDefaultAjax();
+
+    const currentMock = Workspaces.getMockImplementation()();
+    Workspaces.mockReturnValue({
+      ...currentMock,
+      workspace: (ns, nm) => ({
+        ...currentMock.workspace(ns, nm),
         checkBucketAccess: jest.fn().mockResolvedValue({}),
         checkBucketLocation: jest.fn().mockResolvedValue(mockStorageDetails),
         createEntity: jest.fn().mockResolvedValue(mockCreateEntity),
         methodConfig: () => ({
+          ...currentMock.workspace(ns, nm).methodConfig(),
           launch: jest.fn(mockLaunchResponse),
         }),
       }),
-      workspaceV2: (_namespace, _name) => ({
-        getSettings: jest.fn().mockReturnValue([]),
-      }),
-    }));
+    });
 
     // Act
     await act(async () => {

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -650,7 +650,7 @@ describe('Workflow View (GCP)', () => {
       }),
     });
 
-    getLocalPref.mockReturnValue({ retryWithMoreMemory: true });
+    getLocalPref.mockReturnValue({ retryWithMoreMemory: { enabled: true, factor: 1.1 } });
 
     // Mock WORKFLOW_RETRY_WITH_MORE_MEMORY as disabled
     asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);

--- a/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.test.js
@@ -689,6 +689,68 @@ describe('Workflow View (GCP)', () => {
     );
   });
 
+  it('uses stored preferences for retry with more memory when the feature flag is ON', async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const namespace = 'gatk';
+    const name = 'echo_to_file-configured';
+
+    mockDefaultAjax();
+
+    const currentMock = Workspaces.getMockImplementation()();
+    Workspaces.mockReturnValue({
+      ...currentMock,
+      workspace: (ns, nm) => ({
+        ...currentMock.workspace(ns, nm),
+        checkBucketAccess: jest.fn().mockResolvedValue({}),
+        checkBucketLocation: jest.fn().mockResolvedValue(mockStorageDetails),
+        createEntity: jest.fn().mockResolvedValue(mockCreateEntity),
+        methodConfig: () => ({
+          ...currentMock.workspace(ns, nm).methodConfig(),
+          launch: jest.fn(mockLaunchResponse),
+        }),
+      }),
+    });
+
+    getLocalPref.mockReturnValue({ retryWithMoreMemory: { enabled: true, factor: 1.1 } });
+
+    // Mock WORKFLOW_RETRY_WITH_MORE_MEMORY as disabled
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
+
+    // Act
+    await act(async () => {
+      render(h(WorkflowView, { name, namespace, queryParams: { selectionKey } }));
+    });
+
+    // Lots of clicking around to launch submission
+    const fileInputsRadioButton = screen.getByRole('radio', { name: 'Run workflow with inputs defined by file paths' });
+    await user.click(fileInputsRadioButton);
+
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    await user.click(saveButton);
+
+    const launchButton = screen.getByRole('button', { name: 'Launch' });
+    await user.click(launchButton);
+
+    const launchModalHeader = screen.getByText('Confirm launch');
+    expect(launchModalHeader).toBeInTheDocument;
+
+    const secondLaunchButton = screen.getAllByRole('button').filter((button) => button.textContent.includes('Launch'))[0];
+    await user.click(secondLaunchButton);
+
+    // Assert
+    // Check that submission is launched
+    expect(mockLaunchResponse).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Launching analysis...')).toBeInTheDocument;
+
+    // check that retry factor is undefined
+    expect(mockLaunchResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memoryRetryMultiplier: 1.1,
+      })
+    );
+  });
+
   it('renders run analysis modal and check workflow option expectations', async () => {
     // Arrange
     const user = userEvent.setup();


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AN-703

Second commit reverts https://github.com/DataBiosphere/terra-ui/pull/5362

## Summary of changes:
Restore the Retry with More Memory workflow submission setting, but put it behind a feature flag. Care has been taken to ensure that the stored workspace preference is only respected when the feature flag is on.

### Testing strategy
Checked:
 * Feature flag OFF with no workspace preference state
 * Feature flag ON with no workspace preference state
 * Feature flag OFF with workspace preference set to use retry with more memory (this correctly wipes the preference on workflow submission)
 * Feature flag ON with workspace preference set to use retry with more memory