### PR TITLE
CORE-715: dedupe files before processing for IGV

### DIFF
--- a/src/components/IGVFileSelector.js
+++ b/src/components/IGVFileSelector.js
@@ -190,7 +190,10 @@ const validateUrl = async (fileRef) => {
   return url;
 };
 
-export const getValidIgvFiles = async (workspace, entityType, values, signal) => {
+export const getValidIgvFiles = async (workspace, entityType, allValues, signal) => {
+  // De-duplicate values to prevent processing/displaying the same file multiple times.
+  const values = _.uniq(allValues);
+
   const basicFileUrls = values.filter((value) => {
     let url;
     try {

--- a/src/components/IGVFileSelector.test.js
+++ b/src/components/IGVFileSelector.test.js
@@ -155,6 +155,18 @@ describe('getValidIgvFiles', () => {
     ]);
   });
 
+  it('condenses duplicate inputs', async () => {
+    expect(
+      await getValidIgvFiles(mockWorkspace, mockEntityType, ['gs://bucket/test2.vcf', 'gs://bucket/test2.vcf', 'gs://bucket/test2.idx'], mockSignal)
+    ).toEqual([
+      {
+        filePath: 'gs://bucket/test2.vcf',
+        indexFilePath: 'gs://bucket/test2.idx',
+        isSignedUrl: false,
+      },
+    ]);
+  });
+
   describe('TDR URLs', () => {
     it('allows TDR URLs', async () => {
       expect(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-715

## Summary of changes:
When sending data table rows to IGV, if those rows contained multiple references to the same file (such as the same drs:// uri in multiple columns of the same row), the UI would display duplicates to the end user and make duplicate ajax requests to process that file. The duplication is now eliminated.

## Testing strategy
- [x] Tested when running locally
- [x] Added a unit test

## Visual Aids

Note the duplicated ajax requests in dev tools in the "before" screenshot:

### Before
<img width="1669" height="921" alt="igv-dupes-before" src="https://github.com/user-attachments/assets/348a5e59-9522-470b-8743-7bb3ec1cb816" />

### After
<img width="1667" height="892" alt="igv-dupes-after" src="https://github.com/user-attachments/assets/714356dd-c880-47f3-b3ae-14987d1218fc" />


