### PR TITLE
[TSPS-632] Disable View Outputs button for stale Imputation jobs

### DIFF
--- a/src/pages/scientificServices/pipelines/utils/mock-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/mock-utils.ts
@@ -54,7 +54,7 @@ export function mockPipelineRun(status: PipelineRunStatus): PipelineRun {
     status,
     description: 'Test pipeline run',
     timeSubmitted: '2023-10-01T00:00:00Z',
-    timeCompleted: status === 'SUCCEEDED' || status === 'FAILED' ? '2023-10-01T01:00:00Z' : undefined,
+    timeCompleted: status === 'SUCCEEDED' || status === 'FAILED' ? new Date().toISOString() : undefined,
     quotaConsumed: status === 'SUCCEEDED' ? 500 : undefined,
   };
 }

--- a/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.test.tsx
@@ -163,8 +163,41 @@ describe('job history table', () => {
 
     const viewOutputsButton = screen.getByText('View Outputs');
     expect(viewOutputsButton).toBeInTheDocument();
+    expect(viewOutputsButton).not.toBeDisabled();
 
     expect(screen.queryByText('View Error')).not.toBeInTheDocument();
+  });
+
+  it('disables the View Outputs button for jobs that succeeded more than 14 days ago', async () => {
+    const fifteenDaysAgo = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString();
+    const pipelineRun = {
+      ...mockPipelineRun('SUCCEEDED'),
+      timeSubmitted: fifteenDaysAgo,
+      timeCompleted: fifteenDaysAgo,
+    };
+    const pipelineRuns = [pipelineRun];
+
+    const mockPipelineRunResponse = {
+      pageToken: null,
+      results: pipelineRuns,
+      totalResults: 1,
+    };
+
+    asMockedFn(Teaspoons).mockReturnValue(
+      partial<TeaspoonsContract>({
+        getAllPipelineRuns: jest.fn().mockReturnValue(mockPipelineRunResponse),
+      })
+    );
+
+    render(<JobHistory />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(pipelineRun.jobId)).toHaveLength(2);
+    });
+
+    const viewOutputsButton = screen.getByText('View Outputs');
+    expect(viewOutputsButton).toBeInTheDocument();
+    expect(viewOutputsButton).toBeDisabled();
   });
 
   it('shows View Error button for FAILED jobs', async () => {
@@ -426,7 +459,10 @@ describe('job history table', () => {
 
   describe('Deletion Date column', () => {
     it('displays the deletion date for SUCCEEDED jobs', async () => {
-      const pipelineRun = mockPipelineRun('SUCCEEDED');
+      const pipelineRun = {
+        ...mockPipelineRun('SUCCEEDED'),
+        timeCompleted: '2023-10-15T14:00:00Z',
+      };
       const pipelineRuns = [pipelineRun];
 
       const mockPipelineRunResponse = {

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -337,7 +337,8 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
     return <ViewErrorModal pipelineRun={pipelineRun} onDismiss={errorModal.close} />;
   });
 
-  const jobOutputsDeleted = pipelineRun.status === 'SUCCEEDED' && hoursElapsedSinceCompletion(pipelineRun) > 24 * 14; // 24 hours * 14 days
+  const jobOutputsDeleted =
+    pipelineRun.status === 'SUCCEEDED' && (hoursElapsedSinceCompletion(pipelineRun) ?? -1) > 24 * 14; // 24 hours * 14 days
 
   return (
     <div>

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -337,32 +337,46 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
     return <ViewErrorModal pipelineRun={pipelineRun} onDismiss={errorModal.close} />;
   });
 
+  const jobOutputsDeleted = pipelineRun.status === 'SUCCEEDED' && hoursElapsedSinceSubmission(pipelineRun) > 24 * 14; // 24 hours * 14 days
+
   return (
     <div>
       {pipelineRun.status === 'SUCCEEDED' && (
         <>
-          <button
-            type='button'
-            style={{
-              color: '#46A3E9',
-              fontWeight: 700,
-              textDecoration: 'underline',
-              background: 'none',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              font: 'inherit',
-            }}
-            onClick={() => {
-              outputsModal.open({ jobId: pipelineRun.jobId });
-              Metrics().captureEvent(Events.teaspoons.viewJobOutputs, {
-                pipelineName: pipelineRun.pipelineName,
-                pipelineVersion: pipelineRun.pipelineVersion,
-              });
-            }}
+          <TooltipTrigger
+            content={
+              jobOutputsDeleted
+                ? 'The outputs for this job have been deleted. Outputs are available for 2 weeks after job completion.'
+                : undefined
+            }
+            side='top'
           >
-            View Outputs
-          </button>
+            <span style={{ cursor: jobOutputsDeleted ? 'not-allowed' : 'pointer' }}>
+              <button
+                type='button'
+                disabled={jobOutputsDeleted}
+                style={{
+                  color: jobOutputsDeleted ? colors.disabled() : '#46A3E9',
+                  fontWeight: 700,
+                  textDecoration: 'underline',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: jobOutputsDeleted ? 'not-allowed' : 'pointer',
+                  font: 'inherit',
+                }}
+                onClick={() => {
+                  outputsModal.open({ jobId: pipelineRun.jobId });
+                  Metrics().captureEvent(Events.teaspoons.viewJobOutputs, {
+                    pipelineName: pipelineRun.pipelineName,
+                    pipelineVersion: pipelineRun.pipelineVersion,
+                  });
+                }}
+              >
+                View Outputs
+              </button>
+            </span>
+          </TooltipTrigger>
           {outputsModal.maybeRender()}
         </>
       )}

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -337,7 +337,7 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
     return <ViewErrorModal pipelineRun={pipelineRun} onDismiss={errorModal.close} />;
   });
 
-  const jobOutputsDeleted = pipelineRun.status === 'SUCCEEDED' && hoursElapsedSinceSubmission(pipelineRun) > 24 * 14; // 24 hours * 14 days
+  const jobOutputsDeleted = pipelineRun.status === 'SUCCEEDED' && hoursElapsedSinceCompletion(pipelineRun) > 24 * 14; // 24 hours * 14 days
 
   return (
     <div>
@@ -500,4 +500,13 @@ const hoursElapsedSinceSubmission = (pipelineRun: PipelineRun): number => {
   const submittedTime = new Date(pipelineRun.timeSubmitted);
   const currentTime = new Date();
   return (currentTime.getTime() - submittedTime.getTime()) / (1000 * 60 * 60);
+};
+
+const hoursElapsedSinceCompletion = (pipelineRun: PipelineRun): number | undefined => {
+  if (!pipelineRun.timeCompleted) {
+    return undefined;
+  }
+  const completedTime = new Date(pipelineRun.timeCompleted);
+  const currentTime = new Date();
+  return (currentTime.getTime() - completedTime.getTime()) / (1000 * 60 * 60);
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-632

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Disables the View Outputs button for stale jobs
- Adds a tooltip explaining that outputs have been deleted

<img width="1512" height="735" alt="Screenshot 2025-09-23 at 3 00 58 PM" src="https://github.com/user-attachments/assets/7824fa6b-d6c5-4209-9f1e-ae0cb148d876" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
