### PR TITLE
CORE-695: data table provenance handles submissions with no root entity

### DIFF
--- a/src/workspace-data/provenance/workspace-data-provenance-utils.js
+++ b/src/workspace-data/provenance/workspace-data-provenance-utils.js
@@ -28,7 +28,7 @@ const getSubmissionsWithRootEntityType = async (workspace, entityType, { signal 
   const allSubmissions = await Workspaces(signal).workspace(namespace, name).listSubmissions();
   const submissionsMaybeUsingEntityType = _.flow(
     _.filter((submission) => {
-      const submissionEntityType = submission.submissionEntity.entityType;
+      const submissionEntityType = submission.submissionEntity?.entityType;
       return submissionEntityType === entityType || submissionEntityType === `${entityType}_set`;
     }),
     _.slice(0, maxSubmissionsQueriedForProvenance)


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-695

## Summary of changes:
The data table provenance feature reads the last 25 submissions, and compares those submissions' root entity type to the currently-selected data table.

If any of those 25 submissions did not have a root entity type, this feature threw a fatal error. This PR makes the feature resilient to that case.

See also https://github.com/broadinstitute/rawls/pull/3477 for a related error.

### Testing strategy
- [x] Tested running locally

### Visual Aids

#### Before:
<img width="1765" height="889" alt="Screenshot 17-09-2025 at 16 42" src="https://github.com/user-attachments/assets/970f089f-abb1-4b10-bbf8-1851c4bad698" />

#### After:
<img width="1765" height="889" alt="Screenshot 17-09-2025 at 16 42 (1)" src="https://github.com/user-attachments/assets/7f4b994f-b517-4de7-9b48-65a0fd5d0d3c" />

