### PR TITLE
[CORE-645] Support IGV loading when genomic file and index file are on different rows

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -6,6 +6,7 @@ import ButtonBar from 'src/components/ButtonBar';
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common';
 import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/IGVReferenceSelector';
 import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { useCancellation } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -25,8 +26,8 @@ const splitExtension = (fileUrl) => {
 const getCompoundExtension = (fileUrl) => {
   const splitPath = fileUrl.split('?')[0].split('.');
   const numExtensions = splitPath.length > 2 ? 2 : 1;
-  const compoundExtension = splitPath.slice(-1 * numExtensions).join('.');
-  return compoundExtension;
+
+  return splitPath.slice(-1 * numExtensions).join('.');
 };
 
 export const getIgvMetricDetails = (selectedFiles, refGenome) => {
@@ -71,7 +72,24 @@ function indexMap(base) {
   };
 }
 
-const findIndexForFile = (fileUrl, fileUrls) => {
+const searchDBForIndexFiles = async (workspace, entityType, indexCandidates, signal) => {
+  const { namespace, name } = workspace.workspace;
+
+  const searchResponse = await Workspaces(signal)
+    .workspace(namespace, name)
+    .paginatedEntitiesOfType(entityType, {
+      filterOperator: 'or',
+      filterTerms: indexCandidates.join(' '),
+    });
+
+  // Look for any attribute value that matches one of the index candidates
+  return _.find(
+    (attr) => _.some((candidate) => attr?.includes(candidate), indexCandidates),
+    _.flatMap((result) => _.values(result.attributes), searchResponse.results)
+  );
+};
+
+const findIndexForFile = async (workspace, entityType, fileUrl, fileUrls, signal) => {
   if (!genomicFiles.some((extension) => fileUrl.pathname.endsWith(extension))) {
     return undefined;
   }
@@ -92,8 +110,11 @@ const findIndexForFile = (fileUrl, fileUrls) => {
 
   const [base, extension] = splitExtension(fileUrl.pathname);
   const indexCandidates = indexMap(base)[extension];
-
-  return fileUrls.find((url) => indexCandidates.includes(url.pathname));
+  const foundIndex = fileUrls.find((url) => indexCandidates.includes(url.pathname));
+  if (foundIndex) {
+    return foundIndex;
+  }
+  return await searchDBForIndexFiles(workspace, entityType, indexCandidates, signal);
 };
 
 // Determine whether filename has an IGV-eligible extension
@@ -129,7 +150,7 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
   return igvAccessUrls;
 };
 
-export const getValidIgvFiles = async (values, signal) => {
+export const getValidIgvFiles = async (workspace, entityType, values, signal) => {
   const basicFileUrls = values.filter((value) => {
     let url;
     try {
@@ -167,32 +188,35 @@ export const getValidIgvFiles = async (values, signal) => {
     fileUrls.push(url);
   });
 
-  return fileUrls.flatMap((fileUrl) => {
-    const filePath = fileUrl.href;
-    const isSignedUrl = fileUrl.isSignedUrl;
-    if (fileUrl.pathname.endsWith('.bed')) {
-      return [{ filePath, indexFilePath: false, isSignedUrl }];
-    }
-    const indexFileUrl = findIndexForFile(fileUrl, fileUrls);
-    if (indexFileUrl !== undefined) {
-      return [{ filePath, indexFilePath: indexFileUrl.href, isSignedUrl }];
-    }
-    return [];
-  });
+  const results = await Promise.all(
+    fileUrls.map(async (fileUrl) => {
+      const filePath = fileUrl.href;
+      const isSignedUrl = fileUrl.isSignedUrl;
+      if (fileUrl.pathname.endsWith('.bed')) {
+        return [{ filePath, indexFilePath: false, isSignedUrl }];
+      }
+      const indexFileUrl = await findIndexForFile(workspace, entityType, fileUrl, fileUrls, signal);
+      if (indexFileUrl !== undefined) {
+        return [{ filePath, indexFilePath: indexFileUrl.href, isSignedUrl }];
+      }
+      return [];
+    })
+  );
+
+  return results.flat();
 };
 
-export const getValidIgvFilesFromAttributeValues = async (attributeValues, signal) => {
+export const getValidIgvFilesFromAttributeValues = async (workspace, entityType, attributeValues, signal) => {
   const allAttributeStrings = _.flatMap(getStrings, attributeValues);
 
-  const validIgvFiles = await getValidIgvFiles(allAttributeStrings, signal);
-  return validIgvFiles;
+  return await getValidIgvFiles(workspace, entityType, allAttributeStrings, signal);
 };
 
 export const isDrsUri = (value) => {
   return !!value?.toString().startsWith('drs://');
 };
 
-const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
+const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess }) => {
   const [refGenome, setRefGenome] = useState(defaultIgvReference);
   const isRefGenomeValid = Boolean(_.get('genome', refGenome) || _.get('reference.fastaURL', refGenome));
 
@@ -211,12 +235,12 @@ const IGVFileSelector = ({ selectedEntities, onSuccess }) => {
       const drsCandidateFiles = allAttributeValues.filter((value) => isDrsUri(value));
       setHasDrsCandidateFiles(drsCandidateFiles.length >= 2);
 
-      const selections = await getValidIgvFilesFromAttributeValues(allAttributeValues, signal);
+      const selections = await getValidIgvFilesFromAttributeValues(workspace, entityType, allAttributeValues, signal);
       setHasDrsCandidateFiles(selections.length >= 1);
       setSelections(selections);
     }
     fetchData();
-  }, [selectedEntities, setSelections, signal]);
+  }, [workspace, entityType, selectedEntities, setSelections, signal]);
 
   const toggleSelected = (index) => setSelections(_.update([index, 'isSelected'], (v) => !v));
   const numSelected = _.countBy('isSelected', selections).true;

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -74,19 +74,17 @@ function indexMap(base) {
 
 const searchDBForIndexFiles = async (workspace, entityType, indexCandidates, signal) => {
   const { namespace, name } = workspace.workspace;
-
-  const searchResponse = await Workspaces(signal)
-    .workspace(namespace, name)
-    .paginatedEntitiesOfType(entityType, {
-      filterOperator: 'or',
-      filterTerms: indexCandidates.join(' '),
-    });
+  const filterCandidates = indexCandidates.map((candidate) => candidate.split('/').pop()).join(' ');
+  const searchResponse = await Workspaces(signal).workspace(namespace, name).paginatedEntitiesOfType(entityType, {
+    filterOperator: 'or',
+    filterTerms: filterCandidates,
+  });
 
   // Look for any attribute value that matches one of the index candidates
-  return _.find(
-    (attr) => _.some((candidate) => attr?.includes(candidate), indexCandidates),
-    _.flatMap((result) => _.values(result.attributes), searchResponse.results)
-  );
+  return searchResponse.results.filter((result) => {
+    const fileName = result.attributes.file_name;
+    return filterCandidates.includes(fileName);
+  });
 };
 
 const findIndexForFile = async (workspace, entityType, fileUrl, fileUrls, signal) => {
@@ -221,23 +219,17 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   const isRefGenomeValid = Boolean(_.get('genome', refGenome) || _.get('reference.fastaURL', refGenome));
 
   const [selections, setSelections] = useState([]);
-  const [hasDrsCandidateFiles, setHasDrsCandidateFiles] = useState(false);
+  const [isSearchingFiles, setIsSearchingFiles] = useState(true);
 
   const signal = useCancellation();
 
   useEffect(() => {
     async function fetchData() {
       const allAttributeValues = _.flatMap(_.flow(_.get('attributes'), _.values), selectedEntities);
-
-      // If there are 2 or more DRS URIs in this row, then IGV might be openable.
-      // This lets us know we need to show a loading message while awaiting DRS URI
-      // resolution to confirm if IGV is indeed openable for the selections.
-      const drsCandidateFiles = allAttributeValues.filter((value) => isDrsUri(value));
-      setHasDrsCandidateFiles(drsCandidateFiles.length >= 2);
-
       const selections = await getValidIgvFilesFromAttributeValues(workspace, entityType, allAttributeValues, signal);
-      setHasDrsCandidateFiles(selections.length >= 1);
+
       setSelections(selections);
+      setIsSearchingFiles(false);
     }
     fetchData();
   }, [workspace, entityType, selectedEntities, setSelections, signal]);
@@ -246,7 +238,7 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   const numSelected = _.countBy('isSelected', selections).true;
   const isSelectionValid = !!numSelected;
 
-  const noRowsMessage = hasDrsCandidateFiles ? 'Searching for valid files with indices...' : 'No valid files with indices found';
+  const noRowsMessage = isSearchingFiles ? 'Searching for valid files with indices...' : 'No valid files with indices found';
 
   return div({ style: Style.modalDrawer.content }, [
     h(IGVReferenceSelector, {

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -45,6 +45,11 @@ describe('getValidIgvFiles', () => {
       )
     ).toEqual([
       {
+        filePath: 'gs://bucket/test1.bam',
+        indexFilePath: undefined,
+        isSignedUrl: false,
+      },
+      {
         filePath: 'gs://bucket/test2.bam',
         indexFilePath: 'gs://bucket/test2.bai',
         isSignedUrl: false,
@@ -71,6 +76,11 @@ describe('getValidIgvFiles', () => {
         mockSignal
       )
     ).toEqual([
+      {
+        filePath: 'gs://bucket/test1.cram',
+        indexFilePath: undefined,
+        isSignedUrl: false,
+      },
       {
         filePath: 'gs://bucket/test2.cram',
         indexFilePath: 'gs://bucket/test2.crai',
@@ -105,6 +115,11 @@ describe('getValidIgvFiles', () => {
         mockSignal
       )
     ).toEqual([
+      {
+        filePath: 'gs://bucket/test1.vcf',
+        indexFilePath: undefined,
+        isSignedUrl: false,
+      },
       {
         filePath: 'gs://bucket/test2.vcf',
         indexFilePath: 'gs://bucket/test2.idx',
@@ -289,7 +304,13 @@ describe('getValidIgvFilesFromAttributeValues', () => {
         ],
         mockSignal
       )
-    ).toEqual([]);
+    ).toEqual([
+      {
+        filePath: 'https://bucket/foo.vcf.gz?requestedBy=user@domain.tls&userProject=my-billing-project&signature=secret',
+        indexFilePath: undefined,
+        isSignedUrl: true,
+      },
+    ]);
   });
 
   it('robustly detects data table values that are DRS URIs', () => {

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -2,19 +2,47 @@ import { getIgvMetricDetails, getValidIgvFiles, getValidIgvFilesFromAttributeVal
 import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
 
 jest.mock('src/libs/ajax/drs/DrsUriResolver');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
+
+jest.mock('src/libs/ajax/workspaces/Workspaces', () => ({
+  Workspaces: jest.fn(() => ({
+    workspace: jest.fn(() => ({
+      paginatedEntitiesOfType: jest.fn(() =>
+        Promise.resolve({
+          results: [
+            {
+              attributes: {
+                someAttribute: ['mockedIndexFile1', 'mockedIndexFile2'],
+              },
+            },
+          ],
+        })
+      ),
+    })),
+  })),
+}));
+
+const mockWorkspace = { workspace: { namespace: 'ns', name: 'ws' } };
+const mockEntityType = 'entityType';
+const mockSignal = undefined;
 
 describe('getValidIgvFiles', () => {
   it('allows BAM files with indices', async () => {
     expect(
-      await getValidIgvFiles([
-        'gs://bucket/test1.bam',
-        'gs://bucket/test2.bam',
-        'gs://bucket/test2.bai',
-        'gs://bucket/test3.bam',
-        'gs://bucket/test3.bam.bai',
-        'gs://bucket/test4.sorted.bam',
-        'gs://bucket/test4.sorted.bam.bai',
-      ])
+      await getValidIgvFiles(
+        mockWorkspace,
+        mockEntityType,
+        [
+          'gs://bucket/test1.bam',
+          'gs://bucket/test2.bam',
+          'gs://bucket/test2.bai',
+          'gs://bucket/test3.bam',
+          'gs://bucket/test3.bam.bai',
+          'gs://bucket/test4.sorted.bam',
+          'gs://bucket/test4.sorted.bam.bai',
+        ],
+        mockSignal
+      )
     ).toEqual([
       {
         filePath: 'gs://bucket/test2.bam',
@@ -36,13 +64,12 @@ describe('getValidIgvFiles', () => {
 
   it('allows CRAM files with indices', async () => {
     expect(
-      await getValidIgvFiles([
-        'gs://bucket/test1.cram',
-        'gs://bucket/test2.cram',
-        'gs://bucket/test2.crai',
-        'gs://bucket/test3.cram',
-        'gs://bucket/test3.cram.crai',
-      ])
+      await getValidIgvFiles(
+        mockWorkspace,
+        mockEntityType,
+        ['gs://bucket/test1.cram', 'gs://bucket/test2.cram', 'gs://bucket/test2.crai', 'gs://bucket/test3.cram', 'gs://bucket/test3.cram.crai'],
+        mockSignal
+      )
     ).toEqual([
       {
         filePath: 'gs://bucket/test2.cram',
@@ -59,19 +86,24 @@ describe('getValidIgvFiles', () => {
 
   it('allows VCF files with indices', async () => {
     expect(
-      await getValidIgvFiles([
-        'gs://bucket/test1.vcf',
-        'gs://bucket/test2.vcf',
-        'gs://bucket/test2.idx',
-        'gs://bucket/test3.vcf',
-        'gs://bucket/test3.vcf.idx',
-        'gs://bucket/test4.vcf',
-        'gs://bucket/test4.tbi',
-        'gs://bucket/test5.vcf',
-        'gs://bucket/test5.vcf.tbi',
-        'gs://bucket/test6.vcf.gz',
-        'gs://bucket/test6.vcf.gz.tbi',
-      ])
+      await getValidIgvFiles(
+        mockWorkspace,
+        mockEntityType,
+        [
+          'gs://bucket/test1.vcf',
+          'gs://bucket/test2.vcf',
+          'gs://bucket/test2.idx',
+          'gs://bucket/test3.vcf',
+          'gs://bucket/test3.vcf.idx',
+          'gs://bucket/test4.vcf',
+          'gs://bucket/test4.tbi',
+          'gs://bucket/test5.vcf',
+          'gs://bucket/test5.vcf.tbi',
+          'gs://bucket/test6.vcf.gz',
+          'gs://bucket/test6.vcf.gz.tbi',
+        ],
+        mockSignal
+      )
     ).toEqual([
       {
         filePath: 'gs://bucket/test2.vcf',
@@ -102,7 +134,7 @@ describe('getValidIgvFiles', () => {
   });
 
   it('allows BED files', async () => {
-    expect(await getValidIgvFiles(['gs://bucket/test.bed'])).toEqual([
+    expect(await getValidIgvFiles(mockWorkspace, mockEntityType, ['gs://bucket/test.bed'], mockSignal)).toEqual([
       {
         filePath: 'gs://bucket/test.bed',
         indexFilePath: false,
@@ -112,7 +144,9 @@ describe('getValidIgvFiles', () => {
   });
 
   it('requires GCS URLs', async () => {
-    expect(await getValidIgvFiles(['gs://bucket/test.bed', 'https://example.com/test.bed', 'test.bed'])).toEqual([
+    expect(
+      await getValidIgvFiles(mockWorkspace, mockEntityType, ['gs://bucket/test.bed', 'https://example.com/test.bed', 'test.bed'], mockSignal)
+    ).toEqual([
       {
         filePath: 'gs://bucket/test.bed',
         indexFilePath: false,
@@ -124,10 +158,15 @@ describe('getValidIgvFiles', () => {
   describe('TDR URLs', () => {
     it('allows TDR URLs', async () => {
       expect(
-        await getValidIgvFiles([
-          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
-          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
-        ])
+        await getValidIgvFiles(
+          mockWorkspace,
+          mockEntityType,
+          [
+            'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+            'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+          ],
+          mockSignal
+        )
       ).toEqual([
         {
           filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
@@ -139,10 +178,15 @@ describe('getValidIgvFiles', () => {
 
     it('allows TDR URLs with additional path segments', async () => {
       expect(
-        await getValidIgvFiles([
-          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/path/to/test.bam',
-          'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/path/to/test.bam.bai',
-        ])
+        await getValidIgvFiles(
+          mockWorkspace,
+          mockEntityType,
+          [
+            'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/path/to/test.bam',
+            'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/path/to/test.bam.bai',
+          ],
+          mockSignal
+        )
       ).toEqual([
         {
           filePath: 'gs://datarepo-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/path/to/test.bam',
@@ -155,10 +199,15 @@ describe('getValidIgvFiles', () => {
 
     it('allows TDR URLs from non-production environments', async () => {
       expect(
-        await getValidIgvFiles([
-          'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
-          'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
-        ])
+        await getValidIgvFiles(
+          mockWorkspace,
+          mockEntityType,
+          [
+            'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
+            'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/2eeff61f-ae9e-41ae-bb40-909ff6bdfba8/test.bam.bai',
+          ],
+          mockSignal
+        )
       ).toEqual([
         {
           filePath: 'gs://datarepo-dev-ab123456-bucket/cae37a2a-657f-4b04-9fef-59c215020078/5f5f634d-70f3-4914-9c71-9d14c7f98e60/test.bam',
@@ -173,12 +222,17 @@ describe('getValidIgvFiles', () => {
 describe('getValidIgvFilesFromAttributeValues', () => {
   it('gets all valid files from lists', async () => {
     expect(
-      await getValidIgvFilesFromAttributeValues([
-        {
-          itemsType: 'AttributeValue',
-          items: ['gs://bucket/test1.bed', 'gs://bucket/test2.bed', 'gs://bucket/test3.bed'],
-        },
-      ])
+      await getValidIgvFilesFromAttributeValues(
+        mockWorkspace,
+        mockEntityType,
+        [
+          {
+            itemsType: 'AttributeValue',
+            items: ['gs://bucket/test1.bed', 'gs://bucket/test2.bed', 'gs://bucket/test3.bed'],
+          },
+        ],
+        mockSignal
+      )
     ).toEqual([
       {
         filePath: 'gs://bucket/test1.bed',
@@ -214,24 +268,27 @@ describe('getValidIgvFilesFromAttributeValues', () => {
     DrsUriResolver.mockImplementation(() => ({
       getDataObjectMetadata: jest.fn((_, fields) => {
         if (fields.includes('fileName')) {
-          const mockJson = fileNameJson;
-          return Promise.resolve(mockJson);
+          return Promise.resolve(fileNameJson);
         }
         if (fields.includes('accessUrl')) {
-          const mockAccessUrl = fileAccessUrl;
-          const mockAccessUrlJson = { accessUrl: { url: mockAccessUrl } };
+          const mockAccessUrlJson = { accessUrl: { url: fileAccessUrl } };
           return Promise.resolve(mockAccessUrlJson);
         }
       }),
     }));
 
     expect(
-      await getValidIgvFilesFromAttributeValues([
-        {
-          itemsType: 'AttributeValue',
-          items: ['testString', fileDrsUri, 'testString2'],
-        },
-      ])
+      await getValidIgvFilesFromAttributeValues(
+        mockWorkspace,
+        mockEntityType,
+        [
+          {
+            itemsType: 'AttributeValue',
+            items: ['testString', fileDrsUri, 'testString2'],
+          },
+        ],
+        mockSignal
+      )
     ).toEqual([]);
   });
 
@@ -290,12 +347,17 @@ describe('getValidIgvFilesFromAttributeValues', () => {
     }));
 
     expect(
-      await getValidIgvFilesFromAttributeValues([
-        {
-          itemsType: 'AttributeValue',
-          items: ['testString', fileDrsUri, indexFileDrsUri],
-        },
-      ])
+      await getValidIgvFilesFromAttributeValues(
+        mockWorkspace,
+        mockEntityType,
+        [
+          {
+            itemsType: 'AttributeValue',
+            items: ['testString', fileDrsUri, indexFileDrsUri],
+          },
+        ],
+        mockSignal
+      )
     ).toEqual([
       {
         filePath: 'https://bucket/foo.vcf.gz?requestedBy=user@domain.tls&userProject=my-billing-project&signature=secret',

--- a/src/workspace-data/data-table/entity-service/EntitiesContent.js
+++ b/src/workspace-data/data-table/entity-service/EntitiesContent.js
@@ -126,6 +126,8 @@ const ToolDrawer = _.flow(
           title: 'IGV',
           drawerContent: h(IGVFileSelector, {
             onSuccess: onIgvSuccess,
+            workspace,
+            entityType: entityKey,
             selectedEntities,
           }),
         }),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-645

### What
- Update Terra IGV so that genomic data files (e.g., .cram) and their index files (e.g., .crai) can be matched even when they appear on separate rows of a data table.

### Why
- Many datasets (e.g., from AnVIL) export files this way. Without this fix, IGV shows “No valid files with indices found,” blocking browsing. Matching across rows lets IGV load far more genomic data.

### Testing strategy
- Unit Testing:
  - Updated Unit Tests
- Manual Testing:
  - Open a workspace with data tables where files and indices are split across rows.
  - Select a genomic file row (e.g., .cram) and launch IGV.
  - Confirm IGV finds and loads the correct index file (e.g., .crai) from another row.
  - Verify existing single-row file/index behavior still works.
  - Test edge cases: missing indices, multiple possible matches, non-genomic files.

### Screens

**Before**

https://github.com/user-attachments/assets/7192c2f6-1315-4dc1-a728-a2854e0b4f6e

**After**

https://github.com/user-attachments/assets/346ac1b0-9ba1-42f3-bc84-74892efe852c