### PR TITLE
CORE-684: respect credits in spend report

### DIFF
--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -49,7 +49,7 @@ const setAjaxMockValues = async (testPage, ownedBillingProjectName, azureBilling
   const spendReturnResult = {
     spendSummary: {
       cost: spendCost,
-      credits: '2.50',
+      credits: '-2.50',
       currency: 'USD',
       endTime: '2022-03-04T00:00:00.000Z',
       startTime: '2022-02-02T00:00:00.000Z',
@@ -271,7 +271,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectProject(ownedBillingProjectName);
   await billingPage.selectSpendReport();
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,110.00');
+  await billingPage.assertText('Total spend$1,107.67');
   await billingPage.assertText('Total compute$999.00');
   await billingPage.assertText('Total storage$22.00');
   await billingPage.assertText('Total spend includes $89.00 in other infrastructure or query costs related to the general operations of Terra.');
@@ -290,7 +290,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, azureBillingProjectName, '1110.17', 20);
   await billingPage.setSpendReportDays(90);
-  await billingPage.assertText('Total spend$1,110.17');
+  await billingPage.assertText('Total spend$1,107.67');
   // Check that title updated to reflect truncation.
   await billingPage.assertText('Daily Spend');
   await billingPage.assertChartValue('Feb 6', 'Compute', '$900.00');
@@ -304,7 +304,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectSpendReport();
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,110.17');
+  await billingPage.assertText('Total spend$1,107.67');
   await billingPage.assertText('Total analysis compute$999.00');
   await billingPage.assertText('Total workspace storage$22.00');
   await billingPage.assertText('Total workspace infrastructure$11.00');

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -290,7 +290,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, azureBillingProjectName, '1110.17', 20);
   await billingPage.setSpendReportDays(90);
-  await billingPage.assertText('Total spend$1,107.50');
+  await billingPage.assertText('Total spend$1,107.67');
   // Check that title updated to reflect truncation.
   await billingPage.assertText('Daily Spend');
   await billingPage.assertChartValue('Feb 6', 'Compute', '$900.00');
@@ -304,7 +304,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectSpendReport();
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,107.50');
+  await billingPage.assertText('Total spend$1,107.67');
   await billingPage.assertText('Total analysis compute$999.00');
   await billingPage.assertText('Total workspace storage$22.00');
   await billingPage.assertText('Total workspace infrastructure$11.00');

--- a/integration-tests/tests/billing-projects.js
+++ b/integration-tests/tests/billing-projects.js
@@ -271,7 +271,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectProject(ownedBillingProjectName);
   await billingPage.selectSpendReport();
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,107.67');
+  await billingPage.assertText('Total spend$1,107.50');
   await billingPage.assertText('Total compute$999.00');
   await billingPage.assertText('Total storage$22.00');
   await billingPage.assertText('Total spend includes $89.00 in other infrastructure or query costs related to the general operations of Terra.');
@@ -290,7 +290,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   // Change the returned mock cost to mimic different date ranges.
   await setAjaxMockValues(page, ownedBillingProjectName, azureBillingProjectName, '1110.17', 20);
   await billingPage.setSpendReportDays(90);
-  await billingPage.assertText('Total spend$1,107.67');
+  await billingPage.assertText('Total spend$1,107.50');
   // Check that title updated to reflect truncation.
   await billingPage.assertText('Daily Spend');
   await billingPage.assertChartValue('Feb 6', 'Compute', '$900.00');
@@ -304,7 +304,7 @@ const testBillingSpendReportFn = withUserToken(async ({ page, testUrl, token }) 
   await billingPage.selectSpendReport();
 
   // Title and cost are in different elements, but check both in same text assert to verify that category is correctly associated to its cost.
-  await billingPage.assertText('Total spend$1,107.67');
+  await billingPage.assertText('Total spend$1,107.50');
   await billingPage.assertText('Total analysis compute$999.00');
   await billingPage.assertText('Total workspace storage$22.00');
   await billingPage.assertText('Total workspace infrastructure$11.00');

--- a/src/billing/ConsolidatedSpendReport.tsx
+++ b/src/billing/ConsolidatedSpendReport.tsx
@@ -6,7 +6,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import { DateRangeFilter } from 'src/billing/Filter/DateRangeFilter';
 import { SearchFilter } from 'src/billing/Filter/SearchFilter';
 import { SpendReportDownloader } from 'src/billing/SpendReport/SpendReportDownloader';
-import { parseCurrencyIfNeeded } from 'src/billing/utils';
+import { creditedCost, parseCurrencyIfNeeded } from 'src/billing/utils';
 import { BillingProject } from 'src/billing-core/models';
 import { ButtonOutline, Checkbox, fixedSpinnerOverlay } from 'src/components/common';
 import { ariaSort, HeaderRenderer } from 'src/components/table';
@@ -264,13 +264,6 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
                   ws.workspace.name === spendItem.workspace.name &&
                   ws.workspace.namespace === spendItem.workspace.namespace
               );
-
-              // helper to extract cost-minus-credits out of any object with those fields
-              const creditedCost: (obj: any) => number = (obj) => {
-                const cost = parseFloat(obj?.cost ?? '0.00');
-                const credits = parseFloat(obj?.credits ?? '0.00');
-                return cost + credits; // add, since credits are negative values
-              };
 
               if (workspaceDetails) {
                 matchedWorkspaces.add(`${workspaceDetails.workspace.namespace}/${workspaceDetails.workspace.name}`);

--- a/src/billing/ConsolidatedSpendReport.tsx
+++ b/src/billing/ConsolidatedSpendReport.tsx
@@ -265,6 +265,13 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
                   ws.workspace.namespace === spendItem.workspace.namespace
               );
 
+              // helper to extract cost-minus-credits out of any object with those fields
+              const creditedCost: (obj: any) => number = (obj) => {
+                const cost = parseFloat(obj?.cost ?? '0.00');
+                const credits = parseFloat(obj?.credits ?? '0.00');
+                return cost + credits; // add, since credits are negative values
+              };
+
               if (workspaceDetails) {
                 matchedWorkspaces.add(`${workspaceDetails.workspace.namespace}/${workspaceDetails.workspace.name}`);
 
@@ -283,15 +290,15 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
                   cloudPlatform: 'Gcp',
                   bucketName: workspaceDetails?.workspace.bucketName,
 
-                  totalSpend: costFormatter.format(parseFloat(spendItem.cost ?? '0.00')),
+                  totalSpend: costFormatter.format(creditedCost(spendItem)),
                   totalCompute: costFormatter.format(
-                    parseFloat(_.find({ category: 'Compute' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+                    creditedCost(_.find({ category: 'Compute' }, spendItem.subAggregation.spendData))
                   ),
                   totalStorage: costFormatter.format(
-                    parseFloat(_.find({ category: 'Storage' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+                    creditedCost(_.find({ category: 'Storage' }, spendItem.subAggregation.spendData))
                   ),
                   otherSpend: costFormatter.format(
-                    parseFloat(_.find({ category: 'Other' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+                    creditedCost(_.find({ category: 'Other' }, spendItem.subAggregation.spendData))
                   ),
                 } as GoogleWorkspaceInfo;
               }

--- a/src/billing/SpendReport/SpendReport.test.tsx
+++ b/src/billing/SpendReport/SpendReport.test.tsx
@@ -65,9 +65,9 @@ describe('SpendReport', () => {
     const categorySpendData: AggregatedCategorySpendData = {
       aggregationKey: 'Category',
       spendData: [
-        { cost: '999', category: 'Compute', credits: '0.00', currency: 'USD' },
-        { cost: '22', category: 'Storage', credits: '0.00', currency: 'USD' },
-        { cost: '55', category: 'WorkspaceInfrastructure', credits: '0.00', currency: 'USD' },
+        { cost: '999', category: 'Compute', credits: '-1.23', currency: 'USD' },
+        { cost: '22', category: 'Storage', credits: '-4.56', currency: 'USD' },
+        { cost: '55', category: 'WorkspaceInfrastructure', credits: '-0.09', currency: 'USD' },
         { cost: '89', category: 'Other', credits: '0.00', currency: 'USD' },
       ],
     };
@@ -114,9 +114,9 @@ describe('SpendReport', () => {
           subAggregation: {
             aggregationKey: 'Category',
             spendData: [
-              { cost: '9', category: 'Compute', credits: '0.00', currency: 'USD' },
+              { cost: '9', category: 'Compute', credits: '-2.34', currency: 'USD' },
               { cost: '0', category: 'Storage', credits: '0.00', currency: 'USD' },
-              { cost: '1', category: 'Other', credits: '0.00', currency: 'USD' },
+              { cost: '1', category: 'Other', credits: '0.05', currency: 'USD' },
             ],
           },
         },
@@ -218,8 +218,8 @@ describe('SpendReport', () => {
     });
     expect(getSpendReport).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,107.50*');
-    expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
-    expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
+    expect(screen.getByTestId('compute')).toHaveTextContent('$997.77');
+    expect(screen.getByTestId('storage')).toHaveTextContent('$17.44');
     // validate that 'workspaceInfrastructure' card is not shown for GCP report
     expect(screen.queryByTestId('workspaceInfrastructure')).not.toBeInTheDocument();
 
@@ -249,9 +249,9 @@ describe('SpendReport', () => {
       aggregationKeys: ['Category'],
     });
     expect(screen.getByTestId('spend')).toHaveTextContent('$1,107.50*');
-    expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
-    expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
-    expect(screen.getByTestId('workspaceInfrastructure')).toHaveTextContent('$55.00');
+    expect(screen.getByTestId('compute')).toHaveTextContent('$997.77');
+    expect(screen.getByTestId('storage')).toHaveTextContent('$17.44');
+    expect(screen.getByTestId('workspaceInfrastructure')).toHaveTextContent('$54.91');
   });
 
   it('fetches reports based on selected date range, if active', async () => {

--- a/src/billing/SpendReport/SpendReport.test.tsx
+++ b/src/billing/SpendReport/SpendReport.test.tsx
@@ -174,7 +174,7 @@ describe('SpendReport', () => {
     const mockServerResponse: SpendReportServerResponse = {
       spendSummary: {
         cost: totalCost,
-        credits: '2.50',
+        credits: '-2.50',
         currency: 'USD',
         endTime: 'dummyTime',
         startTime: 'dummyTime',
@@ -217,7 +217,7 @@ describe('SpendReport', () => {
       expect(screen.getByText(/\$89.00 in other infrastructure/i)).toBeInTheDocument();
     });
     expect(getSpendReport).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
+    expect(screen.getByTestId('spend')).toHaveTextContent('$1,107.50*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
     // validate that 'workspaceInfrastructure' card is not shown for GCP report
@@ -248,7 +248,7 @@ describe('SpendReport', () => {
       startDate: '2022-03-02',
       aggregationKeys: ['Category'],
     });
-    expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.00*');
+    expect(screen.getByTestId('spend')).toHaveTextContent('$1,107.50*');
     expect(screen.getByTestId('compute')).toHaveTextContent('$999.00');
     expect(screen.getByTestId('storage')).toHaveTextContent('$22.00');
     expect(screen.getByTestId('workspaceInfrastructure')).toHaveTextContent('$55.00');
@@ -272,7 +272,7 @@ describe('SpendReport', () => {
     await waitFor(() => {
       expect(screen.getByText(otherCostMessaging)).toBeInTheDocument();
     });
-    expect(screen.getByTestId('spend')).toHaveTextContent('$1,110.17*');
+    expect(screen.getByTestId('spend')).toHaveTextContent('$1,107.67*');
     expect(getSpendReport).toHaveBeenCalledTimes(2);
     expect(getSpendReport).toHaveBeenNthCalledWith(1, {
       billingProjectName: 'thrifty',

--- a/src/billing/SpendReport/SpendReport.tsx
+++ b/src/billing/SpendReport/SpendReport.tsx
@@ -7,6 +7,7 @@ import { ErrorAlert } from 'src/alerts/ErrorAlert';
 import { DateRangeFilter } from 'src/billing/Filter/DateRangeFilter';
 import { ExternalLink } from 'src/billing/NewBillingProjectWizard/StepWizard/ExternalLink';
 import { CostCard } from 'src/billing/SpendReport/CostCard';
+import { creditedCost } from 'src/billing/utils';
 import { CloudPlatform } from 'src/billing-core/models';
 import { Billing } from 'src/libs/ajax/billing/Billing';
 import {
@@ -295,18 +296,16 @@ export const SpendReport = (props: SpendReportProps) => {
           categorySpendData: CategorySpendData[]
         ): { compute: number; storage: number; workspaceInfrastructure: number; other: number } => {
           return {
-            compute: parseFloat(_.find(['category', 'Compute'], categorySpendData)?.cost ?? '0'),
-            storage: parseFloat(_.find(['category', 'Storage'], categorySpendData)?.cost ?? '0'),
-            workspaceInfrastructure: parseFloat(
-              _.find(['category', 'WorkspaceInfrastructure'], categorySpendData)?.cost ?? '0'
-            ),
-            other: parseFloat(_.find(['category', 'Other'], categorySpendData)?.cost ?? '0'),
+            compute: creditedCost(_.find(['category', 'Compute'], categorySpendData)),
+            storage: creditedCost(_.find(['category', 'Storage'], categorySpendData)),
+            workspaceInfrastructure: creditedCost(_.find(['category', 'WorkspaceInfrastructure'], categorySpendData)),
+            other: creditedCost(_.find(['category', 'Other'], categorySpendData)),
           };
         };
         const costDict = getCategoryCosts(categoryDetails.spendData);
 
         setProjectCost({
-          spend: costFormatter.format(parseFloat(spend.spendSummary.cost)),
+          spend: costFormatter.format(creditedCost(spend.spendSummary)),
           compute: costFormatter.format(costDict.compute),
           storage: costFormatter.format(costDict.storage),
           workspaceInfrastructure: costFormatter.format(costDict.workspaceInfrastructure),

--- a/src/billing/Workspaces/Workspaces.tsx
+++ b/src/billing/Workspaces/Workspaces.tsx
@@ -8,6 +8,7 @@ import { SpendReportDownloader } from 'src/billing/SpendReport/SpendReportDownlo
 import {
   billingAccountIconSize,
   BillingAccountStatus,
+  creditedCost,
   getBillingAccountIconProps,
   parseCurrencyIfNeeded,
 } from 'src/billing/utils';
@@ -243,15 +244,15 @@ export const Workspaces = (props: WorkspacesProps): ReactNode => {
 
           return {
             ...workspace,
-            totalSpend: costFormatter.format(parseFloat(spendItem.cost ?? '0.00')),
+            totalSpend: costFormatter.format(creditedCost(spendItem)),
             totalCompute: costFormatter.format(
-              parseFloat(_.find({ category: 'Compute' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+              creditedCost(_.find({ category: 'Compute' }, spendItem.subAggregation.spendData))
             ),
             totalStorage: costFormatter.format(
-              parseFloat(_.find({ category: 'Storage' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+              creditedCost(_.find({ category: 'Storage' }, spendItem.subAggregation.spendData))
             ),
             otherSpend: costFormatter.format(
-              parseFloat(_.find({ category: 'Other' }, spendItem.subAggregation.spendData)?.cost ?? '0.00')
+              creditedCost(_.find({ category: 'Other' }, spendItem.subAggregation.spendData))
             ),
           };
         });

--- a/src/billing/utils.test.ts
+++ b/src/billing/utils.test.ts
@@ -1,5 +1,4 @@
-import { currencyStringToFloat, parseCurrencyIfNeeded } from 'src/billing/utils';
-import { validateUserEmails } from 'src/billing/utils';
+import { creditedCost, currencyStringToFloat, parseCurrencyIfNeeded, validateUserEmails } from 'src/billing/utils';
 import validate from 'validate.js';
 
 describe('currencyStringToFloat', () => {
@@ -155,5 +154,25 @@ describe('validateUserEmails', () => {
 
     // Assert
     expect(result).toBeUndefined();
+  });
+});
+
+describe('creditedCost', () => {
+  const testCases = [
+    { input: {}, expected: 0 },
+    { input: { cost: '1.23', credits: '-0.23' }, expected: 1 },
+    { input: { cost: '4.56' }, expected: 4.56 },
+    { input: { credits: '-7.89' }, expected: -7.89 },
+    { input: { foo: 'bar', baz: 'qux' }, expected: 0 },
+    { input: 'notanobject', expected: 0 },
+    { input: undefined, expected: 0 },
+  ];
+
+  testCases.forEach(({ input, expected }) => {
+    it(`should return ${expected} for input ${JSON.stringify(input)}`, () => {
+      // Act
+      const result = creditedCost(input as any);
+      expect(result).toBe(expected);
+    });
   });
 });

--- a/src/billing/utils.ts
+++ b/src/billing/utils.ts
@@ -133,3 +133,10 @@ export const validateUserEmails = (userEmails: string[]) => {
     }
   );
 };
+
+// helper to extract cost-minus-credits out of any object with those fields
+export const creditedCost: (obj: any) => number = (obj) => {
+  const cost = parseFloat(obj?.cost ?? '0.00');
+  const credits = parseFloat(obj?.credits ?? '0.00');
+  return cost + credits; // add, since credits are negative values
+};


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-684

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

In spend reports, display (cost-credits) instead of just cost; in other words, display what the user would actually be charged instead of the "list price".


### What

This PR creates a centralized `creditedCost` function to handle extracting `cost` and `credits` properties out of an object, parsing and defaulting their values, and adding them up.


### Testing strategy
- [x] Unit test coverage
- [x] Manually tested running locally

### Visual Aids

_Before_
<img width="1578" height="891" alt="consolidated-before" src="https://github.com/user-attachments/assets/ae795e5d-aba7-40f6-a0b9-f3e9da2548e3" />
<img width="1578" height="891" alt="project-before" src="https://github.com/user-attachments/assets/130ce8ad-0886-4a30-ac97-830d99275447" />

_After_
<img width="1578" height="891" alt="consolidated-after" src="https://github.com/user-attachments/assets/acbb9030-2893-4c1e-8ab1-10982a4620eb" />
<img width="1578" height="891" alt="project-after" src="https://github.com/user-attachments/assets/f6cb7f9f-e2e2-49ce-a0bd-fd74ce779494" />
