### PR TITLE
[TSP-558] Fix broken DSP logo on CLI auth page

### DIFF
--- a/src/pages/scientificServices/cli-auth/CliAuth.tsx
+++ b/src/pages/scientificServices/cli-auth/CliAuth.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
+import dspLogo from 'src/images/brands/scientificServices/dspLogo.svg';
 import colors from 'src/libs/colors';
 
 export const CliAuth = () => {
@@ -11,7 +12,7 @@ export const CliAuth = () => {
   return (
     <div style={{ width: '525px', alignItems: 'center', margin: 'auto', padding: '2rem' }}>
       <img
-        src='src/images/brands/scientificServices/dspLogo.svg'
+        src={dspLogo}
         alt='Broad Institute Data Sciences Platform'
         style={{ width: '200px', alignItems: 'center', margin: 'auto', display: 'block', marginBottom: '2rem' }}
       />


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-558

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Fixes broken logo on CLI auth page

### Why
- Referencing the image path directly works fine locally, but doesn't work after build and deployment due to how the assets are bundled.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
