### PR TITLE
[CORE-630] Rename NIH External Identity to NHGRI AnVIL (eRA Commons)

### DIFF
--- a/src/profile/external-identities/ExternalIdentities.test.tsx
+++ b/src/profile/external-identities/ExternalIdentities.test.tsx
@@ -24,7 +24,7 @@ jest.mock('src/profile/external-identities/OAuth2Account', () => ({
 
 jest.mock('src/profile/external-identities/NihAccount', () => ({
   ...jest.requireActual('src/profile/external-identities/NihAccount'),
-  NihAccount: jest.fn(() => <div>Nih Account</div>),
+  NihAccount: jest.fn(() => <div>NHGRI AnVIL (eRA Commons)</div>),
 }));
 
 describe('ExternalIdentities', () => {
@@ -85,7 +85,7 @@ describe('ExternalIdentities', () => {
     const providerElements = Array.from(screen.getByRole('main').querySelectorAll('div')).map((div) => div.textContent);
     expect(providerElements).toStrictEqual([
       'NIH Researcher Auth Service (RAS)',
-      'Nih Account',
+      'NHGRI AnVIL (eRA Commons)',
       'NHLBI BioData Catalyst Framework Services',
       'NCI CRDC Framework Services',
       'Kids First DRC Framework Services',

--- a/src/profile/external-identities/NihAccount.ts
+++ b/src/profile/external-identities/NihAccount.ts
@@ -58,13 +58,19 @@ export const NihAccount = ({ nihToken }) => {
 
   const isLinked = !!linkedNihUsername && !isLinking;
 
+  const toolTipLinkProps = {
+    style: { textDecoration: 'underline' },
+    target: '_blank',
+  };
+
   return div({ style: styles.idLink.container }, [
     div({ style: styles.idLink.linkContentTop(isLinked) }, [
       div({ style: { ...styles.form.title, marginBottom: 0 } }, [
-        h3({ style: { marginRight: '0.5rem', ...styles.idLink.linkName } }, ['NIH Account']),
+        h3({ style: { marginRight: '0.5rem', ...styles.idLink.linkName } }, ['NHGRI AnVIL (eRA Commons)']),
         h(InfoBox, [
-          'Linking with eRA Commons will allow Terra to automatically determine if you can access controlled datasets hosted in Terra (ex. TCGA) ',
-          'based on your valid dbGaP applications.',
+          'Linking with eRA Commons will allow Terra to automatically determine if you can access controlled AnVIL datasets hosted in Terra based on your valid dbGaP applications. Visit ',
+          h(Link, { href: 'https://anvilproject.org/', ...toolTipLinkProps }, ['AnVIL Portal']),
+          ' to see what datasets are available.',
         ]),
       ]),
       Utils.cond(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-630

### What
- Change “NIH Account” to “NHGRI AnVIL (eRA Commons)”.
- Update tooltip to explain that linking eRA Commons enables Terra to check AnVIL dataset access via dbGaP.

### Why
- After [CORE-609](https://broadworkbench.atlassian.net/browse/CORE-609), Terra only manages access for AnVIL data. The External Identities page should reflect this to avoid confusion.

### Testing strategy
 - Unit Testing
   - Updated existing unit tests to ensure the new name  is visible
 - Manual Testing
   - Check that the new name and tooltip display correctly in the UI.
   - Verify linking/unlinking with eRA Commons still works.

### Screens

<img width="1799" height="1039" alt="After" src="https://github.com/user-attachments/assets/9ff6e21f-1068-4ccf-a097-f3c5d2f55e71" />


[CORE-609]: https://broadworkbench.atlassian.net/browse/CORE-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ