### PR TITLE
[TSPS-567] Put Imputation UI behind private preview

### DIFF
--- a/src/libs/feature-previews-config.ts
+++ b/src/libs/feature-previews-config.ts
@@ -1,8 +1,11 @@
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+
 export const JUPYTERLAB_GCP_FEATURE_ID = 'jupyterlab-gcp';
 export const ENABLE_JUPYTERLAB_ID = 'enableJupyterLabGCP';
 export const COHORT_BUILDER_CARD = 'cohortBuilderCard';
 export const RAS_PROVIDER = 'rasProvider';
 export const IMPROVED_DATA_TABLES = 'improvedDataTables';
+export const IMPUTATION_UI = 'imputationUI';
 
 // If the groups option is defined for a FeaturePreview, it must contain at least one group.
 type GroupsList = readonly [string, ...string[]];
@@ -83,6 +86,16 @@ const featurePreviewsConfig: readonly FeaturePreview[] = [
       'Support for Improved Data Table Performance'
     )}`,
     lastUpdated: '7/10/2025',
+  },
+  {
+    id: IMPUTATION_UI,
+    title: 'Imputation UI',
+    description: 'Enables the user interface for the All of Us + AnVIL Imputation Service.',
+    groups: ['preview-imputation-ui'],
+    feedbackUrl: `mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=${encodeURIComponent(
+      'Feedback on Imputation Service UI'
+    )}`,
+    lastUpdated: '8/10/2025',
   },
 ];
 

--- a/src/pages/scientificServices/landingPage/ScientificServicesWelcomeHeader.tsx
+++ b/src/pages/scientificServices/landingPage/ScientificServicesWelcomeHeader.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dspLogo from 'src/images/brands/scientificServices/dspLogo.svg';
 
 export const ScientificServicesWelcomeHeader = () => {
   return (
@@ -6,11 +7,7 @@ export const ScientificServicesWelcomeHeader = () => {
       <span style={{ fontSize: '24px', marginBottom: '1rem', fontWeight: 700 }}>
         Welcome to Scientific Services from the
       </span>
-      <img
-        src='src/images/brands/scientificServices/dspLogo.svg'
-        alt='Broad Institute Data Sciences Platform'
-        style={{ width: '200px' }}
-      />
+      <img src={dspLogo} alt='Broad Institute Data Sciences Platform' style={{ width: '200px' }} />
     </div>
   );
 };

--- a/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
+++ b/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
@@ -2,6 +2,8 @@ import _ from 'lodash/fp';
 import React from 'react';
 import { TabBar } from 'src/components/tabBars';
 import { TopBar } from 'src/components/TopBar';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { IMPUTATION_UI } from 'src/libs/feature-previews-config';
 import * as Nav from 'src/libs/nav';
 
 export const SCIENTIFIC_SERVICES_SUPPORT_EMAIL = 'scientific-services-support@broadinstitute.org';
@@ -13,20 +15,24 @@ const TAB_LINKS = {
 };
 
 export const pipelinesTopBar = (activeTab: string) => {
+  const isFeatureEnabled = !isFeaturePreviewEnabled(IMPUTATION_UI);
+
   return (
     <>
       <TopBar title='' href={Nav.getLink('root')} />
-      <TabBar
-        aria-label='pipelines menu'
-        activeTab={activeTab}
-        tabNames={_.keys(TAB_LINKS)}
-        getHref={(currentTab) => {
-          return Nav.getLink(TAB_LINKS[currentTab]);
-        }}
-      >
-        {/* TabBar doesn't need any children */}
-        {null}
-      </TabBar>
+      {isFeatureEnabled && (
+        <TabBar
+          aria-label='pipelines menu'
+          activeTab={activeTab}
+          tabNames={_.keys(TAB_LINKS)}
+          getHref={(currentTab) => {
+            return Nav.getLink(TAB_LINKS[currentTab]);
+          }}
+        >
+          {/* TabBar doesn't need any children */}
+          {null}
+        </TabBar>
+      )}
     </>
   );
 };

--- a/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
+++ b/src/pages/scientificServices/pipelines/common/scientific-services-common.tsx
@@ -15,7 +15,7 @@ const TAB_LINKS = {
 };
 
 export const pipelinesTopBar = (activeTab: string) => {
-  const isFeatureEnabled = !isFeaturePreviewEnabled(IMPUTATION_UI);
+  const isFeatureEnabled = isFeaturePreviewEnabled(IMPUTATION_UI);
 
   return (
     <>

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.test.tsx
@@ -1,0 +1,54 @@
+import { asMockedFn } from '@terra-ui-packages/test-utils';
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { ImputationPrivatePreviewGate } from './ImputationPrivatePreviewGate';
+
+jest.mock('src/libs/feature-previews', () => ({
+  ...jest.requireActual('src/libs/feature-previews'),
+  isFeaturePreviewEnabled: jest.fn(),
+}));
+
+describe('ImputationPrivatePreviewGate', () => {
+  const PrivateFeature = () => <div data-testid='private-feature'>You have access to see this secret feature!</div>;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays the feature gate text when feature is disabled', () => {
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(false);
+
+    render(
+      <ImputationPrivatePreviewGate>
+        <PrivateFeature />
+      </ImputationPrivatePreviewGate>
+    );
+
+    expect(screen.getByText(/Thank you for registering for the/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/The All of Us \+ Anvil Imputation Service user interface is currently in private preview/)
+    ).toBeInTheDocument();
+
+    // Feature component should not be rendered
+    expect(screen.queryByTestId('private-feature')).not.toBeInTheDocument();
+  });
+
+  it('displays child component when feature is enabled', () => {
+    asMockedFn(isFeaturePreviewEnabled).mockReturnValue(true);
+
+    render(
+      <ImputationPrivatePreviewGate>
+        <PrivateFeature />
+      </ImputationPrivatePreviewGate>
+    );
+
+    expect(screen.getByTestId('private-feature')).toBeInTheDocument();
+    expect(screen.getByText('You have access to see this secret feature!')).toBeInTheDocument();
+
+    // Feature preview text should not be rendered
+    expect(screen.queryByText(/Thank you for registering for the/)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.test.tsx
@@ -28,9 +28,7 @@ describe('ImputationPrivatePreviewGate', () => {
     );
 
     expect(screen.getByText(/Thank you for registering for the/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/The All of Us \+ Anvil Imputation Service user interface is currently in private preview/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/user interface is currently in private preview/)).toBeInTheDocument();
 
     // Feature component should not be rendered
     expect(screen.queryByTestId('private-feature')).not.toBeInTheDocument();

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
@@ -10,7 +10,7 @@ interface FeaturePreviewLandingProps {
 }
 
 export const ImputationPrivatePreviewGate = ({ children }: FeaturePreviewLandingProps): ReactNode => {
-  const isFeatureEnabled = !isFeaturePreviewEnabled(IMPUTATION_UI);
+  const isFeatureEnabled = isFeaturePreviewEnabled(IMPUTATION_UI);
   return isFeatureEnabled ? (
     children
   ) : (

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
@@ -1,0 +1,64 @@
+import { ButtonPrimary, Icon } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+import colors from 'src/libs/colors';
+import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
+import { IMPUTATION_UI } from 'src/libs/feature-previews-config';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+
+interface FeaturePreviewLandingProps {
+  children: ReactNode;
+}
+
+export const ImputationPrivatePreviewGate = ({ children }: FeaturePreviewLandingProps): ReactNode => {
+  const isFeatureEnabled = !isFeaturePreviewEnabled(IMPUTATION_UI);
+  return isFeatureEnabled ? (
+    children
+  ) : (
+    <div
+      style={{
+        margin: '4rem 3rem',
+        padding: '1rem',
+        width: '40%',
+        minWidth: '300px',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: '1rem' }}>
+        <Icon icon='info-circle-regular' size={32} style={{ color: colors.primary(), marginRight: '0.5rem' }} />
+        <h2>
+          Thank you for registering for the{' '}
+          <span
+            style={{
+              fontStyle: 'italic',
+            }}
+          >
+            All of Us
+          </span>{' '}
+          + AnVIL Imputation Service.{' '}
+        </h2>
+      </div>
+      <div style={{ marginLeft: '2.5rem', marginTop: '1rem' }}>
+        The All of Us + Anvil Imputation Service user interface is currently in private preview and is not yet available
+        to all users. If you have any questions or would like to inquire about early access, please contact us at{' '}
+        <a
+          style={{ textDecoration: 'underline', color: '#46A3E9', fontWeight: 'bold' }}
+          href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
+        >
+          {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+        </a>
+        .
+        <div style={{ marginTop: '1rem' }}>
+          In the meantime, we invite you to use the All of Us + AnVIL Imputation Service using the Command Line
+          Interface (CLI).
+        </div>
+        <ButtonPrimary
+          style={{ marginTop: '1.5rem' }}
+          href='https://allofus-anvil-imputation.terra.bio/'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Try the CLI
+        </ButtonPrimary>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
@@ -5,6 +5,8 @@ import { isFeaturePreviewEnabled } from 'src/libs/feature-previews';
 import { IMPUTATION_UI } from 'src/libs/feature-previews-config';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 
+/* TODO: Delete this entire component once the Imputation UI is generally available. */
+
 interface FeaturePreviewLandingProps {
   children: ReactNode;
 }
@@ -19,7 +21,7 @@ export const ImputationPrivatePreviewGate = ({ children }: FeaturePreviewLanding
         margin: '4rem 3rem',
         padding: '1rem',
         width: '40%',
-        minWidth: '300px',
+        minWidth: '600px',
       }}
     >
       <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: '1rem' }}>

--- a/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
+++ b/src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate.tsx
@@ -39,8 +39,16 @@ export const ImputationPrivatePreviewGate = ({ children }: FeaturePreviewLanding
         </h2>
       </div>
       <div style={{ marginLeft: '2.5rem', marginTop: '1rem' }}>
-        The All of Us + Anvil Imputation Service user interface is currently in private preview and is not yet available
-        to all users. If you have any questions or would like to inquire about early access, please contact us at{' '}
+        The{' '}
+        <span
+          style={{
+            fontStyle: 'italic',
+          }}
+        >
+          All of Us
+        </span>{' '}
+        + AnVIL Imputation Service user interface is currently in private preview and is not yet available to all users.
+        If you have any questions or would like to inquire about early access, please contact us at{' '}
         <a
           style={{ textDecoration: 'underline', color: '#46A3E9', fontWeight: 'bold' }}
           href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
@@ -49,8 +57,15 @@ export const ImputationPrivatePreviewGate = ({ children }: FeaturePreviewLanding
         </a>
         .
         <div style={{ marginTop: '1rem' }}>
-          In the meantime, we invite you to use the All of Us + AnVIL Imputation Service using the Command Line
-          Interface (CLI).
+          In the meantime, we invite you to use the{' '}
+          <span
+            style={{
+              fontStyle: 'italic',
+            }}
+          >
+            All of Us
+          </span>{' '}
+          + AnVIL Imputation Service using the Command Line Interface (CLI).
         </div>
         <ButtonPrimary
           style={{ marginTop: '1.5rem' }}

--- a/src/pages/scientificServices/pipelines/views/About.tsx
+++ b/src/pages/scientificServices/pipelines/views/About.tsx
@@ -4,6 +4,7 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineList } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { ImputationPrivatePreviewGate } from 'src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate';
 
 export const About = () => {
   const [pipelines, setPipelines] = useState<PipelineList | null>(null);
@@ -28,36 +29,38 @@ export const About = () => {
   return (
     <FooterWrapper alwaysShow>
       {pipelinesTopBar('about')}
-      <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
-        <h1>Scientific Services from the Broad Data Sciences Platform</h1>
-        <h2 style={{ marginTop: '2rem' }}>Pipelines</h2>
+      <ImputationPrivatePreviewGate>
+        <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
+          <h1>Scientific Services from the Broad Data Sciences Platform</h1>
+          <h2 style={{ marginTop: '2rem' }}>Pipelines</h2>
 
-        {loading && <Spinner />}
+          {loading && <Spinner />}
 
-        {error && <div style={{ color: 'red' }}>{error}</div>}
+          {error && <div style={{ color: 'red' }}>{error}</div>}
 
-        {pipelines &&
-          pipelines.results.map((pipeline) => (
-            <div key={pipeline.pipelineName}>
-              <h3>{pipeline.displayName}</h3>
-              <div style={{ width: '50%' }}>
-                {pipeline.description ? pipeline.description : <em>No description available</em>}
+          {pipelines &&
+            pipelines.results.map((pipeline) => (
+              <div key={pipeline.pipelineName}>
+                <h3>{pipeline.displayName}</h3>
+                <div style={{ width: '50%' }}>
+                  {pipeline.description ? pipeline.description : <em>No description available</em>}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
 
-        <h2 style={{ marginTop: '2rem' }}>User Documentation</h2>
-        <div style={{ marginTop: '1rem' }}>
-          <a href='services/pipelines' style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}>
-            Get Started
-          </a>
+          <h2 style={{ marginTop: '2rem' }}>User Documentation</h2>
+          <div style={{ marginTop: '1rem' }}>
+            <a href='services/pipelines' style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}>
+              Get Started
+            </a>
+          </div>
+          <div style={{ marginTop: '1rem' }}>
+            <a href='services/pipelines' style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}>
+              About this Service
+            </a>
+          </div>
         </div>
-        <div style={{ marginTop: '1rem' }}>
-          <a href='services/pipelines' style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}>
-            About this Service
-          </a>
-        </div>
-      </div>
+      </ImputationPrivatePreviewGate>
     </FooterWrapper>
   );
 };

--- a/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
@@ -11,6 +11,15 @@ import { JobHistory } from './JobHistory';
 
 jest.mock('src/libs/ajax/teaspoons/Teaspoons');
 
+type FeaturePreviewExports = typeof import('src/libs/feature-previews');
+jest.mock(
+  'src/libs/feature-previews',
+  (): FeaturePreviewExports => ({
+    ...jest.requireActual('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn().mockReturnValue(true),
+  })
+);
+
 jest.mock('react-virtualized', () => {
   const actual = jest.requireActual('react-virtualized');
 

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -14,6 +14,7 @@ import {
   pipelinesTopBar,
   SCIENTIFIC_SERVICES_SUPPORT_EMAIL,
 } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { ImputationPrivatePreviewGate } from 'src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate';
 import { ViewErrorModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewErrorModal';
 import { ViewOutputsModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal';
 
@@ -44,77 +45,79 @@ export const JobHistory = () => {
   return (
     <FooterWrapper alwaysShow>
       {pipelinesTopBar('job history')}
-      <main
-        style={{
-          paddingLeft: '2rem',
-          paddingRight: '2rem',
-          paddingTop: '1rem',
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          rowGap: '1rem',
-        }}
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-          <h3>Job History</h3>
-          <div style={{ marginBottom: '0.25rem' }}>
-            All files associated with jobs will be automatically deleted after 2 weeks from completion.
+      <ImputationPrivatePreviewGate>
+        <main
+          style={{
+            paddingLeft: '2rem',
+            paddingRight: '2rem',
+            paddingTop: '1rem',
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            rowGap: '1rem',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+            <h3>Job History</h3>
+            <div style={{ marginBottom: '0.25rem' }}>
+              All files associated with jobs will be automatically deleted after 2 weeks from completion.
+            </div>
+            <div>
+              For support, email{' '}
+              <a
+                style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
+                href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
+              >
+                {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+              </a>
+            </div>
           </div>
-          <div>
-            For support, email{' '}
-            <a
-              style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
-              href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
-            >
-              {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
-            </a>
+          <div style={{ flex: 1, marginTop: '1rem' }}>
+            {pipelineRunsResponse ? (
+              <AutoSizer>
+                {({ width, height }) => (
+                  // Sorting is unsupported on this table for now. Eventually
+                  // we may update the paginated Teaspoons getAllPipelineRuns endpoint
+                  // to support filters and sorting. Until then, the results will be
+                  // sorted by creation date, with the most recent displayed first.
+                  <FlexTable
+                    aria-label='job history table'
+                    width={width}
+                    height={height}
+                    rowHeight={55}
+                    rowCount={pipelineRunsResponse.results.length}
+                    columns={getColumns(pipelineRunsResponse.results)}
+                    noContentMessage={pipelineRunsResponse.totalResults > 0 ? ' ' : 'Nothing to display'}
+                    tabIndex={-1}
+                    variant={undefined}
+                    styleHeader={() => ({ backgroundColor: '#eff0f1' })}
+                  />
+                )}
+              </AutoSizer>
+            ) : (
+              <Spinner />
+            )}
           </div>
-        </div>
-        <div style={{ flex: 1, marginTop: '1rem' }}>
-          {pipelineRunsResponse ? (
-            <AutoSizer>
-              {({ width, height }) => (
-                // Sorting is unsupported on this table for now. Eventually
-                // we may update the paginated Teaspoons getAllPipelineRuns endpoint
-                // to support filters and sorting. Until then, the results will be
-                // sorted by creation date, with the most recent displayed first.
-                <FlexTable
-                  aria-label='job history table'
-                  width={width}
-                  height={height}
-                  rowHeight={55}
-                  rowCount={pipelineRunsResponse.results.length}
-                  columns={getColumns(pipelineRunsResponse.results)}
-                  noContentMessage={pipelineRunsResponse.totalResults > 0 ? ' ' : 'Nothing to display'}
-                  tabIndex={-1}
-                  variant={undefined}
-                  styleHeader={() => ({ backgroundColor: '#eff0f1' })}
-                />
-              )}
-            </AutoSizer>
-          ) : (
-            <Spinner />
+          {!_.isEmpty(pipelineRunsResponse?.results) && (
+            <div style={{ marginBottom: '0.5rem' }}>
+              {/* @ts-ignore */}
+              <Paginator
+                filteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
+                unfilteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
+                pageNumber={pageNumber}
+                setPageNumber={(v) => {
+                  setPageNumber(v);
+                }}
+                itemsPerPage={itemsPerPage}
+                setItemsPerPage={(v) => {
+                  setPageNumber(1);
+                  setItemsPerPage(v);
+                }}
+              />
+            </div>
           )}
-        </div>
-        {!_.isEmpty(pipelineRunsResponse?.results) && (
-          <div style={{ marginBottom: '0.5rem' }}>
-            {/* @ts-ignore */}
-            <Paginator
-              filteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
-              unfilteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
-              pageNumber={pageNumber}
-              setPageNumber={(v) => {
-                setPageNumber(v);
-              }}
-              itemsPerPage={itemsPerPage}
-              setItemsPerPage={(v) => {
-                setPageNumber(1);
-                setItemsPerPage(v);
-              }}
-            />
-          </div>
-        )}
-      </main>
+        </main>
+      </ImputationPrivatePreviewGate>
     </FooterWrapper>
   );
 };

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -11,6 +11,15 @@ import { prepareUploadStartPipelineRun, RunJob } from './RunJob';
 // Mock dependencies
 jest.mock('src/libs/ajax/teaspoons/Teaspoons');
 
+type FeaturePreviewExports = typeof import('src/libs/feature-previews');
+jest.mock(
+  'src/libs/feature-previews',
+  (): FeaturePreviewExports => ({
+    ...jest.requireActual('src/libs/feature-previews'),
+    isFeaturePreviewEnabled: jest.fn().mockReturnValue(true),
+  })
+);
+
 // Mock page navigation functions
 jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -10,6 +10,7 @@ import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation } from 'src/libs/react-utils';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { ImputationPrivatePreviewGate } from 'src/pages/scientificServices/pipelines/components/ImputationPrivatePreviewGate';
 import { PipelineFileInput } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput';
 import { PipelineRunDescription } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineRunDescription';
 import { PipelineStringInput } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput';
@@ -211,150 +212,152 @@ export const RunJob = () => {
   return (
     <FooterWrapper alwaysShow>
       {pipelinesTopBar('run job')}
-      <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem 2rem' }}>
-        <div style={{ flex: 1, marginRight: '2rem' }}>
-          <h3 style={{ marginBottom: '0.5rem' }}>
-            Select a pipeline version <span style={{ color: '#DB3214' }}>*</span>
-          </h3>
-          <div style={{ marginBottom: '2rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <div style={{ width: 400 }}>
-                <Select
-                  aria-label={`selected pipeline ${selectedPipeline?.displayName}`}
-                  isDisabled={isEmpty(pipelineVersionOptions)}
-                  value={selectedPipeline}
-                  options={pipelineVersionOptions}
-                  getOptionLabel={(r) => r.label}
-                  onChange={(r) => {
-                    if (r === null) {
-                      return;
-                    }
-                    setSelectedPipeline(r.value);
-                  }}
-                  menuPortalTarget={getPopupRoot()}
-                />
-              </div>
-              {isEmpty(pipelineVersionOptions) && <Spinner />}
-            </div>
-            {selectedPipeline && (
-              <div style={{ width: '400px', marginTop: '0.5rem' }}>
-                {
-                  pipelinesList.find((pipeline) => pipeline.pipelineVersion === selectedPipeline.pipelineVersion)
-                    ?.description
-                }
-              </div>
-            )}
-          </div>
-
-          {!isLoading && (
-            <>
-              {/* Displays all STRING inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => input.type === 'STRING')
-                .map((input) => {
-                  return (
-                    <PipelineStringInput
-                      input={input}
-                      onChange={(value) =>
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: value,
-                        }))
+      <ImputationPrivatePreviewGate>
+        <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem 2rem' }}>
+          <div style={{ flex: 1, marginRight: '2rem' }}>
+            <h3 style={{ marginBottom: '0.5rem' }}>
+              Select a pipeline version <span style={{ color: '#DB3214' }}>*</span>
+            </h3>
+            <div style={{ marginBottom: '2rem' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <div style={{ width: 400 }}>
+                  <Select
+                    aria-label={`selected pipeline ${selectedPipeline?.displayName}`}
+                    isDisabled={isEmpty(pipelineVersionOptions)}
+                    value={selectedPipeline}
+                    options={pipelineVersionOptions}
+                    getOptionLabel={(r) => r.label}
+                    onChange={(r) => {
+                      if (r === null) {
+                        return;
                       }
-                      value={selectedUserInputs[input.name]}
-                      key={`${input.name}`}
-                    />
-                  );
-                })}
-
-              {/* Displays optional run description */}
-              <PipelineRunDescription value={runDescription} onChange={setRunDescription} />
-
-              {/* Displays all FILE inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => input.type === 'FILE')
-                .map((input) => {
-                  return (
-                    <PipelineFileInput
-                      key={`${input.name}`}
-                      input={input}
-                      uploadProgress={uploadProgress[input.name]}
-                      selectedFile={selectedUserInputs[input.name] || null}
-                      onFileSelect={(file) => {
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: file,
-                        }));
-                      }}
-                    />
-                  );
-                })}
-              {!submittedJobId && (
-                <ButtonPrimary
-                  disabled={!selectedPipeline || isSubmitting || !areAllRequiredInputsFilled()}
-                  style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
-                  onClick={handleSubmit}
-                >
-                  {isSubmitting ? 'Submitting...' : 'Submit'}
-                </ButtonPrimary>
+                      setSelectedPipeline(r.value);
+                    }}
+                    menuPortalTarget={getPopupRoot()}
+                  />
+                </div>
+                {isEmpty(pipelineVersionOptions) && <Spinner />}
+              </div>
+              {selectedPipeline && (
+                <div style={{ width: '400px', marginTop: '0.5rem' }}>
+                  {
+                    pipelinesList.find((pipeline) => pipeline.pipelineVersion === selectedPipeline.pipelineVersion)
+                      ?.description
+                  }
+                </div>
               )}
-              {submittedJobId && (
-                <>
-                  <div>
-                    <div
-                      style={{
-                        width: 500,
-                        border: '1px solid #8f95a0',
-                        borderRadius: '4px',
-                        padding: '1rem',
-                        marginTop: '1rem',
-                        backgroundColor: '#fff',
-                        display: 'flex',
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                      }}
-                    >
-                      <Icon icon='success-standard' size={36} style={{ color: '#74AE43', margin: '0 1rem' }} />
-                      <div>
-                        Your job has been submitted. You can check the status of that job by going to the{' '}
-                        <Link style={{ color: '#46A3E9' }} href={Nav.getLink('pipelines-history')}>
-                          Job History
-                        </Link>{' '}
-                        tab.
-                        <div style={{ marginTop: '1rem' }}>
-                          <span style={{ fontWeight: 'bold' }}>Job ID:</span> <code>{submittedJobId}</code>
-                          <ClipboardButton style={{ marginLeft: '0.5rem' }} text={submittedJobId} />
+            </div>
+
+            {!isLoading && (
+              <>
+                {/* Displays all STRING inputs, one after another */}
+                {pipelineInputs
+                  .filter((input) => input.type === 'STRING')
+                  .map((input) => {
+                    return (
+                      <PipelineStringInput
+                        input={input}
+                        onChange={(value) =>
+                          setSelectedUserInputs((prev) => ({
+                            ...prev,
+                            [input.name]: value,
+                          }))
+                        }
+                        value={selectedUserInputs[input.name]}
+                        key={`${input.name}`}
+                      />
+                    );
+                  })}
+
+                {/* Displays optional run description */}
+                <PipelineRunDescription value={runDescription} onChange={setRunDescription} />
+
+                {/* Displays all FILE inputs, one after another */}
+                {pipelineInputs
+                  .filter((input) => input.type === 'FILE')
+                  .map((input) => {
+                    return (
+                      <PipelineFileInput
+                        key={`${input.name}`}
+                        input={input}
+                        uploadProgress={uploadProgress[input.name]}
+                        selectedFile={selectedUserInputs[input.name] || null}
+                        onFileSelect={(file) => {
+                          setSelectedUserInputs((prev) => ({
+                            ...prev,
+                            [input.name]: file,
+                          }));
+                        }}
+                      />
+                    );
+                  })}
+                {!submittedJobId && (
+                  <ButtonPrimary
+                    disabled={!selectedPipeline || isSubmitting || !areAllRequiredInputsFilled()}
+                    style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
+                    onClick={handleSubmit}
+                  >
+                    {isSubmitting ? 'Submitting...' : 'Submit'}
+                  </ButtonPrimary>
+                )}
+                {submittedJobId && (
+                  <>
+                    <div>
+                      <div
+                        style={{
+                          width: 500,
+                          border: '1px solid #8f95a0',
+                          borderRadius: '4px',
+                          padding: '1rem',
+                          marginTop: '1rem',
+                          backgroundColor: '#fff',
+                          display: 'flex',
+                          flexDirection: 'row',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <Icon icon='success-standard' size={36} style={{ color: '#74AE43', margin: '0 1rem' }} />
+                        <div>
+                          Your job has been submitted. You can check the status of that job by going to the{' '}
+                          <Link style={{ color: '#46A3E9' }} href={Nav.getLink('pipelines-history')}>
+                            Job History
+                          </Link>{' '}
+                          tab.
+                          <div style={{ marginTop: '1rem' }}>
+                            <span style={{ fontWeight: 'bold' }}>Job ID:</span> <code>{submittedJobId}</code>
+                            <ClipboardButton style={{ marginLeft: '0.5rem' }} text={submittedJobId} />
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
-                  <ButtonPrimary
-                    disabled={!selectedPipeline || isSubmitting}
-                    style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
-                    onClick={() => {
-                      resetSelectedUserInputs();
-                      setRunDescription('');
-                      setSubmittedJobId(undefined);
-                      setUploadProgress({});
-                    }}
-                  >
-                    Run another job
-                  </ButtonPrimary>
-                </>
-              )}
-            </>
-          )}
-          {isLoading && (
-            <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Spinner /> Loading pipeline details...
-            </div>
-          )}
+                    <ButtonPrimary
+                      disabled={!selectedPipeline || isSubmitting}
+                      style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
+                      onClick={() => {
+                        resetSelectedUserInputs();
+                        setRunDescription('');
+                        setSubmittedJobId(undefined);
+                        setUploadProgress({});
+                      }}
+                    >
+                      Run another job
+                    </ButtonPrimary>
+                  </>
+                )}
+              </>
+            )}
+            {isLoading && (
+              <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <Spinner /> Loading pipeline details...
+              </div>
+            )}
+          </div>
+          <div>
+            <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
+            <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
+          </div>
         </div>
-        <div>
-          <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
-          <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
-        </div>
-      </div>
+      </ImputationPrivatePreviewGate>
     </FooterWrapper>
   );
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-567

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

<img width="1200" height="905" alt="screencapture-localhost-3000-2025-08-13-13_06_33" src="https://github.com/user-attachments/assets/f9aa80d2-006e-4b1f-ab4f-fb068ea5935b" />



### What
- Puts Imputation UI behind a private preview
- Adds a new landing page to show users who don't yet have access

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
