### PR TITLE
[TSPS-522] Capture Mixpanel metrics for Imputation UI

### DIFF
--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -88,7 +88,12 @@ const eventsList = {
   provenanceFile: 'provenance:file',
   resourceLeave: 'resource:leave',
   teaspoons: {
-    fileUpload: 'teaspoons:fileUpload',
+    // teaspoons:{pageName}:{actionName}
+    fileUpload: 'teaspoons:runJob:fileUpload',
+    submitJob: 'teaspoons:runJob:submitJob',
+    viewJobOutputs: 'teaspoons:jobHistory:viewJobOutputs',
+    downloadJobOutputFile: 'teaspoons:jobHistory:downloadJobOutputFile',
+    viewJobErrors: 'teaspoons:jobHistory:viewJobErrors',
   },
   uploaderCreateCollection: 'uploader:collection:create',
   uploaderUploadMetadata: 'uploader:metadata:upload',

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -87,6 +87,9 @@ const eventsList = {
   provenanceColumn: 'provenance:column',
   provenanceFile: 'provenance:file',
   resourceLeave: 'resource:leave',
+  teaspoons: {
+    fileUpload: 'teaspoons:fileUpload',
+  },
   uploaderCreateCollection: 'uploader:collection:create',
   uploaderUploadMetadata: 'uploader:metadata:upload',
   uploaderCreateTable: 'uploader:table:create',

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -6,9 +6,11 @@ import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { AutoSizer } from 'react-virtualized';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { FlexTable, HeaderCell, Paginator, TooltipCell } from 'src/components/table';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { GetPipelineRunsResponse, PipelineRun } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
+import Events from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
 import {
   pipelinesTopBar,
@@ -304,7 +306,13 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
               cursor: 'pointer',
               font: 'inherit',
             }}
-            onClick={() => outputsModal.open({ jobId: pipelineRun.jobId })}
+            onClick={() => {
+              outputsModal.open({ jobId: pipelineRun.jobId });
+              Metrics().captureEvent(Events.teaspoons.viewJobOutputs, {
+                pipelineName: pipelineRun.pipelineName,
+                pipelineVersion: pipelineRun.pipelineVersion,
+              });
+            }}
           >
             View Outputs
           </button>
@@ -325,7 +333,13 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
               cursor: 'pointer',
               font: 'inherit',
             }}
-            onClick={() => errorModal.open({ jobId: pipelineRun.jobId })}
+            onClick={() => {
+              errorModal.open({ jobId: pipelineRun.jobId });
+              Metrics().captureEvent(Events.teaspoons.viewJobErrors, {
+                pipelineName: pipelineRun.pipelineName,
+                pipelineVersion: pipelineRun.pipelineVersion,
+              });
+            }}
           >
             View Error
           </button>
@@ -346,7 +360,13 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
               cursor: 'pointer',
               font: 'inherit',
             }}
-            onClick={() => errorModal.open({ jobId: pipelineRun.jobId })}
+            onClick={() => {
+              errorModal.open({ jobId: pipelineRun.jobId });
+              Metrics().captureEvent(Events.teaspoons.viewJobErrors, {
+                pipelineName: pipelineRun.pipelineName,
+                pipelineVersion: pipelineRun.pipelineVersion,
+              });
+            }}
           >
             View Error
           </button>

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -19,11 +19,14 @@ import { PipelineStringInput } from 'src/pages/scientificServices/pipelines/comp
 import { HelpfulTipsWidget } from 'src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget';
 import { QuotaRemainingWidget } from 'src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget';
 
+// Returns the time taken to upload the file (for Mixpanel)
 async function uploadFileWithSignedUrl(
   inputFile: File,
   signedUrl: string,
   onProgress?: (percent: number) => void
-): Promise<void> {
+): Promise<number> {
+  const startTime = Date.now();
+
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
@@ -36,7 +39,9 @@ async function uploadFileWithSignedUrl(
 
     xhr.addEventListener('load', () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve();
+        const endTime = Date.now();
+        const duration = endTime - startTime;
+        resolve(duration);
       } else {
         reject(new Error(`Upload failed with status ${xhr.status}`));
       }
@@ -87,7 +92,7 @@ export async function prepareUploadStartPipelineRun(
         const file = selectedUserInputs[input.name];
         const signedUrl = fileInputUploadUrls[input.name].signedUrl;
         if (file instanceof File) {
-          await uploadFileWithSignedUrl(file, signedUrl, (percent) => {
+          const fileUploadDurationMillis = await uploadFileWithSignedUrl(file, signedUrl, (percent) => {
             setUploadProgress((prev) => ({
               ...prev,
               [input.name]: percent,
@@ -100,7 +105,7 @@ export async function prepareUploadStartPipelineRun(
             pipelineVersion,
             fileSize: file.size,
             fileType: file.type,
-            fileUploadDuration: 1234, // Placeholder, actual duration can be calculated if needed
+            fileUploadDurationMillis,
           });
 
           return;
@@ -109,7 +114,7 @@ export async function prepareUploadStartPipelineRun(
       })
   );
 
-  // await Teaspoons().startPipelineRun(jobId);
+  await Teaspoons().startPipelineRun(jobId);
   return jobId;
 }
 

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -4,8 +4,10 @@ import React, { useEffect, useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { getPopupRoot } from 'src/components/popup-utils';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { useCancellation } from 'src/libs/react-utils';
@@ -85,18 +87,29 @@ export async function prepareUploadStartPipelineRun(
         const file = selectedUserInputs[input.name];
         const signedUrl = fileInputUploadUrls[input.name].signedUrl;
         if (file instanceof File) {
-          return await uploadFileWithSignedUrl(file, signedUrl, (percent) => {
+          await uploadFileWithSignedUrl(file, signedUrl, (percent) => {
             setUploadProgress((prev) => ({
               ...prev,
               [input.name]: percent,
             }));
           });
+
+          // Capture the file upload metrics, but don't wait for the request to complete
+          Metrics().captureEvent(Events.teaspoons.fileUpload, {
+            pipelineName,
+            pipelineVersion,
+            fileSize: file.size,
+            fileType: file.type,
+            fileUploadDuration: 1234, // Placeholder, actual duration can be calculated if needed
+          });
+
+          return;
         }
         throw new Error(`Expected a File for input ${input.name}, but got ${typeof file}`);
       })
   );
 
-  await Teaspoons().startPipelineRun(jobId);
+  // await Teaspoons().startPipelineRun(jobId);
   return jobId;
 }
 

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -99,7 +99,8 @@ export async function prepareUploadStartPipelineRun(
             }));
           });
 
-          // Capture the file upload metrics, but don't wait for the request to complete
+          // Capture the file upload metrics. We don't await the Mixpanel metrics capture
+          // because we don't want to block the user from proceeding, so this is a fire-and-forget.
           Metrics().captureEvent(Events.teaspoons.fileUpload, {
             pipelineName,
             pipelineVersion,

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -224,6 +224,10 @@ export const RunJob = () => {
       notify('error', `Pipeline failed to submit. ${errorMessage}`);
     } finally {
       setIsSubmitting(false);
+      Metrics().captureEvent(Events.teaspoons.submitJob, {
+        pipelineName,
+        pipelineVersion: selectedPipeline.pipelineVersion,
+      });
     }
   };
 

--- a/src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal.tsx
+++ b/src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal.tsx
@@ -1,8 +1,10 @@
 import { ButtonPrimary, Icon, Modal, Spinner } from '@terra-ui-packages/components';
 import { formatDate } from '@terra-ui-packages/core-utils';
 import React, { ReactNode, useEffect, useState } from 'react';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import Events from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
 
 /**
@@ -69,6 +71,11 @@ export const ViewOutputsModal = ({ jobId, onDismiss }: OutputsModalProps): React
                     <ButtonPrimary
                       onClick={() => {
                         window.open(url, '_blank');
+                        Metrics().captureEvent(Events.teaspoons.downloadJobOutputFile, {
+                          pipelineName: result.pipelineRunReport.pipelineName,
+                          pipelineVersion: result.pipelineRunReport.pipelineVersion,
+                          outputName: key,
+                        });
                       }}
                       style={{ marginLeft: '1rem' }}
                     >


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-522

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Adds new Mixpanel events to capture when a user performs the following actions:

* Uploads a file(how big was the file? how long did it take to upload? what was the file type?)
* Submits a job
* Views the job outputs modal
* Downloads an output file
* Views the job errors modal

Captures the pipelineName and pipelineVersion for all of the above so we can slice metrics across future pipelines.

Here's an example of what a fileUpload event looks like in the Mixpanel dashboard:
<img width="810" height="908" alt="Screenshot 2025-08-20 at 1 06 43 PM" src="https://github.com/user-attachments/assets/c013884a-ab40-49ba-a99a-f4e79b172d17" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
