### PR TITLE
[TSPS-629] Display pipeline outputs on Run Job page

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -19,7 +19,6 @@
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
   "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
-  "teaspoonsUrlRootLocal": "http://localhost:8080",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -19,6 +19,7 @@
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
   "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
+  "teaspoonsUrlRootLocal": "http://localhost:8080",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -12,6 +12,11 @@ export interface PipelineInput {
   fileSuffix?: string; // Only present for FILE types
 }
 
+export interface PipelineOutput {
+  name: string;
+  type: 'FILE' | 'STRING';
+}
+
 /* Represents the quota settings for a particular pipeline */
 export interface PipelineQuota {
   pipelineName: string;
@@ -29,6 +34,7 @@ export interface PipelineQuota {
 export interface PipelineWithDetails extends Pipeline {
   type: string; // e.g. "imputation"
   inputs: PipelineInput[];
+  outputs: PipelineOutput[];
   pipelineQuota?: PipelineQuota;
 }
 

--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -14,7 +14,7 @@ export interface PipelineInput {
 
 export interface PipelineOutput {
   name: string;
-  type: 'FILE' | 'STRING';
+  type: string;
 }
 
 /* Represents the quota settings for a particular pipeline */

--- a/src/pages/scientificServices/pipelines/utils/mock-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/mock-utils.ts
@@ -1,6 +1,7 @@
 import {
   Pipeline,
   PipelineInput,
+  PipelineOutput,
   PipelineRun,
   PipelineRunStatus,
   PipelineWithDetails,
@@ -28,6 +29,20 @@ export function mockPipelineWithDetails(name: string): PipelineWithDetails {
         fileSuffix: '.vcf.gz',
       },
     ] as PipelineInput[],
+    outputs: [
+      {
+        name: 'imputedMultiSampleVcf',
+        type: 'FILE',
+      },
+      {
+        name: 'imputedMultiSampleVcfIndex',
+        type: 'FILE',
+      },
+      {
+        name: 'chunksInfo',
+        type: 'FILE',
+      },
+    ] as PipelineOutput[],
     pipelineQuota: {
       pipelineName: name,
       defaultQuota: 2500,

--- a/src/pages/scientificServices/pipelines/utils/output-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/output-utils.ts
@@ -10,6 +10,6 @@ export const OUTPUT_DESCRIPTIONS: Record<string, PipelineOutputDescription> = {
     helpText: 'Lorem ipsum bla bla bla bla bla bla bla bla bla bla bla bla bla bla ',
   },
   chunksInfo: {
-    helpText: 'bla bla bla bla !',
+    helpText: 'this output is sick !',
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/output-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/output-utils.ts
@@ -1,0 +1,15 @@
+export interface PipelineOutputDescription {
+  helpText: string;
+}
+
+export const OUTPUT_DESCRIPTIONS: Record<string, PipelineOutputDescription> = {
+  imputedMultiSampleVcf: {
+    helpText: 'Lorem ipsum bla bla bla',
+  },
+  imputedMultiSampleVcfIndex: {
+    helpText: 'Lorem ipsum bla bla bla bla bla bla bla bla bla bla bla bla bla bla ',
+  },
+  chunksInfo: {
+    helpText: 'bla bla bla bla !',
+  },
+};

--- a/src/pages/scientificServices/pipelines/utils/output-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/output-utils.ts
@@ -1,17 +1,17 @@
 export interface PipelineOutputDescription {
-  helpText: string;
+  description: string;
 }
 
 export const PIPELINE_OUTPUT_DESCRIPTIONS: Record<string, Record<string, PipelineOutputDescription>> = {
   array_imputation: {
     imputedMultiSampleVcf: {
-      helpText: 'A multi-sample VCF file containing imputed genotypes for all samples',
+      description: 'A multi-sample VCF file containing imputed genotypes for all samples',
     },
     imputedMultiSampleVcfIndex: {
-      helpText: 'An index file for the imputed multi-sample VCF file',
+      description: 'An index file for the imputed multi-sample VCF file',
     },
     chunksInfo: {
-      helpText: 'A TSV file containing information about the chunks used during imputation',
+      description: 'A TSV file containing information about the chunks used during imputation',
     },
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/output-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/output-utils.ts
@@ -11,7 +11,7 @@ export const PIPELINE_OUTPUT_DESCRIPTIONS: Record<string, Record<string, Pipelin
       description: 'An index file for the imputed multi-sample VCF file',
     },
     chunksInfo: {
-      description: 'A TSV file containing information about the chunks used during imputation',
+      description: 'A TSV file containing QC information about the chunks used during imputation',
     },
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/output-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/output-utils.ts
@@ -2,14 +2,16 @@ export interface PipelineOutputDescription {
   helpText: string;
 }
 
-export const OUTPUT_DESCRIPTIONS: Record<string, PipelineOutputDescription> = {
-  imputedMultiSampleVcf: {
-    helpText: 'Lorem ipsum bla bla bla',
-  },
-  imputedMultiSampleVcfIndex: {
-    helpText: 'Lorem ipsum bla bla bla bla bla bla bla bla bla bla bla bla bla bla ',
-  },
-  chunksInfo: {
-    helpText: 'this output is sick !',
+export const PIPELINE_OUTPUT_DESCRIPTIONS: Record<string, Record<string, PipelineOutputDescription>> = {
+  array_imputation: {
+    imputedMultiSampleVcf: {
+      helpText: 'A multi-sample VCF file containing imputed genotypes for all samples',
+    },
+    imputedMultiSampleVcfIndex: {
+      helpText: 'An index file for the imputed multi-sample VCF file',
+    },
+    chunksInfo: {
+      helpText: 'A TSV file containing information about the chunks used during imputation',
+    },
   },
 };

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -70,6 +70,7 @@ describe('RunJob Component', () => {
     ...mockPipeline,
     type: 'imputation',
     inputs: mockPipelineInputs,
+    outputs: [],
   };
 
   const mockPipelineList: PipelineList = {

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -29,6 +29,7 @@ import {
   uploadPipelineFiles,
 } from 'src/pages/scientificServices/pipelines/utils/submission-utils';
 import { HelpfulTipsWidget } from 'src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget';
+import { PipelineOutputsWidget } from 'src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget';
 import { QuotaRemainingWidget } from 'src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget';
 
 export const RunJob = () => {
@@ -227,7 +228,7 @@ export const RunJob = () => {
                 })}
 
               {/* Displays optional run description */}
-              <PipelineRunDescription value={runDescription} onChange={setRunDescription} />
+              {selectedPipeline && <PipelineRunDescription value={runDescription} onChange={setRunDescription} />}
 
               {/* Displays all FILE inputs, one after another */}
               {pipelineInputs
@@ -354,6 +355,7 @@ export const RunJob = () => {
         <div>
           <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
           <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
+          <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
         </div>
       </div>
     </FooterWrapper>

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -354,8 +354,8 @@ export const RunJob = () => {
         </div>
         <div>
           <QuotaRemainingWidget selectedPipeline={selectedPipeline} />
-          <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
           <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
+          <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
         </div>
       </div>
     </FooterWrapper>

--- a/src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/HelpfulTipsWidget.tsx
@@ -1,6 +1,7 @@
-import { Icon } from '@terra-ui-packages/components';
 import React, { ReactNode } from 'react';
 import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
+
+import { PipelineWidgetContainer } from './PipelineWidgetContainer';
 
 export const PIPELINE_TIPS: Record<string, { id: string; content: ReactNode }[]> = {
   // Add tips for new pipelines here, and they'll automatically be displayed.
@@ -33,17 +34,7 @@ export const HelpfulTipsWidget = ({ selectedPipeline }: { selectedPipeline?: Pip
   if (!pipelineTips || pipelineTips.length === 0) return null;
 
   return (
-    <div
-      style={{
-        backgroundColor: '#f4f6f9',
-        width: 400,
-        padding: '1rem',
-        borderRadius: '4px',
-      }}
-    >
-      <h3 style={{ marginTop: '0.5rem' }}>
-        <Icon icon='info-circle' style={{ color: '#5CC88D' }} /> Helpful Tips
-      </h3>
+    <PipelineWidgetContainer title='Helpful Tips' padding='1rem'>
       <ul style={{ paddingInlineStart: '1.5rem' }}>
         {pipelineTips.map((tip) => (
           <li key={tip.id} data-testid={`tip-${tip.id}`} style={{ marginTop: '1rem' }}>
@@ -51,6 +42,6 @@ export const HelpfulTipsWidget = ({ selectedPipeline }: { selectedPipeline?: Pip
           </li>
         ))}
       </ul>
-    </div>
+    </PipelineWidgetContainer>
   );
 };

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.test.tsx
@@ -15,7 +15,7 @@ describe('PipelineOutputsWidget', () => {
     pipelineDetails.outputs?.forEach((output) => {
       expect(screen.getByText(output.name)).toBeInTheDocument();
       expect(
-        screen.getByText(PIPELINE_OUTPUT_DESCRIPTIONS[pipelineDetails.pipelineName][output.name].helpText)
+        screen.getByText(PIPELINE_OUTPUT_DESCRIPTIONS[pipelineDetails.pipelineName][output.name].description)
       ).toBeInTheDocument();
     });
   });

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { mockPipelineWithDetails } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
+import { PIPELINE_OUTPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/output-utils';
+import { PipelineOutputsWidget } from 'src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget';
+
+describe('PipelineOutputsWidget', () => {
+  it('renders all outputs for a pipeline', () => {
+    const pipelineDetails = mockPipelineWithDetails('array_imputation');
+    render(<PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />);
+
+    expect(screen.getByText('Pipeline Outputs')).toBeInTheDocument();
+
+    pipelineDetails.outputs?.forEach((output) => {
+      expect(screen.getByText(output.name)).toBeInTheDocument();
+      expect(
+        screen.getByText(PIPELINE_OUTPUT_DESCRIPTIONS[pipelineDetails.pipelineName][output.name].helpText)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('displays "no description available" for outputs without a description', () => {
+    const pipelineDetails = {
+      ...mockPipelineWithDetails('array_imputation'),
+      outputs: [{ name: 'unknownOutput', type: 'STRING' }],
+    } as PipelineWithDetails;
+
+    render(<PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />);
+
+    expect(screen.getByText('unknownOutput')).toBeInTheDocument();
+    expect(screen.getByText('No description available')).toBeInTheDocument();
+  });
+
+  it('displays "no outputs" message for pipelines without outputs', () => {
+    const pipelineDetails = { ...mockPipelineWithDetails('array_imputation'), outputs: [] };
+    render(<PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />);
+
+    expect(screen.getByText('This pipeline does not have any outputs')).toBeInTheDocument();
+  });
+
+  it('displays "select a pipeline" prior to pipeline details being loaded', () => {
+    render(<PipelineOutputsWidget selectedPipelineDetails={undefined} />);
+
+    expect(screen.queryByText('Pipeline Outputs')).toBeInTheDocument();
+    expect(screen.getByText('Select a pipeline to see outputs')).toBeInTheDocument();
+  });
+});

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -1,8 +1,8 @@
 import { Icon } from '@terra-ui-packages/components';
 import React from 'react';
-import { PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { PipelineOutput, PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { cond, DEFAULT } from 'src/libs/utils';
-import { OUTPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/output-utils';
+import { PIPELINE_OUTPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/output-utils';
 
 export const PipelineOutputsWidget = ({
   selectedPipelineDetails,
@@ -30,15 +30,19 @@ export const PipelineOutputsWidget = ({
         [
           !!pipelineOutputs,
           () => {
-            if (!pipelineOutputs) {
-              // this should never happen because of the cond predicate above, but typescript
-              // has no idea what cond is doing, so we sadly need the extra type guard
-              return <div style={{ marginTop: '1rem' }}>This pipeline does not have any outputs.</div>;
+            if (!pipelineOutputs || pipelineOutputs.length === 0) {
+              return (
+                <div style={{ marginTop: '1rem', fontStyle: 'italic' }}>This pipeline does not have any outputs</div>
+              );
             }
             return (
               <div style={{ marginTop: '1rem' }}>
                 {pipelineOutputs.map((output) => (
-                  <OutputDetails key={output.name} outputName={output.name} outputType={output.type} />
+                  <OutputDetails
+                    key={output.name}
+                    pipelineName={selectedPipelineDetails.pipelineName}
+                    output={output}
+                  />
                 ))}
               </div>
             );
@@ -50,11 +54,13 @@ export const PipelineOutputsWidget = ({
   );
 };
 
-const OutputDetails = ({ outputName, outputType }: { outputName: string; outputType: 'FILE' | 'STRING' }) => {
+const OutputDetails = ({ pipelineName, output }: { pipelineName: string; output: PipelineOutput }) => {
+  const outputDescription = PIPELINE_OUTPUT_DESCRIPTIONS[pipelineName]?.[output.name]?.helpText;
+
   return (
     <div style={{ marginTop: '1rem', borderLeft: '3px solid #e4e5e6', paddingLeft: '0.5rem' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <div style={{ fontWeight: 500, paddingBottom: '0.5rem' }}>{outputName}</div>
+        <div style={{ fontWeight: 500, paddingBottom: '0.5rem' }}>{output.name}</div>
         <div
           style={{
             backgroundColor: '#e7f3fb',
@@ -72,15 +78,11 @@ const OutputDetails = ({ outputName, outputType }: { outputName: string; outputT
               fontSize: '0.875rem',
             }}
           >
-            {outputType.toLowerCase()}
+            {output.type.toLowerCase()}
           </span>
         </div>
       </div>
-      <div style={{ width: '80%', fontSize: 13 }}>
-        {OUTPUT_DESCRIPTIONS[outputName]
-          ? OUTPUT_DESCRIPTIONS[outputName].helpText
-          : `No description available for this ${outputType.toLowerCase()} output.`}
-      </div>
+      <div style={{ width: '80%', fontSize: 13 }}>{outputDescription || 'No description available'}</div>
     </div>
   );
 };

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -1,8 +1,9 @@
-import { Icon } from '@terra-ui-packages/components';
 import React from 'react';
 import { PipelineOutput, PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { cond, DEFAULT } from 'src/libs/utils';
 import { PIPELINE_OUTPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/output-utils';
+
+import { PipelineWidgetContainer } from './PipelineWidgetContainer';
 
 export const PipelineOutputsWidget = ({
   selectedPipelineDetails,
@@ -12,19 +13,7 @@ export const PipelineOutputsWidget = ({
   const pipelineOutputs = selectedPipelineDetails?.outputs;
 
   return (
-    <div
-      style={{
-        marginTop: '1rem',
-        marginBottom: '1rem',
-        backgroundColor: '#f4f6f9',
-        width: 400,
-        padding: '1rem 1rem 1.5rem',
-        borderRadius: '4px',
-      }}
-    >
-      <h3 style={{ marginTop: '0.5rem' }}>
-        <Icon icon='info-circle' style={{ color: '#5CC88D' }} /> Pipeline Outputs
-      </h3>
+    <PipelineWidgetContainer title='Pipeline Outputs'>
       {cond(
         [!selectedPipelineDetails, () => <div style={{ marginTop: '1rem' }}>Select a pipeline to see outputs</div>],
         [
@@ -50,7 +39,7 @@ export const PipelineOutputsWidget = ({
         ],
         [DEFAULT, () => <div style={{ marginTop: '1rem' }}>Loading pipeline details...</div>]
       )}
-    </div>
+    </PipelineWidgetContainer>
   );
 };
 

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -1,0 +1,92 @@
+import { Icon } from '@terra-ui-packages/components';
+import React from 'react';
+import { PipelineWithDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { cond, DEFAULT } from 'src/libs/utils';
+import { OUTPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/output-utils';
+
+export const PipelineOutputsWidget = ({
+  selectedPipelineDetails,
+}: {
+  selectedPipelineDetails?: PipelineWithDetails;
+}) => {
+  const pipelineOutputs = selectedPipelineDetails?.outputs;
+
+  return (
+    <div
+      style={{
+        marginTop: '1rem',
+        backgroundColor: '#f4f6f9',
+        width: 400,
+        padding: '1rem',
+        borderRadius: '4px',
+      }}
+    >
+      <h3 style={{ marginTop: '0.5rem' }}>
+        <Icon icon='info-circle' style={{ color: '#5CC88D' }} /> Pipeline Outputs
+      </h3>
+      {cond(
+        [!selectedPipelineDetails, () => <div style={{ marginTop: '1rem' }}>Select a pipeline to see outputs</div>],
+        [
+          !!pipelineOutputs,
+          () => {
+            if (!pipelineOutputs) {
+              // this should never happen because of the cond predicate above, but typescript
+              // has no idea what cond is doing, so we sadly need the extra type guard
+              return <div style={{ marginTop: '1rem' }}>This pipeline does not have any outputs.</div>;
+            }
+            return (
+              <div style={{ marginTop: '1rem' }}>
+                {pipelineOutputs.map((output) => (
+                  <OutputDetails key={output.name} outputName={output.name} outputType={output.type} />
+                ))}
+              </div>
+            );
+          },
+        ],
+        [DEFAULT, () => <div style={{ marginTop: '1rem' }}>Loading pipeline details...</div>]
+      )}
+    </div>
+  );
+};
+
+const OutputDetails = ({ outputName, outputType }: { outputName: string; outputType: 'FILE' | 'STRING' }) => {
+  return (
+    <div style={{ marginTop: '1rem', borderLeft: '3px solid #e4e5e6', paddingLeft: '0.5rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <div style={{ fontWeight: 500, paddingBottom: '0.5rem' }}>{outputName}</div>
+        <div
+          style={{
+            backgroundColor: OUTPUT_TYPE_COLORS[outputType],
+            borderRadius: 8,
+            display: 'flex',
+            alignItems: 'center',
+            padding: '0.1rem 0.25rem',
+          }}
+        >
+          <Icon
+            icon={outputType === 'FILE' ? 'fileAlt' : 'fileAlt'}
+            data-testid={`output-type-${outputType.toLowerCase()}`}
+          />
+          <span
+            style={{
+              marginLeft: '0.25rem',
+              fontSize: '0.875rem',
+            }}
+          >
+            {outputType.toLowerCase()}
+          </span>
+        </div>
+      </div>
+      <div style={{ width: '80%' }}>
+        {OUTPUT_DESCRIPTIONS[outputName]
+          ? OUTPUT_DESCRIPTIONS[outputName].helpText
+          : `No description available for this ${outputType.toLowerCase()} output.`}
+      </div>
+    </div>
+  );
+};
+
+const OUTPUT_TYPE_COLORS: Record<'FILE' | 'STRING', string> = {
+  FILE: '#e7f3fb',
+  STRING: '#5cc88d',
+};

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -15,9 +15,10 @@ export const PipelineOutputsWidget = ({
     <div
       style={{
         marginTop: '1rem',
+        marginBottom: '1rem',
         backgroundColor: '#f4f6f9',
         width: 400,
-        padding: '1rem',
+        padding: '1rem 1rem 1.5rem 1rem',
         borderRadius: '4px',
       }}
     >
@@ -56,20 +57,18 @@ const OutputDetails = ({ outputName, outputType }: { outputName: string; outputT
         <div style={{ fontWeight: 500, paddingBottom: '0.5rem' }}>{outputName}</div>
         <div
           style={{
-            backgroundColor: OUTPUT_TYPE_COLORS[outputType],
+            backgroundColor: '#e7f3fb',
             borderRadius: 8,
+            border: '1px solid #e4e5e6',
             display: 'flex',
             alignItems: 'center',
-            padding: '0.1rem 0.25rem',
+            padding: '0.25rem 0.5rem',
           }}
         >
-          <Icon
-            icon={outputType === 'FILE' ? 'fileAlt' : 'fileAlt'}
-            data-testid={`output-type-${outputType.toLowerCase()}`}
-          />
           <span
             style={{
-              marginLeft: '0.25rem',
+              textTransform: 'capitalize',
+              fontWeight: 500,
               fontSize: '0.875rem',
             }}
           >
@@ -84,9 +83,4 @@ const OutputDetails = ({ outputName, outputType }: { outputName: string; outputT
       </div>
     </div>
   );
-};
-
-const OUTPUT_TYPE_COLORS: Record<'FILE' | 'STRING', string> = {
-  FILE: '#e7f3fb',
-  STRING: '#5cc88d',
 };

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -18,7 +18,7 @@ export const PipelineOutputsWidget = ({
         marginBottom: '1rem',
         backgroundColor: '#f4f6f9',
         width: 400,
-        padding: '1rem 1rem 1.5rem 1rem',
+        padding: '1rem 1rem 1.5rem',
         borderRadius: '4px',
       }}
     >
@@ -55,7 +55,7 @@ export const PipelineOutputsWidget = ({
 };
 
 const OutputDetails = ({ pipelineName, output }: { pipelineName: string; output: PipelineOutput }) => {
-  const outputDescription = PIPELINE_OUTPUT_DESCRIPTIONS[pipelineName]?.[output.name]?.helpText;
+  const outputDescription = PIPELINE_OUTPUT_DESCRIPTIONS[pipelineName]?.[output.name]?.description;
 
   return (
     <div style={{ marginTop: '1rem', borderLeft: '3px solid #e4e5e6', paddingLeft: '0.5rem' }}>

--- a/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineOutputsWidget.tsx
@@ -77,7 +77,7 @@ const OutputDetails = ({ outputName, outputType }: { outputName: string; outputT
           </span>
         </div>
       </div>
-      <div style={{ width: '80%' }}>
+      <div style={{ width: '80%', fontSize: 13 }}>
         {OUTPUT_DESCRIPTIONS[outputName]
           ? OUTPUT_DESCRIPTIONS[outputName].helpText
           : `No description available for this ${outputType.toLowerCase()} output.`}

--- a/src/pages/scientificServices/pipelines/widgets/PipelineWidgetContainer.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/PipelineWidgetContainer.tsx
@@ -1,0 +1,39 @@
+import { Icon } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+
+interface PipelineWidgetWrapperProps {
+  title: string;
+  children: ReactNode;
+  marginTop?: string;
+  marginBottom?: string;
+  width?: number;
+  padding?: string;
+}
+
+// Wrapper component for sidebar widgets to ensure consistent styling
+export const PipelineWidgetContainer = ({
+  title,
+  children,
+  marginTop = '1rem',
+  marginBottom = '1rem',
+  width = 400,
+  padding = '1rem 1rem 1.5rem',
+}: PipelineWidgetWrapperProps) => {
+  return (
+    <div
+      style={{
+        marginTop,
+        marginBottom,
+        backgroundColor: '#f4f6f9',
+        width,
+        padding,
+        borderRadius: '4px',
+      }}
+    >
+      <h3 style={{ marginTop: '0.5rem' }}>
+        <Icon icon='info-circle' style={{ color: '#5CC88D' }} /> {title}
+      </h3>
+      {children}
+    </div>
+  );
+};

--- a/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
@@ -1,4 +1,3 @@
-import { Icon } from '@terra-ui-packages/components';
 import React from 'react';
 import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
@@ -6,22 +5,13 @@ import { cond, DEFAULT } from 'src/libs/utils';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { useUserQuota } from 'src/pages/scientificServices/pipelines/hooks/useUserQuota';
 
+import { PipelineWidgetContainer } from './PipelineWidgetContainer';
+
 export const QuotaRemainingWidget = ({ selectedPipeline }: { selectedPipeline?: Pipeline }) => {
   const { quota, pipelineDetails, meetsMinimumQuota } = useUserQuota(selectedPipeline);
 
   return (
-    <div
-      style={{
-        marginBottom: '1rem',
-        backgroundColor: '#f4f6f9',
-        width: 400,
-        padding: '1rem 1rem 1.5rem',
-        borderRadius: '4px',
-      }}
-    >
-      <h3 style={{ marginTop: '0.5rem' }}>
-        <Icon icon='info-circle' style={{ color: '#5CC88D' }} /> Quota Remaining
-      </h3>
+    <PipelineWidgetContainer title='Quota Remaining' marginBottom='1rem'>
       {cond(
         [!selectedPipeline, () => <div style={{ marginTop: '1rem' }}>Select a pipeline to see quota</div>],
         [
@@ -109,6 +99,6 @@ export const QuotaRemainingWidget = ({ selectedPipeline }: { selectedPipeline?: 
         </a>
         &nbsp;with quota.
       </div>
-    </div>
+    </PipelineWidgetContainer>
   );
 };

--- a/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
@@ -15,7 +15,7 @@ export const QuotaRemainingWidget = ({ selectedPipeline }: { selectedPipeline?: 
         marginBottom: '1rem',
         backgroundColor: '#f4f6f9',
         width: 400,
-        padding: '1rem',
+        padding: '1rem 1rem 1.5rem 1rem',
         borderRadius: '4px',
       }}
     >

--- a/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
+++ b/src/pages/scientificServices/pipelines/widgets/QuotaRemainingWidget.tsx
@@ -15,7 +15,7 @@ export const QuotaRemainingWidget = ({ selectedPipeline }: { selectedPipeline?: 
         marginBottom: '1rem',
         backgroundColor: '#f4f6f9',
         width: 400,
-        padding: '1rem 1rem 1.5rem 1rem',
+        padding: '1rem 1rem 1.5rem',
         borderRadius: '4px',
       }}
     >


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-629
<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds a new sidebar widget to the Run Job page so users can see the pipeline outputs of their selected pipeline


<img width="3024" height="1910" alt="screencapture-localhost-3000-2025-09-25-14_04_21" src="https://github.com/user-attachments/assets/bf83321a-bd8f-4493-a6bb-17f0e3adcd71" />




### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
