### PR TITLE
[TSPS-564] Better UX for jobs stuck in "Preparing"

### DIFF
--- a/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
@@ -247,6 +247,66 @@ describe('job history table', () => {
     expect(await screen.findByText('Pipeline Error', { exact: false })).toBeInTheDocument();
   });
 
+  describe('Job Status column', () => {
+    it('displays Preparing if the job was submitted less than 10 minutes ago and is in PREPARING status', async () => {
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const pipelineRun = {
+        ...mockPipelineRun('PREPARING'),
+        timeSubmitted: fiveMinutesAgo,
+      };
+      const pipelineRuns = [pipelineRun];
+
+      const mockPipelineRunResponse = {
+        pageToken: null,
+        results: pipelineRuns,
+        totalResults: 1,
+      };
+
+      asMockedFn(Teaspoons).mockReturnValue(
+        partial<TeaspoonsContract>({
+          getAllPipelineRuns: jest.fn().mockReturnValue(mockPipelineRunResponse),
+        })
+      );
+
+      render(<JobHistory />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(pipelineRun.jobId)).toHaveLength(2);
+      });
+
+      expect(screen.getByText('Preparing')).toBeInTheDocument();
+    });
+
+    it('displays FAILED if the job was submitted more than 10 minutes ago and is in PREPARING status', async () => {
+      const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+      const pipelineRun = {
+        ...mockPipelineRun('PREPARING'),
+        timeSubmitted: fifteenMinutesAgo,
+      };
+      const pipelineRuns = [pipelineRun];
+
+      const mockPipelineRunResponse = {
+        pageToken: null,
+        results: pipelineRuns,
+        totalResults: 1,
+      };
+
+      asMockedFn(Teaspoons).mockReturnValue(
+        partial<TeaspoonsContract>({
+          getAllPipelineRuns: jest.fn().mockReturnValue(mockPipelineRunResponse),
+        })
+      );
+
+      render(<JobHistory />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText(pipelineRun.jobId)).toHaveLength(2);
+      });
+
+      expect(screen.getByText('Failed')).toBeInTheDocument();
+    });
+  });
+
   describe('Quota Used column', () => {
     it("displays '0 samples' when quotaUsed is undefined", async () => {
       const pipelineRun = mockPipelineRun('FAILED');

--- a/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineRun } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { mockPipelineRun } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
+import { PREPARING_JOB_CUTOFF_HOURS } from 'src/pages/scientificServices/pipelines/views/JobHistory';
 import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
 
 import { JobHistory } from './JobHistory';
@@ -248,11 +249,11 @@ describe('job history table', () => {
   });
 
   describe('Job Status column', () => {
-    it('displays Preparing if the job was submitted less than 10 minutes ago and is in PREPARING status', async () => {
-      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    it(`displays PREPARING if the job was submitted less than ${PREPARING_JOB_CUTOFF_HOURS} hours ago and is in PREPARING status`, async () => {
+      const elevenHoursAgo = new Date(Date.now() - 60 * 60 * 1000 * (PREPARING_JOB_CUTOFF_HOURS - 1)).toISOString();
       const pipelineRun = {
         ...mockPipelineRun('PREPARING'),
-        timeSubmitted: fiveMinutesAgo,
+        timeSubmitted: elevenHoursAgo,
       };
       const pipelineRuns = [pipelineRun];
 
@@ -275,13 +276,14 @@ describe('job history table', () => {
       });
 
       expect(screen.getByText('Preparing')).toBeInTheDocument();
+      expect(screen.queryByText('View Error')).not.toBeInTheDocument();
     });
 
-    it('displays FAILED if the job was submitted more than 10 minutes ago and is in PREPARING status', async () => {
-      const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+    it(`displays FAILED if the job was submitted more than ${PREPARING_JOB_CUTOFF_HOURS} hours ago and is in PREPARING status`, async () => {
+      const thirteenHoursAgo = new Date(Date.now() - 60 * 60 * 1000 * (PREPARING_JOB_CUTOFF_HOURS + 1)).toISOString();
       const pipelineRun = {
         ...mockPipelineRun('PREPARING'),
-        timeSubmitted: fifteenMinutesAgo,
+        timeSubmitted: thirteenHoursAgo,
       };
       const pipelineRuns = [pipelineRun];
 
@@ -304,6 +306,7 @@ describe('job history table', () => {
       });
 
       expect(screen.getByText('Failed')).toBeInTheDocument();
+      expect(screen.getByText('View Error')).toBeInTheDocument();
     });
   });
 

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -229,7 +229,11 @@ const DescriptionCell = ({ pipelineRun }: CellProps): ReactNode => {
 };
 
 const StatusCell = ({ pipelineRun }: CellProps): ReactNode => {
-  return <div style={{ display: 'flex', alignItems: 'center' }}>{getRunStatusIcon(pipelineRun.status)}</div>;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      {getRunStatusIcon(pipelineRun.status, pipelineRun.timeSubmitted)}
+    </div>
+  );
 };
 
 /** Format date like "Feb 15, 2025", and enable tooltip with precise time */
@@ -279,7 +283,7 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
   });
 
   const errorModal = useModalHandler(() => {
-    return <ViewErrorModal jobId={pipelineRun.jobId} onDismiss={errorModal.close} />;
+    return <ViewErrorModal pipelineRun={pipelineRun} onDismiss={errorModal.close} />;
   });
 
   return (
@@ -326,11 +330,32 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
           {errorModal.maybeRender()}
         </>
       )}
+      {pipelineRun.status === 'PREPARING' && (
+        <>
+          <button
+            type='button'
+            style={{
+              color: '#46A3E9',
+              fontWeight: 700,
+              textDecoration: 'underline',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              font: 'inherit',
+            }}
+            onClick={() => errorModal.open({ jobId: pipelineRun.jobId })}
+          >
+            View Error
+          </button>
+          {errorModal.maybeRender()}
+        </>
+      )}
     </div>
   );
 };
 
-const getRunStatusIcon = (status: PipelineRunStatus): ReactNode => {
+const getRunStatusIcon = (status: PipelineRunStatus, timeSubmitted: string): ReactNode => {
   switch (status) {
     case 'SUCCEEDED':
       return (
@@ -340,6 +365,24 @@ const getRunStatusIcon = (status: PipelineRunStatus): ReactNode => {
       );
     case 'RUNNING':
       return <div style={{ display: 'flex', alignItems: 'center' }}>In Progress</div>;
+    case 'PREPARING': {
+      // In most cases, jobs stuck in Preparing can be considered failures.
+      // However, we have a small window where we still show "Preparing" in case the user happens
+      // to check the Job History page while the job submission is still in progress (i.e. due to a slow file upload).
+      const submittedTime = new Date(timeSubmitted);
+      const currentTime = new Date();
+      const minutesElapsed = (currentTime.getTime() - submittedTime.getTime()) / (1000 * 60);
+
+      if (minutesElapsed > 10) {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', color: '#DB3214', gap: '0.5rem' }}>
+            <Icon icon='warning-standard' /> Failed
+          </div>
+        );
+      }
+
+      return <div style={{ display: 'flex', alignItems: 'center' }}>Preparing</div>;
+    }
     case 'FAILED':
       return (
         <div style={{ display: 'flex', alignItems: 'center', color: '#DB3214', gap: '0.5rem' }}>

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -17,6 +17,9 @@ import {
 import { ViewErrorModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewErrorModal';
 import { ViewOutputsModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal';
 
+// If a job is still in "Preparing" state after this many hours, we consider it a failure.
+export const PREPARING_JOB_CUTOFF_HOURS = 12;
+
 /*
    Right now, this will show all pipeline runs. Once we support more than one pipeline,
    we'll need to add a filter for the pipeline name.
@@ -326,7 +329,7 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
           {errorModal.maybeRender()}
         </>
       )}
-      {pipelineRun.status === 'PREPARING' && (
+      {pipelineRun.status === 'PREPARING' && hoursElapsedSinceSubmission(pipelineRun) > PREPARING_JOB_CUTOFF_HOURS && (
         <>
           <button
             type='button'
@@ -363,13 +366,11 @@ const getRunStatusIcon = (pipelineRun: PipelineRun): ReactNode => {
       return <div style={{ display: 'flex', alignItems: 'center' }}>In Progress</div>;
     case 'PREPARING': {
       // In most cases, jobs stuck in Preparing can be considered failures.
-      // However, we have a small window where we still show "Preparing" in case the user happens
-      // to check the Job History page while the job submission is still in progress (i.e. due to a slow file upload).
-      const submittedTime = new Date(pipelineRun.timeSubmitted);
-      const currentTime = new Date();
-      const minutesElapsed = (currentTime.getTime() - submittedTime.getTime()) / (1000 * 60);
+      // However, we have a window where we still show "Preparing" in case the user happens
+      // to check the Job History page while the job submission is still in progress (i.e. due to a slow/large file upload).
+      const hoursElapsed = hoursElapsedSinceSubmission(pipelineRun);
 
-      if (minutesElapsed > 10) {
+      if (hoursElapsed > PREPARING_JOB_CUTOFF_HOURS) {
         return (
           <div style={{ display: 'flex', alignItems: 'center', color: '#DB3214', gap: '0.5rem' }}>
             <Icon icon='warning-standard' /> Failed
@@ -397,4 +398,10 @@ const pipelineNameToColor = (pipelineRun: PipelineRun): string => {
     default:
       return '#AA4D8B4D';
   }
+};
+
+const hoursElapsedSinceSubmission = (pipelineRun: PipelineRun): number => {
+  const submittedTime = new Date(pipelineRun.timeSubmitted);
+  const currentTime = new Date();
+  return (currentTime.getTime() - submittedTime.getTime()) / (1000 * 60 * 60);
 };

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -7,7 +7,7 @@ import { AutoSizer } from 'react-virtualized';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { FlexTable, HeaderCell, Paginator, TooltipCell } from 'src/components/table';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
-import { GetPipelineRunsResponse, PipelineRun, PipelineRunStatus } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { GetPipelineRunsResponse, PipelineRun } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import { useCancellation } from 'src/libs/react-utils';
 import {
@@ -229,11 +229,7 @@ const DescriptionCell = ({ pipelineRun }: CellProps): ReactNode => {
 };
 
 const StatusCell = ({ pipelineRun }: CellProps): ReactNode => {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center' }}>
-      {getRunStatusIcon(pipelineRun.status, pipelineRun.timeSubmitted)}
-    </div>
-  );
+  return <div style={{ display: 'flex', alignItems: 'center' }}>{getRunStatusIcon(pipelineRun)}</div>;
 };
 
 /** Format date like "Feb 15, 2025", and enable tooltip with precise time */
@@ -355,8 +351,8 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
   );
 };
 
-const getRunStatusIcon = (status: PipelineRunStatus, timeSubmitted: string): ReactNode => {
-  switch (status) {
+const getRunStatusIcon = (pipelineRun: PipelineRun): ReactNode => {
+  switch (pipelineRun.status) {
     case 'SUCCEEDED':
       return (
         <div style={{ display: 'flex', alignItems: 'center', color: '#74AE43', gap: '0.5rem' }}>
@@ -369,7 +365,7 @@ const getRunStatusIcon = (status: PipelineRunStatus, timeSubmitted: string): Rea
       // In most cases, jobs stuck in Preparing can be considered failures.
       // However, we have a small window where we still show "Preparing" in case the user happens
       // to check the Job History page while the job submission is still in progress (i.e. due to a slow file upload).
-      const submittedTime = new Date(timeSubmitted);
+      const submittedTime = new Date(pipelineRun.timeSubmitted);
       const currentTime = new Date();
       const minutesElapsed = (currentTime.getTime() - submittedTime.getTime()) / (1000 * 60);
 
@@ -390,7 +386,7 @@ const getRunStatusIcon = (status: PipelineRunStatus, timeSubmitted: string): Rea
         </div>
       );
     default:
-      return <div style={{ display: 'flex', alignItems: 'center' }}>{capitalize(status)}</div>;
+      return <div style={{ display: 'flex', alignItems: 'center' }}>{capitalize(pipelineRun.status)}</div>;
   }
 };
 

--- a/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { mockPipelineRun } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
 import { asMockedFn, partial, renderWithAppContexts } from 'src/testing/test-utils';
 
 import { ViewErrorModal } from './ViewErrorModal';
@@ -10,7 +11,7 @@ import { ViewErrorModal } from './ViewErrorModal';
 jest.mock('src/libs/ajax/teaspoons/Teaspoons');
 
 describe('ViewErrorModal', () => {
-  const jobId = 'test-job-id';
+  const pipelineRun = mockPipelineRun('FAILED');
   const onDismissMock = jest.fn();
 
   it('displays loading state initially', () => {
@@ -20,10 +21,10 @@ describe('ViewErrorModal', () => {
       })
     );
 
-    renderWithAppContexts(<ViewErrorModal jobId={jobId} onDismiss={onDismissMock} />);
+    renderWithAppContexts(<ViewErrorModal pipelineRun={pipelineRun} onDismiss={onDismissMock} />);
 
     expect(screen.getByText('Loading error details...')).toBeInTheDocument();
-    expect(screen.getByText(`Pipeline Error - ${jobId}`)).toBeInTheDocument();
+    expect(screen.getByText(`Pipeline Error - ${pipelineRun.jobId}`)).toBeInTheDocument();
   });
 
   it('fetches and displays error information', async () => {
@@ -43,7 +44,7 @@ describe('ViewErrorModal', () => {
       })
     );
 
-    renderWithAppContexts(<ViewErrorModal jobId={jobId} onDismiss={onDismissMock} />);
+    renderWithAppContexts(<ViewErrorModal pipelineRun={pipelineRun} onDismiss={onDismissMock} />);
 
     await waitFor(() => {
       expect(screen.queryByText('Loading error details...')).not.toBeInTheDocument();
@@ -68,7 +69,7 @@ describe('ViewErrorModal', () => {
       })
     );
 
-    renderWithAppContexts(<ViewErrorModal jobId={jobId} onDismiss={onDismissMock} />);
+    renderWithAppContexts(<ViewErrorModal pipelineRun={pipelineRun} onDismiss={onDismissMock} />);
 
     // Wait for loading to complete
     await waitFor(() => {
@@ -94,7 +95,7 @@ describe('ViewErrorModal', () => {
       })
     );
 
-    renderWithAppContexts(<ViewErrorModal jobId={jobId} onDismiss={onDismissMock} />);
+    renderWithAppContexts(<ViewErrorModal pipelineRun={pipelineRun} onDismiss={onDismissMock} />);
 
     await waitFor(() => {
       expect(screen.queryByText('Loading error details...')).not.toBeInTheDocument();
@@ -124,7 +125,7 @@ describe('ViewErrorModal', () => {
       })
     );
 
-    renderWithAppContexts(<ViewErrorModal jobId={jobId} onDismiss={onDismissMock} />);
+    renderWithAppContexts(<ViewErrorModal pipelineRun={pipelineRun} onDismiss={onDismissMock} />);
 
     await waitFor(() => {
       expect(screen.queryByText('Loading error details...')).not.toBeInTheDocument();
@@ -135,5 +136,12 @@ describe('ViewErrorModal', () => {
 
     // Verify causes section is not displayed
     expect(screen.queryByText('Error Causes:')).not.toBeInTheDocument();
+  });
+
+  it('displays error message when pipeline run is stuck in PREPARING state', () => {
+    const preparingPipelineRun = mockPipelineRun('PREPARING');
+    renderWithAppContexts(<ViewErrorModal pipelineRun={preparingPipelineRun} onDismiss={onDismissMock} />);
+
+    expect(screen.getByText('There was an error preparing this job.', { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.tsx
+++ b/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.tsx
@@ -19,6 +19,7 @@ export const ViewErrorModal = ({ pipelineRun, onDismiss }: ErrorModalProps): Rea
   const signal = useCancellation();
 
   useEffect(() => {
+    if (pipelineRun.status === 'PREPARING') return;
     const fetchPipelineRunResults = async () => {
       try {
         setLoading(true);
@@ -37,57 +38,58 @@ export const ViewErrorModal = ({ pipelineRun, onDismiss }: ErrorModalProps): Rea
       <div>
         <h3>Error Details</h3>
 
-        {loading ? (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <Spinner />
-            <div style={{ marginTop: '1rem' }}>Loading error details...</div>
-          </div>
-        ) : (
-          <div>
-            {result?.errorReport ? (
-              <div style={{ margin: '1rem 0' }}>
-                <div
-                  style={{
-                    backgroundColor: '#f8d7da',
-                    color: '#842029',
-                    padding: '1rem',
-                    borderRadius: '4px',
-                    marginBottom: '1rem',
-                  }}
-                >
-                  <div style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>Error Message:</div>
-                  <div style={{ fontFamily: 'monospace' }}>{result.errorReport.message}</div>
-                </div>
-
-                {result.errorReport.causes && result.errorReport.causes.length > 0 && (
-                  <div style={{ marginTop: '1rem' }}>
-                    <div style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>Error Causes:</div>
-                    <div
-                      style={{
-                        backgroundColor: '#f8f9fa',
-                        padding: '1rem',
-                        borderRadius: '4px',
-                        fontFamily: 'monospace',
-                        whiteSpace: 'pre-wrap',
-                      }}
-                    >
-                      {result.errorReport.causes.map((cause, index) => (
-                        // eslint-disable-next-line react/no-array-index-key
-                        <div key={index} style={{ marginBottom: '0.5rem' }}>
-                          {cause}
-                        </div>
-                      ))}
-                    </div>
+        {pipelineRun.status === 'FAILED' &&
+          (loading ? (
+            <div style={{ textAlign: 'center', padding: '2rem' }}>
+              <Spinner />
+              <div style={{ marginTop: '1rem' }}>Loading error details...</div>
+            </div>
+          ) : (
+            <div>
+              {result?.errorReport ? (
+                <div style={{ margin: '1rem 0' }}>
+                  <div
+                    style={{
+                      backgroundColor: '#f8d7da',
+                      color: '#842029',
+                      padding: '1rem',
+                      borderRadius: '4px',
+                      marginBottom: '1rem',
+                    }}
+                  >
+                    <div style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>Error Message:</div>
+                    <div style={{ fontFamily: 'monospace' }}>{result.errorReport.message}</div>
                   </div>
-                )}
-              </div>
-            ) : (
-              <div style={{ padding: '1rem', textAlign: 'center' }}>
-                No detailed error information available for this job.
-              </div>
-            )}
-          </div>
-        )}
+
+                  {result.errorReport.causes && result.errorReport.causes.length > 0 && (
+                    <div style={{ marginTop: '1rem' }}>
+                      <div style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>Error Causes:</div>
+                      <div
+                        style={{
+                          backgroundColor: '#f8f9fa',
+                          padding: '1rem',
+                          borderRadius: '4px',
+                          fontFamily: 'monospace',
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {result.errorReport.causes.map((cause, index) => (
+                          // eslint-disable-next-line react/no-array-index-key
+                          <div key={index} style={{ marginBottom: '0.5rem' }}>
+                            {cause}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div style={{ padding: '1rem', textAlign: 'center' }}>
+                  No detailed error information available for this job.
+                </div>
+              )}
+            </div>
+          ))}
 
         {pipelineRun.status === 'PREPARING' && (
           <div style={{ padding: '1rem', textAlign: 'center' }}>

--- a/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.tsx
+++ b/src/pages/scientificServices/pipelines/views/modals/ViewErrorModal.tsx
@@ -1,18 +1,19 @@
 import { ButtonPrimary, Modal, Spinner } from '@terra-ui-packages/components';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
-import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { PipelineRun, PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { useCancellation } from 'src/libs/react-utils';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 
 /**
  * Modal component for displaying pipeline errors
  */
 interface ErrorModalProps {
-  jobId: string;
+  pipelineRun: PipelineRun;
   onDismiss: () => void;
 }
 
-export const ViewErrorModal = ({ jobId, onDismiss }: ErrorModalProps): ReactNode => {
+export const ViewErrorModal = ({ pipelineRun, onDismiss }: ErrorModalProps): ReactNode => {
   const [result, setResult] = useState<PipelineRunResponse>();
   const [loading, setLoading] = useState(true);
   const signal = useCancellation();
@@ -21,7 +22,7 @@ export const ViewErrorModal = ({ jobId, onDismiss }: ErrorModalProps): ReactNode
     const fetchPipelineRunResults = async () => {
       try {
         setLoading(true);
-        const results = await Teaspoons(signal).getPipelineRunResult(jobId);
+        const results = await Teaspoons(signal).getPipelineRunResult(pipelineRun.jobId);
         setResult(results);
       } finally {
         setLoading(false);
@@ -29,10 +30,10 @@ export const ViewErrorModal = ({ jobId, onDismiss }: ErrorModalProps): ReactNode
     };
 
     fetchPipelineRunResults();
-  }, [jobId, signal]);
+  }, [pipelineRun, signal]);
 
   return (
-    <Modal width={800} title={`Pipeline Error - ${jobId}`} onDismiss={onDismiss} showButtons={false}>
+    <Modal width={800} title={`Pipeline Error - ${pipelineRun.jobId}`} onDismiss={onDismiss} showButtons={false}>
       <div>
         <h3>Error Details</h3>
 
@@ -85,6 +86,19 @@ export const ViewErrorModal = ({ jobId, onDismiss }: ErrorModalProps): ReactNode
                 No detailed error information available for this job.
               </div>
             )}
+          </div>
+        )}
+
+        {pipelineRun.status === 'PREPARING' && (
+          <div style={{ padding: '1rem', textAlign: 'center' }}>
+            There was an error preparing this job. Please try again or contact{' '}
+            <a
+              style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
+              href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
+            >
+              {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+            </a>{' '}
+            if the issue persists.
           </div>
         )}
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-564

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

* If a job has been Preparing for more than 12 hours, display it as Failed in the Job History table
* In that case, a "View Error" button will show up and the following modal will appear:

<img width="839" height="282" alt="Screenshot 2025-08-07 at 5 45 21 PM" src="https://github.com/user-attachments/assets/22b45cfd-34a1-4b2a-b850-83323ea43c14" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
