### PR TITLE
[CORE-696] Allow wrapping for sample selection in Terra IGV

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -305,7 +305,22 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
                     checked: isSelected,
                     onChange: () => toggleSelected(index),
                   },
-                  [div({ style: { paddingLeft: '0.25rem', flex: 1, ...Style.noWrapEllipsis } }, [fileName])]
+                  [
+                    h(
+                      Link,
+                      {
+                        style: {
+                          marginLeft: '0.5rem',
+                          padding: '0.5rem',
+                          minWidth: 0,
+                          overflow: 'hidden',
+                          ...Style.noWrapEllipsis,
+                        },
+                        tooltip: fileName,
+                      },
+                      [fileName]
+                    ),
+                  ]
                 ),
               ]);
             },

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -80,11 +80,26 @@ const searchDBForIndexFiles = async (workspace, entityType, indexCandidates, sig
     filterTerms: filterCandidates,
   });
 
-  // Look for any attribute value that matches one of the index candidates
-  return searchResponse.results.filter((result) => {
-    const fileName = result.attributes.file_name;
-    return filterCandidates.includes(fileName);
-  });
+  const URL_REGEX = /^(gs:\/\/|drs:\/\/|https?:\/\/|ftp:\/\/)/;
+
+  for (const result of searchResponse.results) {
+    const attributeValues = Object.values(result.attributes);
+    const match = attributeValues.find((val) => {
+      if (typeof val !== 'string') return false;
+      const fileName = val.split('/').pop();
+      return filterCandidates.includes(fileName);
+    });
+    if (match) {
+      let urlCandidate = match;
+      if (!URL_REGEX.test(match)) {
+        urlCandidate = attributeValues.find((val) => typeof val === 'string' && URL_REGEX.test(val));
+      }
+      if (urlCandidate && URL_REGEX.test(urlCandidate)) {
+        return await validateUrl(urlCandidate);
+      }
+    }
+  }
+  return undefined;
 };
 
 const findIndexForFile = async (workspace, entityType, fileUrl, fileUrls, signal) => {
@@ -148,6 +163,23 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
   return igvAccessUrls;
 };
 
+const validateUrl = async (fileRef) => {
+  const isDrs = isDrsUri(fileRef);
+  let accessUrl;
+
+  if (isDrs) {
+    const result = await DrsUriResolver().getDataObjectMetadata(fileRef, ['accessUrl']);
+    accessUrl = result.accessUrl.url;
+  } else {
+    accessUrl = fileRef;
+  }
+
+  const url = new URL(accessUrl);
+  url.isSignedUrl = isDrs;
+
+  return url;
+};
+
 export const getValidIgvFiles = async (workspace, entityType, values, signal) => {
   const basicFileUrls = values.filter((value) => {
     let url;
@@ -163,7 +195,7 @@ export const getValidIgvFiles = async (workspace, entityType, values, signal) =>
       // Filter to URLs that point to a file with one of the relevant extensions.
       const filename = url.pathname.split('/').at(-1);
       return hasValidIgvExtension(filename);
-    } catch (err) {
+    } catch {
       return false;
     }
   });

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -314,13 +314,13 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
                   {
                     checked: isSelected,
                     onChange: () => toggleSelected(index),
+                    style: { padding: '0.5rem' },
                   },
                   [
                     h(
                       Link,
                       {
                         style: {
-                          marginLeft: '0.5rem',
                           padding: '0.5rem',
                           minWidth: 0,
                           overflow: 'hidden',

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { useEffect, useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { AutoSizer, List } from 'react-virtualized';
+import { AutoSizer, CellMeasurer, CellMeasurerCache, List } from 'react-virtualized';
 import ButtonBar from 'src/components/ButtonBar';
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common';
 import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/IGVReferenceSelector';
@@ -282,6 +282,11 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
 
   const noRowsMessage = isSearchingFiles ? 'Searching for valid files with indices...' : 'No valid files with indices found';
 
+  const cache = new CellMeasurerCache({
+    fixedWidth: true,
+    defaultHeight: 30,
+  });
+
   return div({ style: Style.modalDrawer.content }, [
     h(IGVReferenceSelector, {
       value: refGenome,
@@ -300,39 +305,53 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
             height,
             width,
             rowCount: selections.length,
-            rowHeight: 30,
+            deferredMeasurementCache: cache,
+            rowHeight: cache.rowHeight,
             noRowsRenderer: () => noRowsMessage,
-            rowRenderer: ({ index, style, key }) => {
+            rowRenderer: ({ index, style, key, parent }) => {
               const { filePath, isSelected } = selections[index];
 
               // Show the file name, i.e. the last URL path segment, without URL parameters
               const fileName = _.last(filePath.split('/')).split('?')[0];
 
-              return div({ key, style: { ...style, display: 'flex' } }, [
-                h(
-                  LabeledCheckbox,
-                  {
-                    checked: isSelected,
-                    onChange: () => toggleSelected(index),
-                    style: { padding: '0.5rem' },
-                  },
-                  [
+              return h(
+                CellMeasurer,
+                {
+                  cache,
+                  columnIndex: 0,
+                  key,
+                  parent,
+                  rowIndex: index,
+                },
+                [
+                  div({ key, style: { ...style, display: 'flex' } }, [
                     h(
-                      Link,
+                      LabeledCheckbox,
                       {
-                        style: {
-                          padding: '0.5rem',
-                          minWidth: 0,
-                          overflow: 'hidden',
-                          ...Style.noWrapEllipsis,
-                        },
-                        tooltip: fileName,
+                        checked: isSelected,
+                        onChange: () => toggleSelected(index),
+                        style: { padding: '0.5rem' },
                       },
-                      [fileName]
+                      [
+                        h(
+                          Link,
+                          {
+                            style: {
+                              padding: '0.5rem',
+                              minWidth: 0,
+                              overflow: 'hidden',
+                              whiteSpace: 'normal',
+                              wordBreak: 'break-all',
+                            },
+                            tooltip: fileName,
+                          },
+                          [fileName]
+                        ),
+                      ]
                     ),
-                  ]
-                ),
-              ]);
+                  ]),
+                ]
+              );
             },
           });
         },

--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -136,15 +136,25 @@ const hasValidIgvExtension = (filename) => {
   return !!base && allFiles.includes(extension);
 };
 
+export const getDrsDataObjectMetadata = async (value, fields, signal = undefined) => {
+  try {
+    return await DrsUriResolver(signal).getDataObjectMetadata(value, fields);
+  } catch {
+    return {
+      fileName: '',
+      accessUrl: { url: '' },
+    };
+  }
+};
+
 export const resolveValidIgvDrsUris = async (values, signal) => {
   const igvDrsUris = [];
 
   await Promise.all(
     values.map(async (value) => {
       if (isDrsUri(value)) {
-        const json = await DrsUriResolver(signal).getDataObjectMetadata(value, ['fileName']);
-        const filename = json.fileName;
-        const isValid = hasValidIgvExtension(filename);
+        const { fileName } = await getDrsDataObjectMetadata(value, ['fileName'], signal);
+        const isValid = hasValidIgvExtension(fileName);
         if (isValid) {
           igvDrsUris.push(value);
         }
@@ -155,7 +165,7 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
   const igvAccessUrls = [];
   await Promise.all(
     igvDrsUris.map(async (value) => {
-      const { accessUrl } = await DrsUriResolver(signal).getDataObjectMetadata(value, ['accessUrl']);
+      const { accessUrl } = await getDrsDataObjectMetadata(value, ['accessUrl'], signal);
       igvAccessUrls.push(accessUrl.url);
     })
   );
@@ -168,7 +178,7 @@ const validateUrl = async (fileRef) => {
   let accessUrl;
 
   if (isDrs) {
-    const result = await DrsUriResolver().getDataObjectMetadata(fileRef, ['accessUrl']);
+    const result = await getDrsDataObjectMetadata(fileRef, ['accessUrl']);
     accessUrl = result.accessUrl.url;
   } else {
     accessUrl = fileRef;

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -45,11 +45,6 @@ describe('getValidIgvFiles', () => {
       )
     ).toEqual([
       {
-        filePath: 'gs://bucket/test1.bam',
-        indexFilePath: undefined,
-        isSignedUrl: false,
-      },
-      {
         filePath: 'gs://bucket/test2.bam',
         indexFilePath: 'gs://bucket/test2.bai',
         isSignedUrl: false,
@@ -76,11 +71,6 @@ describe('getValidIgvFiles', () => {
         mockSignal
       )
     ).toEqual([
-      {
-        filePath: 'gs://bucket/test1.cram',
-        indexFilePath: undefined,
-        isSignedUrl: false,
-      },
       {
         filePath: 'gs://bucket/test2.cram',
         indexFilePath: 'gs://bucket/test2.crai',
@@ -115,11 +105,6 @@ describe('getValidIgvFiles', () => {
         mockSignal
       )
     ).toEqual([
-      {
-        filePath: 'gs://bucket/test1.vcf',
-        indexFilePath: undefined,
-        isSignedUrl: false,
-      },
       {
         filePath: 'gs://bucket/test2.vcf',
         indexFilePath: 'gs://bucket/test2.idx',
@@ -304,13 +289,7 @@ describe('getValidIgvFilesFromAttributeValues', () => {
         ],
         mockSignal
       )
-    ).toEqual([
-      {
-        filePath: 'https://bucket/foo.vcf.gz?requestedBy=user@domain.tls&userProject=my-billing-project&signature=secret',
-        indexFilePath: undefined,
-        isSignedUrl: true,
-      },
-    ]);
+    ).toEqual([]);
   });
 
   it('robustly detects data table values that are DRS URIs', () => {

--- a/src/libs/ajax/drs/DrsUriResolver.ts
+++ b/src/libs/ajax/drs/DrsUriResolver.ts
@@ -8,7 +8,7 @@ export const DrsUriResolver = (signal?: AbortSignal) => ({
   // DRSHub now gets a signed URL instead of Martha
   getSignedUrl: async ({ bucket, object, dataObjectUri, googleProject }) => {
     const res = await fetchDrsHub(
-      '/api/v4/gcs/getSignedUrl',
+      'api/v4/gcs/getSignedUrl',
       _.mergeAll([
         jsonBody({ bucket, object, dataObjectUri, googleProject }),
         authOpts(),
@@ -21,7 +21,7 @@ export const DrsUriResolver = (signal?: AbortSignal) => ({
 
   getDataObjectMetadata: async (url, fields) => {
     const res = await fetchDrsHub(
-      '/api/v4/drs/resolve',
+      'api/v4/drs/resolve',
       _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
     );
     return res.json();


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-696

### What
- Update IGV’s sample selection window in Terra to handle long sample names by showing them in a toolTip
- Fixed returning of indexFileUrl and handling DRS resolution errors

### Why
- Long concatenated sample names are currently cut off, making it hard for users to know which file they are selecting. Showing the full name improves usability and prevents mistakes.

### Testing strategy
- Manual Testing:
  - Upload files with long names and confirm the full text is visible in the tooltip.
  - Check that normal-length names and IGV functionality are unaffected.

### Screens

https://github.com/user-attachments/assets/231ae416-f8fa-480a-bc69-d47ab2d8a94b

