### PR TITLE
[CORE-688] Restore IGV for non-DRS URIs

### DIFF
--- a/src/components/IGVBrowser.js
+++ b/src/components/IGVBrowser.js
@@ -19,6 +19,13 @@ import { RequesterPaysModal } from 'src/workspaces/common/requester-pays/Request
 import IGVSessionModal from './IGVSessionModal';
 import { updateUrlWithSession, useIGVSessions } from './useIGVSessions';
 
+function processUrl(url, isSignedUrl) {
+  if (url && isGoogleURL(url) && isGoogleStorageURL(url) && isSignedUrl) {
+    return translateGoogleCloudURL(url);
+  }
+  return url;
+}
+
 // format for selectedFiles prop: [{ filePath, indexFilePath, isSignedUrl } }]
 const IGVBrowser = ({ selectedFiles, refGenome: { genome, reference }, workspace, onDismiss, initialSession }) => {
   const [loadingIgv, setLoadingIgv] = useState(true);
@@ -112,9 +119,8 @@ const IGVBrowser = ({ selectedFiles, refGenome: { genome, reference }, workspace
       // Enable viewing features upon searching most genes, without needing to zoom several times
       const visibilityWindow = 75_000;
 
-      const igvProcessedFullUrl = fullUrl && isGoogleURL(fullUrl) && isGoogleStorageURL(fullUrl) ? translateGoogleCloudURL(fullUrl) : fullUrl;
-      const igvProcessedFullIndexUrl =
-        fullIndexUrl && isGoogleURL(fullIndexUrl) && isGoogleStorageURL(fullIndexUrl) ? translateGoogleCloudURL(fullIndexUrl) : fullIndexUrl;
+      const igvProcessedFullUrl = processUrl(fullUrl, isSignedUrl);
+      const igvProcessedFullIndexUrl = processUrl(fullIndexUrl, isSignedUrl);
 
       igvBrowser.current.loadTrack({
         name: name || `${simpleUrl} (${url})`,

--- a/src/components/IGVBrowser.test.js
+++ b/src/components/IGVBrowser.test.js
@@ -300,6 +300,45 @@ describe('IGVBrowser', () => {
       });
     });
   });
+
+  it('does not transform Google URLs that are not signed URLs', async () => {
+    // Arrange
+    const fakeBucketName = 'test-bucket';
+
+    // Test files with regular Google Storage URLs (not signed URLs)
+    const googleStorageFiles = [
+      {
+        filePath: `gs://${fakeBucketName}/regular-file.bam`,
+        indexFilePath: `gs://${fakeBucketName}/regular-file.bai`,
+        isSignedUrl: false,
+      },
+    ];
+
+    state.knownBucketRequesterPaysStatuses.get.mockReturnValue({ [fakeBucketName]: false });
+    Utils.mergeQueryParams.mockImplementation((_params, url) => url);
+
+    // Act
+    await act(async () => {
+      render(
+        h(IGVBrowser, {
+          selectedFiles: googleStorageFiles,
+          refGenome: { genome: 'hg38', reference: null },
+          workspace: mockWorkspace,
+          onDismiss: jest.fn(),
+        })
+      );
+    });
+
+    // Assert - Verify that regular Google Storage URLs were NOT transformed to Media API URLs
+    await waitFor(() => {
+      expect(mockLoadTrack).toHaveBeenCalledWith({
+        name: expect.stringContaining('regular-file.bam'),
+        url: `gs://${fakeBucketName}/regular-file.bam`,
+        indexURL: `gs://${fakeBucketName}/regular-file.bai`,
+        visibilityWindow: 75000,
+      });
+    });
+  });
 });
 
 describe('IGVBrowser Session Management', () => {

--- a/src/components/IGVBrowser.test.js
+++ b/src/components/IGVBrowser.test.js
@@ -302,6 +302,8 @@ describe('IGVBrowser', () => {
   });
 
   it('does not transform Google URLs that are not signed URLs', async () => {
+    // This helps confirm that IGV works for non-DRS URIs
+
     // Arrange
     const fakeBucketName = 'test-bucket';
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-688

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
This fixes a Terra IGV regression introduced yesterday due to #5404.  

Previously, that PR fixed DRS URIs after a major IGV upgrade, but inadvertently broke non-DRS URIs in Terra IGV in a way that wasn't caught by unit tests.

Now, both non-DRS URIs and DRS URIs work in Terra IGV.  Unit tests now confirm expected behavior for both cases.

### Bug demo

https://github.com/user-attachments/assets/9f2a536b-f5a1-43bc-8b2b-4c0ac33fcc76

### Fix demo
IGV now works for non-DRS URIs _and_ DRS URIs:

https://github.com/user-attachments/assets/3375e7f9-59a9-4a4b-80e1-0cbc64218706

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->
Automated tests now cover this case.

To manually confirm the fix:

1.  Go to http://localhost:3000/#workspaces/anvil-dev-developer-work/igv_drs_test_area/data
2.  Click "Data"
3.  Select 3rd table, "table_with_numeric_field_id"
4.  Select checkbox in first row
5.  Click IGV icon above table, then click "Open with IGV"
6.  Note "IGV" panel appears at right and says "Searching for valid files with indices...". Wait a few seconds.
7.  Select checkbox in first file returned in "IGV" panel at right
8.  Click "Launch IGV"
9.  Confirm IGV genome browser display loads in UI
10.  Change your IGV genomic window -- e.g. enter "LDLR" in the IGV search box, click enter to submit query
11.  Confirm IGV error message does not appear
12.  Confirm IGV track "NA06985.haplotypeCalls.er.raw.g.vcf.gz" shows genomic features for the VCF file -- i.e. blue and grey rectangles.
13.  Repeat steps 1-12, but select checkbox for "GCS_PUBLIC_VCF_AND_TBI" in "table_with_numeric_field_id" table, confirm no "Not found" error occurs, and that you see colored rectangles upon searching LDLR after IGV loads

In Step 10, note there's an incidental bug shown above, where the thin blue analysis panel at right gets pushed off the page. This is a separate issue.


- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
