### PR TITLE
[CORE-670] Clarify cost considerations tooltip text

### DIFF
--- a/src/pages/workspaces/workspace/workflows/WorkflowView.js
+++ b/src/pages/workspaces/workspace/workflows/WorkflowView.js
@@ -1024,7 +1024,7 @@ export const WorkflowView = _.flow(
                       h('br'),
                       '1. Costs are in USD.',
                       h('br'),
-                      '2. Costs are VM and disk costs only. Bucket storage and egress costs are not included.',
+                      '2. Costs are VM CPU and RAM costs only. Disk, bucket storage and egress costs are not included.',
                       h('br'),
                       '3. Based on GCP list prices. Discounts are not included.',
                       h('br'),


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-670

### What
- Update tooltip text for #2 in cost thresholds considerations to:

“Costs are VM CPU and RAM costs only. Disk, bucket storage and egress costs are not included.”

### Why
- Cromwell estimates do not include disk, storage, or egress costs, which caused user confusion when actual charges were higher. The tooltip now matches the real behavior and documentation.

### Testing strategy
- Manual Testing
  - Confirm updated tooltip text appears in the UI.
  - Verify no other tooltip or cost logic is affected.

### Screens

<img width="1798" height="730" alt="After" src="https://github.com/user-attachments/assets/1b2a4019-59f2-4535-94c4-e171567f7d88" />
