### PR TITLE
[TSPS-560] Update paths and hostname for Imputation UI

### DIFF
--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -436,7 +436,7 @@ export const brands: Record<string, BrandConfiguration> = {
     landingPageBackgroundSize: 'cover',
     welcomeHeader: <ScientificServicesWelcomeHeader />,
     description: <ScientificServicesDescription />,
-    hostName: 'app.terra.bio', // TODO: TSPS-484, provision scientificservices.terra.bio (or something)
+    hostName: 'services.terra.bio',
     compactTopBar: true,
     docLinks: [],
     landingPageCards: [],

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -5,19 +5,19 @@ import { RunJob } from 'src/pages/scientificServices/pipelines/views/RunJob';
 export const navPaths = [
   {
     name: 'pipelines-about',
-    path: '/services/pipelines',
+    path: '/imputation',
     component: About,
     title: 'Home',
   },
   {
     name: 'pipelines-run',
-    path: '/services/pipelines/run',
+    path: '/imputation/run',
     component: RunJob,
     title: 'Run Job',
   },
   {
     name: 'pipelines-history',
-    path: '/services/pipelines/history',
+    path: '/imputation/history',
     component: JobHistory,
     title: 'Job History',
   },

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -5,19 +5,19 @@ import { RunJob } from 'src/pages/scientificServices/pipelines/views/RunJob';
 export const navPaths = [
   {
     name: 'pipelines-about',
-    path: '/imputation',
+    path: '/pipelines/imputation',
     component: About,
     title: 'Home',
   },
   {
     name: 'pipelines-run',
-    path: '/imputation/run',
+    path: '/pipelines/imputation/run',
     component: RunJob,
     title: 'Run Job',
   },
   {
     name: 'pipelines-history',
-    path: '/imputation/history',
+    path: '/pipelines/imputation/history',
     component: JobHistory,
     title: 'Job History',
   },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Updates hostname, which will automatically trigger the branding
- Updates some routes based on team discussion

### Why
- Nesting under /services was redundant, since the subdomain will be services.terra.bio. We also wanted to specifically call out imputation in the path

### Testing strategy
N/A
