### PR TITLE
[CORE-644] Refresh saved IGV sessions

### DIFF
--- a/src/components/useIGVSessions.js
+++ b/src/components/useIGVSessions.js
@@ -16,6 +16,21 @@ export const useIGVSessions = (workspaceId) => {
     }
   };
 
+  const refreshSessions = () => {
+    if (!workspaceId) {
+      setSavedSessions([]);
+      return;
+    }
+
+    try {
+      const sessionListKey = `igv-session-list-${workspaceId}`;
+      const list = localStorage.getItem(sessionListKey);
+      setSavedSessions(list ? JSON.parse(list) : []);
+    } catch {
+      setSavedSessions([]);
+    }
+  };
+
   const loadSession = withErrorReporting('Unable to load session')(async (sessionName) => {
     try {
       const sessionKey = `igvSession-${workspaceId}-${sessionName}`;
@@ -112,5 +127,6 @@ export const useIGVSessions = (workspaceId) => {
     loadSession,
     saveSession,
     deleteSession,
+    refreshSessions,
   };
 };

--- a/src/workspace-data/data-table/entity-service/EntitiesContent.js
+++ b/src/workspace-data/data-table/entity-service/EntitiesContent.js
@@ -289,7 +289,7 @@ const EntitiesContent = ({
   const [showSessionModal, setShowSessionModal] = useState(false);
   const [sessionAction, setSessionAction] = useState(null);
 
-  const { savedSessions, loadSession: loadSessionData, deleteSession } = useIGVSessions(workspace?.workspace?.workspaceId);
+  const { savedSessions, loadSession: loadSessionData, deleteSession, refreshSessions } = useIGVSessions(workspace?.workspace?.workspaceId);
 
   const loadSession = async (sessionName) => {
     try {
@@ -639,6 +639,7 @@ const EntitiesContent = ({
         onDismiss: () => {
           setIgvFiles(undefined);
           setIgvInitialSession(undefined);
+          refreshSessions();
         },
         initialSession: igvInitialSession,
       })


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-644

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Follow-up to https://github.com/DataBiosphere/terra-ui/pull/5387 and https://github.com/DataBiosphere/terra-ui/pull/5393 : those PRs had a small bug where returning to the data table from the IGV browser wouldn't immediately refresh the saved sessions.  If you saved a session and clicked 'return to data table', then attempted to load the session you had just saved, it wouldn't be present in the list until the page was refreshed.  This PR automatically refreshes the saved session list.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
