### PR TITLE
CORE-694: data table, file browser icons were incorrectly sticky

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -60,7 +60,7 @@ a {
   overflow-y: scroll;
 }
 
-.table-row:not(:hover, :focus-within) .hover-only, .table-cell:not(:hover, :focus-within) .cell-hover-only {
+.table-row:not(:hover) .hover-only, .table-cell:not(:hover) .cell-hover-only {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
   height: 1px;

--- a/src/workspace-data/data-table/shared/DataTable.js
+++ b/src/workspace-data/data-table/shared/DataTable.js
@@ -634,6 +634,7 @@ const DataTable = (props) => {
                       const editLink =
                         editable &&
                         dataProvider.features.supportsEntityUpdating &&
+                        !updatingEntity &&
                         h(EditDataLink, {
                           'aria-label': `Edit attribute ${attributeName} of ${entityType} ${entityName}`,
                           'aria-haspopup': 'dialog',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-694

## Summary of changes:
The "edit" and "copy to clipboard" icons for a data table cell stayed visible after you moused away from that cell. Now they properly disappear.

This bug also affected the "copy to clipboard" icon on the file browser, and is fixed there as well.

## Testing strategy
Tested while running locally. No new unit tests.

## Visual Aids

### Data Table, before

https://github.com/user-attachments/assets/01cb5b04-3bc2-4876-ba9d-5608d9d9f655

### Data Table, after

https://github.com/user-attachments/assets/2083fdbc-94e6-4920-b2c9-c3ad4f170e4c

### File Browser, before

https://github.com/user-attachments/assets/a0867959-2ab8-4853-8000-c5e933546682

### File Browser, after

https://github.com/user-attachments/assets/9f330169-192e-4057-9138-08394d5e501b
