### PR TITLE
[TSPS-565] Display "0" instead of "N/A" in quota consumed column, add tooltip for running jobs

### DIFF
--- a/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
@@ -246,4 +246,63 @@ describe('job history table', () => {
 
     expect(await screen.findByText('Pipeline Error', { exact: false })).toBeInTheDocument();
   });
+
+  describe('Quota Used column', () => {
+    it("displays '0 samples' when quotaUsed is undefined", async () => {
+      const pipelineRun = mockPipelineRun('FAILED');
+      const pipelineRuns = [pipelineRun];
+
+      const mockPipelineRunResponse = {
+        pageToken: null,
+        results: pipelineRuns,
+        totalResults: 1,
+      };
+
+      asMockedFn(Teaspoons).mockReturnValue(
+        partial<TeaspoonsContract>({
+          getAllPipelineRuns: jest.fn().mockReturnValue(mockPipelineRunResponse),
+        })
+      );
+
+      render(<JobHistory />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(pipelineRun.jobId)).toHaveLength(2);
+      });
+
+      expect(screen.getByText('0 samples')).toBeInTheDocument();
+    });
+
+    it('displays an informational tooltip for in progress jobs', async () => {
+      const pipelineRun = {
+        ...mockPipelineRun('RUNNING'),
+        quotaConsumed: 500,
+      };
+      const pipelineRuns = [pipelineRun];
+      const mockPipelineRunResponse = {
+        pageToken: null,
+        results: pipelineRuns,
+        totalResults: 1,
+      };
+
+      asMockedFn(Teaspoons).mockReturnValue(
+        partial<TeaspoonsContract>({
+          getAllPipelineRuns: jest.fn().mockReturnValue(mockPipelineRunResponse),
+        })
+      );
+
+      render(<JobHistory />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(pipelineRun.jobId)).toHaveLength(2);
+      });
+
+      expect(screen.getByText('500 samples')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'This job is still in progress. The amount of quota consumed may change as the job progresses. If the job fails, no quota will be consumed.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -1,4 +1,4 @@
-import { Icon, Spinner, useModalHandler } from '@terra-ui-packages/components';
+import { Icon, Spinner, TooltipTrigger, useModalHandler } from '@terra-ui-packages/components';
 import { formatDate, formatDatetime } from '@terra-ui-packages/core-utils';
 import _, { capitalize } from 'lodash';
 import pluralize from 'pluralize';
@@ -8,6 +8,7 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { FlexTable, HeaderCell, Paginator, TooltipCell } from 'src/components/table';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { GetPipelineRunsResponse, PipelineRun, PipelineRunStatus } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 import { useCancellation } from 'src/libs/react-utils';
 import {
   pipelinesTopBar,
@@ -258,10 +259,16 @@ const DataDeletionDateCell = ({ pipelineRun }: CellProps): ReactNode => {
 
 const QuotaUsedCell = (props: CellProps): ReactNode => {
   return (
-    <div>
-      {props.pipelineRun.quotaConsumed
-        ? `${props.pipelineRun.quotaConsumed} ${pluralize('sample', props.pipelineRun.quotaConsumed)}`
-        : 'N/A'}
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+      {props.pipelineRun.quotaConsumed || 0} {pluralize('sample', props.pipelineRun.quotaConsumed || 0)}
+      {props.pipelineRun.status === 'RUNNING' && (
+        <TooltipTrigger
+          content='This job is still in progress. The amount of quota consumed may change as the job progresses. If the job fails, no quota will be consumed.'
+          side='top'
+        >
+          <Icon icon='info-circle' style={{ marginLeft: '0.25rem', color: colors.primary() }} />
+        </TooltipTrigger>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-565

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

* Jobs that have not consumed any quota will display 0 instead of N/A
* Adds an information tooltip to explain that running jobs may see value fluctuate as the job progresses

<img width="423" height="216" alt="Screenshot 2025-08-07 at 3 26 41 PM" src="https://github.com/user-attachments/assets/5f08e01a-e34d-4cc2-82aa-e40491300e8b" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
