### PR TITLE
[CORE-693] Fix overlapping download button in consolidated spend report

### DIFF
--- a/src/billing/ConsolidatedSpendReport.tsx
+++ b/src/billing/ConsolidatedSpendReport.tsx
@@ -410,7 +410,7 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
           {ownedWorkspaces.length >= itemsPerPage && (
             <ButtonOutline
               aria-label='Show all workspaces'
-              style={{ gridRowStart: 1, gridColumnStart: 3, marginLeft: '2rem', marginTop: '2.5rem', width: '50%' }}
+              style={{ gridRowStart: 1, gridColumnStart: 3, marginLeft: '2rem', marginTop: '2.5rem' }}
               tooltip='Spend report defaults to 250 workspaces, click to load remaining'
               onClick={() => {
                 setItemsPerPage(2500000);
@@ -422,7 +422,7 @@ export const ConsolidatedSpendReport = (props: ConsolidatedSpendReportProps): Re
           <SpendReportDownloader
             title={`Consolidated Spend Report (${spendReportLengthInDays} days)`}
             filteredOwnedWorkspaces={filteredOwnedWorkspaces}
-            style={{ gridRowStart: 1, gridColumnStart: 3, margin: '2.3rem' }}
+            style={{ gridRowStart: 1, gridColumnStart: 4, margin: '2.3rem' }}
           />
         </div>
         <div aria-live='polite' aria-atomic>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-693

### What
- Fixes a UI issue where the download button overlaps and blocks other buttons when users have many workspaces.

### Why
- The overlap prevents users from accessing other controls, especially for those managing hundreds of workspaces.

### Testing strategy
- Manual Testing
  - Checked layout with few and many workspaces.
  - Verified the download button no longer blocks other controls.
  - Tested across browsers and screen sizes.

### Screens

**Before**
<img width="2974" height="778" alt="image" src="https://github.com/user-attachments/assets/6d5ee2ac-2de6-4828-81df-216b9064b2db" />

**After (Few Workspaces)**
<img width="1788" height="943" alt="Screenshot 2025-09-08 at 1 39 11 PM" src="https://github.com/user-attachments/assets/c2d6a5c4-5f7f-4652-ac47-8c9e15ff5afc" />

**After (Many Workpsaces)**
<img width="1792" height="943" alt="Screenshot 2025-09-08 at 1 38 44 PM" src="https://github.com/user-attachments/assets/40a0dc6c-5a98-4655-ab46-c5aec6064da9" />
