### PR TITLE
[TSPS-598] Add content-type header to resumable upload session

### DIFF
--- a/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
@@ -1,4 +1,4 @@
-import { checkUploadStatus } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
+import { checkUploadStatus, initiateResumableUpload } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 import * as uploadUtils from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 
 global.fetch = jest.fn();
@@ -125,6 +125,53 @@ describe('upload-utils', () => {
       expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
       expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Range', 'bytes 5-9/10');
       expect(mockXHR.send).toHaveBeenCalledWith(inputFile.slice(5));
+    });
+  });
+
+  describe('initiateResumableUpload', () => {
+    it('initiates a resumable upload session', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        headers: {
+          get: () => 'http://signed.url/session',
+        },
+      });
+
+      const mockSetUploadState = jest.fn();
+      const inputName = 'testInput';
+      const inputFile = new File(['abcdefghij'], 'foo.txt');
+      const signedUrl = 'http://signed.url/upload';
+
+      const mockXHR = new MockXMLHttpRequest();
+      mockXHR.addEventListener = jest.fn((event, callback) => {
+        if (event === 'load') {
+          setTimeout(() => callback({ status: 200 }), 0);
+        }
+      });
+
+      Object.defineProperty(mockXHR, 'status', {
+        value: 200,
+        writable: true,
+      });
+
+      global.XMLHttpRequest = jest.fn(() => mockXHR) as any;
+
+      await initiateResumableUpload(inputName, inputFile, signedUrl, mockSetUploadState);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        signedUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'x-goog-resumable': 'start', 'Content-Type': 'application/octet-stream' },
+        })
+      );
+
+      expect(global.XMLHttpRequest).toHaveBeenCalled();
+      expect(mockXHR.open).toHaveBeenCalledWith('PUT', 'http://signed.url/session');
+      expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+      expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Range', 'bytes 0-9/10');
+      expect(mockXHR.send).toHaveBeenCalledWith(inputFile);
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -114,7 +114,7 @@ export async function initiateResumableUpload(
   // which we'll use to upload the file.
   const initRes = await fetch(signedUrl, {
     method: 'POST',
-    headers: { 'x-goog-resumable': 'start' },
+    headers: { 'x-goog-resumable': 'start', 'Content-Type': 'application/octet-stream' },
   });
 
   const sessionUrl = initRes.headers.get('Location');

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -300,7 +300,7 @@ describe('uploadPipelineFiles function', () => {
     // Verify that the file upload was initiated
     expect(global.fetch).toHaveBeenCalledWith('https://mock-signed-url.com/upload', {
       method: 'POST',
-      headers: { 'x-goog-resumable': 'start' },
+      headers: { 'x-goog-resumable': 'start', 'Content-Type': 'application/octet-stream' },
     });
 
     // Verify that XMLHttpRequest was used for file upload


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-598

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

The signed url expects this header to be set. My bad for letting this slip through testing- I wasn't originally setting this header in the backend for the resumable session, but I added it last minute and forgot to update it here.

Nothing in prod is currently broken, but uploads in the UI will break on Monday at ~11am unless this gets merged by ~10am on Monday. I don't think it's a huge deal if upload is broken for a day... there's a reason we're behind private preview still 🙂 

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
