### PR TITLE
[TSPS-616] Show file upload ETA for Imputation inputs

### DIFF
--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -100,7 +100,6 @@ describe('PipelineFileInput', () => {
       />
     );
 
-    expect(screen.getByText('In progress')).toBeInTheDocument();
     expect(screen.getByText('Estimated time remaining:')).toBeInTheDocument();
     expect(screen.getByText('2 minutes 1 second')).toBeInTheDocument();
   });

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -88,7 +88,7 @@ describe('PipelineFileInput', () => {
     const uploadState: PipelineInputFileUploadState = {
       progress: 50,
       signedUrl: 'http://signed.url',
-      uploadEtaSeconds: 120,
+      uploadEtaSeconds: 121,
     };
 
     render(
@@ -102,7 +102,7 @@ describe('PipelineFileInput', () => {
 
     expect(screen.getByText('In progress')).toBeInTheDocument();
     expect(screen.getByText('Estimated time remaining:')).toBeInTheDocument();
-    expect(screen.getByText('120 seconds')).toBeInTheDocument();
+    expect(screen.getByText('2 minutes 1 second')).toBeInTheDocument();
   });
 
   it('shows upload error and retry button', () => {

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -68,6 +68,43 @@ describe('PipelineFileInput', () => {
     expect(screen.getByText(/Upload successful/)).toBeInTheDocument();
   });
 
+  it('shows upload ETA as Calculating when no ETA is ready yet', () => {
+    const uploadState: PipelineInputFileUploadState = { progress: 1, signedUrl: 'http://signed.url' };
+
+    render(
+      <PipelineFileInput
+        input={mockInput}
+        selectedFile={new File(['test'], 'test.vcf.gz')}
+        uploadState={uploadState}
+        onFileSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Estimated time remaining:')).toBeInTheDocument();
+    expect(screen.getByText('Calculating...')).toBeInTheDocument();
+  });
+
+  it('shows upload progress with ETA', () => {
+    const uploadState: PipelineInputFileUploadState = {
+      progress: 50,
+      signedUrl: 'http://signed.url',
+      uploadEtaSeconds: 120,
+    };
+
+    render(
+      <PipelineFileInput
+        input={mockInput}
+        selectedFile={new File(['test'], 'test.vcf.gz')}
+        uploadState={uploadState}
+        onFileSelect={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Estimated time remaining:')).toBeInTheDocument();
+    expect(screen.getByText('120 seconds')).toBeInTheDocument();
+  });
+
   it('shows upload error and retry button', () => {
     const uploadState: PipelineInputFileUploadState = {
       progress: 50,

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -101,7 +101,7 @@ describe('PipelineFileInput', () => {
     );
 
     expect(screen.getByText('Estimated time remaining:')).toBeInTheDocument();
-    expect(screen.getByText('2 minutes 1 second')).toBeInTheDocument();
+    expect(screen.getByText('2 minutes')).toBeInTheDocument();
   });
 
   it('shows upload error and retry button', () => {

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -11,6 +11,7 @@ import { resumeUpload } from 'src/pages/scientificServices/pipelines/utils/uploa
 export interface PipelineInputFileUploadState {
   signedUrl?: string; // The resumable upload session URL
   progress: number; // Progress percentage (0-100)
+  uploadEta?: number; // Estimated time remaining in seconds
   errorMessage?: string; // Optional error message
 }
 
@@ -270,6 +271,10 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
                         transition: 'width 0.3s ease-in-out',
                       }}
                     />
+                  </div>
+                  <div style={{ marginTop: '0.5rem', display: 'flex' }}>
+                    <div style={{ fontWeight: 'bold', marginRight: '0.25rem' }}>Estimated time remaining:</div>
+                    {uploadState.uploadEta ? `${Math.round(uploadState.uploadEta)} seconds` : 'Calculating...'}
                   </div>
                 </div>
               </>

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -6,7 +6,10 @@ import colors from 'src/libs/colors';
 import { notify } from 'src/libs/notifications';
 import { formatBytes } from 'src/libs/utils';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/input-utils';
-import { resumeUpload } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
+import {
+  resumeUpload,
+  uploadTimeRemainingDisplayText,
+} from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 
 export interface PipelineInputFileUploadState {
   signedUrl?: string; // The resumable upload session URL
@@ -274,9 +277,7 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
                   </div>
                   <div style={{ marginTop: '0.5rem', display: 'flex' }}>
                     <div style={{ fontWeight: 'bold', marginRight: '0.25rem' }}>Estimated time remaining:</div>
-                    {uploadState.uploadEtaSeconds
-                      ? `${Math.round(uploadState.uploadEtaSeconds)} seconds`
-                      : 'Calculating...'}
+                    {uploadTimeRemainingDisplayText(uploadState.uploadEtaSeconds)}
                   </div>
                 </div>
               </>

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -11,7 +11,7 @@ import { resumeUpload } from 'src/pages/scientificServices/pipelines/utils/uploa
 export interface PipelineInputFileUploadState {
   signedUrl?: string; // The resumable upload session URL
   progress: number; // Progress percentage (0-100)
-  uploadEta?: number; // Estimated time remaining in seconds
+  uploadEtaSeconds?: number; // Estimated time remaining in seconds
   errorMessage?: string; // Optional error message
 }
 
@@ -274,7 +274,9 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
                   </div>
                   <div style={{ marginTop: '0.5rem', display: 'flex' }}>
                     <div style={{ fontWeight: 'bold', marginRight: '0.25rem' }}>Estimated time remaining:</div>
-                    {uploadState.uploadEta ? `${Math.round(uploadState.uploadEta)} seconds` : 'Calculating...'}
+                    {uploadState.uploadEtaSeconds
+                      ? `${Math.round(uploadState.uploadEtaSeconds)} seconds`
+                      : 'Calculating...'}
                   </div>
                 </div>
               </>

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
@@ -1,4 +1,8 @@
-import { checkUploadStatus, initiateResumableUpload } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
+import {
+  checkUploadStatus,
+  initiateResumableUpload,
+  uploadTimeRemainingDisplayText,
+} from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 import * as uploadUtils from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 
 global.fetch = jest.fn();
@@ -172,6 +176,22 @@ describe('upload-utils', () => {
       expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
       expect(mockXHR.setRequestHeader).toHaveBeenCalledWith('Content-Range', 'bytes 0-9/10');
       expect(mockXHR.send).toHaveBeenCalledWith(inputFile);
+    });
+  });
+
+  describe('uploadTimeRemainingDisplayText', () => {
+    it('returns "Calculating..." when eta is undefined', () => {
+      expect(uploadTimeRemainingDisplayText(undefined)).toBe('Calculating...');
+    });
+
+    it('returns a mix of minutes and seconds when ETA is greater than 60 seconds', () => {
+      expect(uploadTimeRemainingDisplayText(125)).toBe('2 minutes 5 seconds');
+      expect(uploadTimeRemainingDisplayText(61)).toBe('1 minute 1 second');
+    });
+
+    it('returns only seconds value when ETA is less than 60 seconds', () => {
+      expect(uploadTimeRemainingDisplayText(45)).toBe('45 seconds');
+      expect(uploadTimeRemainingDisplayText(1)).toBe('1 second');
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.test.ts
@@ -184,9 +184,10 @@ describe('upload-utils', () => {
       expect(uploadTimeRemainingDisplayText(undefined)).toBe('Calculating...');
     });
 
-    it('returns a mix of minutes and seconds when ETA is greater than 60 seconds', () => {
-      expect(uploadTimeRemainingDisplayText(125)).toBe('2 minutes 5 seconds');
-      expect(uploadTimeRemainingDisplayText(61)).toBe('1 minute 1 second');
+    it('returns minutes (rounded to the nearest minute) when ETA is greater than 60 seconds', () => {
+      expect(uploadTimeRemainingDisplayText(61)).toBe('1 minute');
+      expect(uploadTimeRemainingDisplayText(125)).toBe('2 minutes');
+      expect(uploadTimeRemainingDisplayText(160)).toBe('3 minutes');
     });
 
     it('returns only seconds value when ETA is less than 60 seconds', () => {

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -109,6 +109,9 @@ export async function initiateResumableUpload(
   signedUrl: string,
   setUploadState: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>
 ): Promise<number> {
+  // Keeps track of all progress measurements to calculate average upload rate and estimated time remaining
+  const uploadRates: number[] = [];
+
   // Step 1: Initiate the resumable upload session.
   // Google will return a session URL in the Location header,
   // which we'll use to upload the file.
@@ -125,17 +128,50 @@ export async function initiateResumableUpload(
 
   // Step 2: Upload the file using XMLHttpRequest for progress tracking
   const startTime = Date.now();
+  let lastEtaUpdate = 0; // Track when we last updated the ETA
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
     xhr.upload.addEventListener('progress', (event) => {
       if (event.lengthComputable) {
+        const currentTime = Date.now();
+        const elapsedTime = currentTime - startTime;
+        const uploadRate = event.loaded / elapsedTime; // bytes per ms
+
         const percent = Math.round((event.loaded / event.total) * 100);
-        setUploadState((prev) => ({
-          ...prev,
-          [inputName]: { progress: percent, signedUrl: sessionUrl },
-        }));
+
+        // Only update ETA every 2 seconds or on the first update, to avoid choppy ETA updates
+        if (currentTime - lastEtaUpdate >= 2000 || lastEtaUpdate === 0) {
+          uploadRates.push(uploadRate);
+          if (uploadRates.length > 5) {
+            uploadRates.shift(); // Remove the oldest measurement
+          }
+
+          const averageUploadRate = uploadRates.reduce((acc, rate) => acc + rate, 0) / uploadRates.length;
+          const bytesRemaining = inputFile.size - event.loaded;
+          const estimatedTimeRemainingMs = bytesRemaining / averageUploadRate;
+
+          setUploadState((prev) => ({
+            ...prev,
+            [inputName]: {
+              progress: percent,
+              signedUrl: sessionUrl,
+              uploadEta: uploadRates.length < 5 ? undefined : estimatedTimeRemainingMs / 1000,
+            },
+          }));
+
+          lastEtaUpdate = currentTime;
+        } else {
+          // Just update progress without changing ETA to keep it smooth
+          setUploadState((prev) => ({
+            ...prev,
+            [inputName]: {
+              ...prev[inputName],
+              progress: percent,
+            },
+          }));
+        }
       }
     });
 

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -115,8 +115,8 @@ export async function resumeUpload(
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
-    const uploadRateSamples: number[] = [];
     const startTime = Date.now();
+    const uploadRateSamples: number[] = [];
     const lastEtaUpdate = 0;
 
     xhr.upload.addEventListener(
@@ -174,9 +174,6 @@ export async function initiateResumableUpload(
   signedUrl: string,
   setUploadState: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>
 ): Promise<number> {
-  // Keeps track of all progress measurements to calculate average upload rate and estimated time remaining
-  const uploadRateSamples: number[] = [];
-
   // Step 1: Initiate the resumable upload session.
   // Google will return a session URL in the Location header,
   // which we'll use to upload the file.
@@ -193,6 +190,7 @@ export async function initiateResumableUpload(
 
   // Step 2: Upload the file using XMLHttpRequest for progress tracking
   const startTime = Date.now();
+  const uploadRateSamples: number[] = [];
   const lastEtaUpdate = 0;
 
   return new Promise((resolve, reject) => {
@@ -246,11 +244,11 @@ export async function initiateResumableUpload(
   });
 }
 
-export const uploadTimeRemainingDisplayText = (seconds?: number) => {
-  if (!seconds) return 'Calculating...';
+export const uploadTimeRemainingDisplayText = (secondsRemaining?: number) => {
+  if (!secondsRemaining) return 'Calculating...';
 
-  const minsRemaining = Math.floor(seconds / 60);
-  const secsRemaining = Math.floor(seconds % 60);
+  const minsRemaining = Math.floor(secondsRemaining / 60);
+  const secsRemaining = Math.floor(secondsRemaining % 60);
 
   const minsDisplayText = minsRemaining > 0 ? `${minsRemaining} ${pluralize('minute', minsRemaining)}` : '';
   const secsDisplayText = `${secsRemaining} ${pluralize('second', secsRemaining)}`;

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -1,6 +1,64 @@
 import { Dispatch, SetStateAction } from 'react';
 import { PipelineInputFileUploadState } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput';
 
+// Returns a function that handles progress events for file uploads
+// This function updates the upload state with progress percentage and estimated time remaining
+function createProgressEventListener(
+  inputName: string,
+  inputFile: File,
+  sessionUrl: string,
+  setUploadState: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>,
+  startTime: number,
+  uploadRateSamples: number[],
+  lastEtaUpdate: number,
+  uploadedBytesOffset: number
+) {
+  return (event: ProgressEvent) => {
+    if (event.lengthComputable) {
+      const currentTime = Date.now();
+      const elapsedTime = currentTime - startTime;
+
+      // Calculate total bytes uploaded (for resumed uploads, add the offset)
+      const totalBytesUploaded = uploadedBytesOffset + event.loaded;
+      const uploadRate = totalBytesUploaded / elapsedTime; // bytes per ms
+
+      const percent = Math.round((totalBytesUploaded / inputFile.size) * 100);
+
+      // Only update ETA every 2 seconds or on the first update, to avoid choppy ETA updates
+      if (currentTime - lastEtaUpdate >= 2000 || lastEtaUpdate === 0) {
+        uploadRateSamples.push(uploadRate);
+        if (uploadRateSamples.length > 5) {
+          uploadRateSamples.shift(); // Remove the oldest sample
+        }
+
+        const averageUploadRate = uploadRateSamples.reduce((acc, rate) => acc + rate, 0) / uploadRateSamples.length;
+        const bytesRemaining = inputFile.size - totalBytesUploaded;
+        const estimatedTimeRemainingMs = bytesRemaining / averageUploadRate;
+
+        setUploadState((prev) => ({
+          ...prev,
+          [inputName]: {
+            progress: percent,
+            signedUrl: sessionUrl,
+            uploadEta: uploadRateSamples.length < 5 ? undefined : estimatedTimeRemainingMs / 1000,
+          },
+        }));
+
+        lastEtaUpdate = currentTime;
+      } else {
+        // Just update progress without changing ETA to keep it smooth
+        setUploadState((prev) => ({
+          ...prev,
+          [inputName]: {
+            ...prev[inputName],
+            progress: percent,
+          },
+        }));
+      }
+    }
+  };
+}
+
 /* Check the status of a resumable upload session. Returns the last byte that GCS received */
 export async function checkUploadStatus(sessionUrl: string): Promise<number> {
   const res = await fetch(sessionUrl, {
@@ -56,16 +114,23 @@ export async function resumeUpload(
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
-    xhr.upload.addEventListener('progress', (event) => {
-      if (event.lengthComputable) {
-        const totalProgress = ((uploadedBytes + event.loaded) / inputFile.size) * 100;
-        const percent = Math.round(totalProgress);
-        setUploadState((prev) => ({
-          ...prev,
-          [inputName]: { ...prev[inputName], progress: percent, errorMessage: undefined },
-        }));
-      }
-    });
+    const uploadRateSamples: number[] = [];
+    const startTime = Date.now();
+    const lastEtaUpdate = 0;
+
+    xhr.upload.addEventListener(
+      'progress',
+      createProgressEventListener(
+        inputName,
+        inputFile,
+        sessionUrl,
+        setUploadState,
+        startTime,
+        uploadRateSamples,
+        lastEtaUpdate,
+        uploadedBytes // byte offset for resumable upload
+      )
+    );
 
     xhr.addEventListener('load', () => {
       if (xhr.status >= 200 && xhr.status < 300) {
@@ -110,7 +175,7 @@ export async function initiateResumableUpload(
   setUploadState: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>
 ): Promise<number> {
   // Keeps track of all progress measurements to calculate average upload rate and estimated time remaining
-  const uploadRates: number[] = [];
+  const uploadRateSamples: number[] = [];
 
   // Step 1: Initiate the resumable upload session.
   // Google will return a session URL in the Location header,
@@ -128,52 +193,24 @@ export async function initiateResumableUpload(
 
   // Step 2: Upload the file using XMLHttpRequest for progress tracking
   const startTime = Date.now();
-  let lastEtaUpdate = 0; // Track when we last updated the ETA
+  const lastEtaUpdate = 0;
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
-    xhr.upload.addEventListener('progress', (event) => {
-      if (event.lengthComputable) {
-        const currentTime = Date.now();
-        const elapsedTime = currentTime - startTime;
-        const uploadRate = event.loaded / elapsedTime; // bytes per ms
-
-        const percent = Math.round((event.loaded / event.total) * 100);
-
-        // Only update ETA every 2 seconds or on the first update, to avoid choppy ETA updates
-        if (currentTime - lastEtaUpdate >= 2000 || lastEtaUpdate === 0) {
-          uploadRates.push(uploadRate);
-          if (uploadRates.length > 5) {
-            uploadRates.shift(); // Remove the oldest measurement
-          }
-
-          const averageUploadRate = uploadRates.reduce((acc, rate) => acc + rate, 0) / uploadRates.length;
-          const bytesRemaining = inputFile.size - event.loaded;
-          const estimatedTimeRemainingMs = bytesRemaining / averageUploadRate;
-
-          setUploadState((prev) => ({
-            ...prev,
-            [inputName]: {
-              progress: percent,
-              signedUrl: sessionUrl,
-              uploadEta: uploadRates.length < 5 ? undefined : estimatedTimeRemainingMs / 1000,
-            },
-          }));
-
-          lastEtaUpdate = currentTime;
-        } else {
-          // Just update progress without changing ETA to keep it smooth
-          setUploadState((prev) => ({
-            ...prev,
-            [inputName]: {
-              ...prev[inputName],
-              progress: percent,
-            },
-          }));
-        }
-      }
-    });
+    xhr.upload.addEventListener(
+      'progress',
+      createProgressEventListener(
+        inputName,
+        inputFile,
+        sessionUrl,
+        setUploadState,
+        startTime,
+        uploadRateSamples,
+        lastEtaUpdate,
+        0 // no offset for new upload
+      )
+    );
 
     xhr.addEventListener('load', () => {
       if (xhr.status >= 200 && xhr.status < 300) {

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -252,6 +252,6 @@ export const uploadTimeRemainingDisplayText = (secondsRemaining?: number) => {
     return `${minsRemainingRounded} ${pluralize('minute', minsRemainingRounded)}`;
   }
 
-  const secsRemainingRounded = Math.round(secondsRemaining % 60);
+  const secsRemainingRounded = Math.round(secondsRemaining);
   return `${secsRemainingRounded} ${pluralize('second', secsRemainingRounded)}`;
 };

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -247,10 +247,11 @@ export async function initiateResumableUpload(
 export const uploadTimeRemainingDisplayText = (secondsRemaining?: number) => {
   if (!secondsRemaining) return 'Calculating...';
 
-  const minsRemaining = Math.floor(secondsRemaining / 60);
-  const secsRemaining = Math.floor(secondsRemaining % 60);
+  if (secondsRemaining > 60) {
+    const minsRemainingRounded = Math.round(secondsRemaining / 60);
+    return `${minsRemainingRounded} ${pluralize('minute', minsRemainingRounded)}`;
+  }
 
-  const minsDisplayText = minsRemaining > 0 ? `${minsRemaining} ${pluralize('minute', minsRemaining)}` : '';
-  const secsDisplayText = `${secsRemaining} ${pluralize('second', secsRemaining)}`;
-  return `${minsDisplayText}${minsRemaining > 0 ? ' ' : ''}${secsDisplayText}`;
+  const secsRemainingRounded = Math.round(secondsRemaining % 60);
+  return `${secsRemainingRounded} ${pluralize('second', secsRemainingRounded)}`;
 };

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -2,7 +2,8 @@ import { Dispatch, SetStateAction } from 'react';
 import { PipelineInputFileUploadState } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput';
 
 // Returns a function that handles progress events for file uploads
-// This function updates the upload state with progress percentage and estimated time remaining
+// This function updates the upload state with progress percentage and
+// estimated time remaining using a moving average of upload rates
 function createProgressEventListener(
   inputName: string,
   inputFile: File,
@@ -10,18 +11,16 @@ function createProgressEventListener(
   setUploadState: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>,
   startTime: number,
   uploadRateSamples: number[],
-  lastEtaUpdate: number,
-  uploadedBytesOffset: number
+  lastEtaUpdate: number
 ) {
   return (event: ProgressEvent) => {
     if (event.lengthComputable) {
       const currentTime = Date.now();
       const elapsedTime = currentTime - startTime;
 
-      // Calculate total bytes uploaded (for resumed uploads, add the offset)
-      const totalBytesUploaded = uploadedBytesOffset + event.loaded;
+      // Calculate the upload rate of the most recent progress event
+      const totalBytesUploaded = event.loaded;
       const uploadRate = totalBytesUploaded / elapsedTime; // bytes per ms
-
       const percent = Math.round((totalBytesUploaded / inputFile.size) * 100);
 
       // Only update ETA every 2 seconds or on the first update, to avoid choppy ETA updates
@@ -46,7 +45,8 @@ function createProgressEventListener(
 
         lastEtaUpdate = currentTime;
       } else {
-        // Just update progress without changing ETA to keep it smooth
+        // Last progress event was less than 2 seconds ago, so we'll just update percent progress
+        // without changing ETA to keep it smooth
         setUploadState((prev) => ({
           ...prev,
           [inputName]: {
@@ -127,8 +127,7 @@ export async function resumeUpload(
         setUploadState,
         startTime,
         uploadRateSamples,
-        lastEtaUpdate,
-        uploadedBytes // byte offset for resumable upload
+        lastEtaUpdate
       )
     );
 
@@ -207,8 +206,7 @@ export async function initiateResumableUpload(
         setUploadState,
         startTime,
         uploadRateSamples,
-        lastEtaUpdate,
-        0 // no offset for new upload
+        lastEtaUpdate
       )
     );
 

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -1,3 +1,4 @@
+import pluralize from 'pluralize';
 import { Dispatch, SetStateAction } from 'react';
 import { PipelineInputFileUploadState } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput';
 
@@ -39,7 +40,7 @@ function createProgressEventListener(
           [inputName]: {
             progress: percent,
             signedUrl: sessionUrl,
-            uploadEta: uploadRateSamples.length < 5 ? undefined : estimatedTimeRemainingMs / 1000,
+            uploadEtaSeconds: uploadRateSamples.length < 5 ? undefined : estimatedTimeRemainingMs / 1000,
           },
         }));
 
@@ -244,3 +245,14 @@ export async function initiateResumableUpload(
     xhr.send(inputFile);
   });
 }
+
+export const uploadTimeRemainingDisplayText = (seconds?: number) => {
+  if (!seconds) return 'Calculating...';
+
+  const minsRemaining = Math.floor(seconds / 60);
+  const secsRemaining = Math.floor(seconds % 60);
+
+  const minsDisplayText = minsRemaining > 0 ? `${minsRemaining} ${pluralize('minute', minsRemaining)}` : '';
+  const secsDisplayText = `${secsRemaining} ${pluralize('second', secsRemaining)}`;
+  return `${minsDisplayText}${minsRemaining > 0 ? ' ' : ''}${secsDisplayText}`;
+};

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -77,8 +77,8 @@ export const RunJob = () => {
   };
 
   async function onUploadComplete(jobId: string) {
-    const submittedJobId = await startPipelineRun(jobId);
-    setSubmittedJobId(submittedJobId);
+    // const submittedJobId = await startPipelineRun(jobId);
+    setSubmittedJobId('foooo!');
     setIsSubmitting(false);
   }
 

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -77,8 +77,8 @@ export const RunJob = () => {
   };
 
   async function onUploadComplete(jobId: string) {
-    // const submittedJobId = await startPipelineRun(jobId);
-    setSubmittedJobId('foooo!');
+    const submittedJobId = await startPipelineRun(jobId);
+    setSubmittedJobId(submittedJobId);
     setIsSubmitting(false);
   }
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-616

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

* Adds an ETA for file uploads

Note:  screenshot below is outdated: seconds will no longer be displayed if the ETA is > 1 minute

https://github.com/user-attachments/assets/d626df9d-78d2-4391-ba2c-afb812231054


<img width="552" height="282" alt="Screenshot 2025-09-24 at 10 00 38 AM" src="https://github.com/user-attachments/assets/9d9c4e91-934a-4294-974e-4ef05eaa39a1" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
