### PR TITLE
TSPS-642 Support FLOAT inputs and add minDr2ForInclusion

### DIFF
--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -7,7 +7,7 @@ export interface Pipeline {
 
 export interface PipelineInput {
   name: string;
-  type: 'FILE' | 'STRING';
+  type: 'FILE' | 'STRING' | 'FLOAT';
   isRequired: boolean;
   fileSuffix?: string; // Only present for FILE types
 }

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -6,6 +6,15 @@ import { renderWithAppContexts } from 'src/testing/test-utils';
 
 import { PipelineFileInput, PipelineInputFileUploadState } from './PipelineFileInput';
 
+jest.mock('src/pages/scientificServices/pipelines/utils/pipeline-input-utils', () => ({
+  INPUT_DESCRIPTIONS: {
+    multiSampleVcf: {
+      label: 'Select a multi-sample VCF file',
+      validationRegex: '^[a-zA-Z0-9_.-]+$',
+    },
+  },
+}));
+
 const mockInput: PipelineInput = {
   name: 'multiSampleVcf',
   type: 'FILE',
@@ -13,7 +22,24 @@ const mockInput: PipelineInput = {
   fileSuffix: '.vcf.gz',
 };
 
+const optionalInput: PipelineInput = {
+  name: 'favoriteDog',
+  type: 'FILE',
+  isRequired: false,
+  fileSuffix: '.vcf.gz',
+};
+
 describe('PipelineFileInput', () => {
+  const defaultProps = {
+    input: mockInput,
+    value: '',
+    onChange: jest.fn(),
+    onValidation: jest.fn(),
+    selectedFile: null,
+    onFileSelect: jest.fn(),
+    validationError: undefined,
+  };
+
   it('renders label and required indicator', () => {
     render(
       <PipelineFileInput
@@ -26,6 +52,16 @@ describe('PipelineFileInput', () => {
     );
     expect(screen.getByText(/Select a multi-sample VCF file/i)).toBeInTheDocument();
     expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('shows required indicator for required inputs', () => {
+    render(<PipelineFileInput {...defaultProps} />);
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('does not show required indicator for optional inputs', () => {
+    render(<PipelineFileInput {...defaultProps} input={optionalInput} />);
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
   });
 
   it('calls onFileSelect when file is selected via input', async () => {

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -40,7 +40,7 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
   setUploadState,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { label, validationRegex } = INPUT_DESCRIPTIONS[input.name];
+  const { label, validationRegex } = INPUT_DESCRIPTIONS[input.name] || {};
 
   const validateFile = (file: File | null) => {
     // Check for required file

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
@@ -11,7 +11,7 @@ jest.mock('src/pages/scientificServices/pipelines/utils/pipeline-input-utils', (
       label: 'Enter a float value',
       placeholder: 'Enter a number',
       helpText: 'Must be a valid floating-point number.',
-      validationRegex: '^(0(\\.\\d*)?|1(\\.0*)?|\\.\\d+)$',
+      validationRegex: String.raw`^(0(\.\d*)?|1(\.0*)?|\.\d+)$`,
     },
   },
 }));

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
@@ -11,7 +11,7 @@ jest.mock('src/pages/scientificServices/pipelines/utils/pipeline-input-utils', (
       label: 'Enter a float value',
       placeholder: 'Enter a number',
       helpText: 'Must be a valid floating-point number.',
-      validationRegex: '^(?:0(?:\\.\\d+)?|1(?:\\.0+)?|\\.\\d+)$',
+      validationRegex: '^(0(\\.\\d+)?|1(\\.0+)?|\\.\\d+)$',
     },
   },
 }));
@@ -82,7 +82,7 @@ describe('PipelineFloatInput', () => {
     const onValidation = jest.fn();
     render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
 
-    const input = screen.getByRole('spinbutton');
+    const input = screen.getByRole('textbox');
     await user.type(input, '.5');
 
     expect(onValidation).toHaveBeenCalledWith(undefined);
@@ -93,10 +93,22 @@ describe('PipelineFloatInput', () => {
     const onValidation = jest.fn();
     render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
 
-    const input = screen.getByRole('spinbutton');
+    const input = screen.getByRole('textbox');
     await user.type(input, '10');
 
     expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+  });
+
+  it('calls onValidation with error for weird floatish input', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, '.');
+    expect(input).toHaveValue(0);
+
+    // expect(onValidation).toHaveBeenCalledWith('Invalid float value');
   });
 
   it('calls onValidation with error for negative float input out of range', async () => {
@@ -104,7 +116,7 @@ describe('PipelineFloatInput', () => {
     const onValidation = jest.fn();
     render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
 
-    const input = screen.getByRole('spinbutton');
+    const input = screen.getByRole('textbox');
     await user.type(input, '-0.1');
 
     expect(onValidation).toHaveBeenCalledWith('Invalid float value');

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
@@ -11,7 +11,7 @@ jest.mock('src/pages/scientificServices/pipelines/utils/pipeline-input-utils', (
       label: 'Enter a float value',
       placeholder: 'Enter a number',
       helpText: 'Must be a valid floating-point number.',
-      validationRegex: '^(0(\\.\\d+)?|1(\\.0+)?|\\.\\d+)$',
+      validationRegex: '^(0(\\.\\d*)?|1(\\.0*)?|\\.\\d+)$',
     },
   },
 }));
@@ -83,6 +83,16 @@ describe('PipelineFloatInput', () => {
     fireEvent.change(input, { target: { value: '.5' } });
 
     expect(defaultProps.onChange).toHaveBeenCalledWith('.5');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onValidation with undefined for valid input ending in .', async () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.' } });
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith('0.');
     expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
   });
 

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
@@ -57,7 +57,7 @@ describe('PipelineFloatInput', () => {
 
   it('renders input placeholder', () => {
     render(<PipelineFloatInput {...defaultProps} />);
-    const input = screen.getByRole('spinbutton');
+    const input = screen.getByRole('textbox');
     expect(input).toHaveAttribute('placeholder', 'Enter a number');
   });
 
@@ -67,59 +67,53 @@ describe('PipelineFloatInput', () => {
   });
 
   it('calls onValidation with undefined for valid float input', async () => {
-    const user = userEvent.setup();
-    const onValidation = jest.fn();
-    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+    render(<PipelineFloatInput {...defaultProps} />);
 
-    const input = screen.getByRole('spinbutton');
-    await user.type(input, '0.5');
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0.5' } });
 
-    expect(onValidation).toHaveBeenCalledWith(undefined);
+    expect(defaultProps.onChange).toHaveBeenCalledWith('0.5');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
   });
 
   it('calls onValidation with undefined for valid float input without starting 0', async () => {
-    const user = userEvent.setup();
-    const onValidation = jest.fn();
-    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+    render(<PipelineFloatInput {...defaultProps} />);
 
     const input = screen.getByRole('textbox');
-    await user.type(input, '.5');
+    fireEvent.change(input, { target: { value: '.5' } });
 
-    expect(onValidation).toHaveBeenCalledWith(undefined);
+    expect(defaultProps.onChange).toHaveBeenCalledWith('.5');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
   });
 
   it('calls onValidation with error for float input out of range', async () => {
-    const user = userEvent.setup();
-    const onValidation = jest.fn();
-    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+    render(<PipelineFloatInput {...defaultProps} />);
 
     const input = screen.getByRole('textbox');
-    await user.type(input, '10');
+    fireEvent.change(input, { target: { value: '10' } });
 
-    expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+    expect(defaultProps.onChange).toHaveBeenCalledWith('10');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith('Invalid float value');
   });
 
-  it('calls onValidation with error for weird floatish input', async () => {
-    const user = userEvent.setup();
-    const onValidation = jest.fn();
-    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+  it('calls onValidation with error for . input', async () => {
+    render(<PipelineFloatInput {...defaultProps} />);
 
     const input = screen.getByRole('textbox');
-    await user.type(input, '.');
-    expect(input).toHaveValue(0);
+    fireEvent.change(input, { target: { value: '.' } });
 
-    // expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+    expect(defaultProps.onChange).toHaveBeenCalledWith('.');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith('Invalid float value');
   });
 
   it('calls onValidation with error for negative float input out of range', async () => {
-    const user = userEvent.setup();
-    const onValidation = jest.fn();
-    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+    render(<PipelineFloatInput {...defaultProps} />);
 
     const input = screen.getByRole('textbox');
-    await user.type(input, '-0.1');
+    fireEvent.change(input, { target: { value: '-0.1' } });
 
-    expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+    expect(defaultProps.onChange).toHaveBeenCalledWith('-0.1');
+    expect(defaultProps.onValidation).toHaveBeenCalledWith('Invalid float value');
   });
 
   it('does not validate empty input', async () => {
@@ -127,7 +121,7 @@ describe('PipelineFloatInput', () => {
     const onValidation = jest.fn();
     render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
 
-    const input = screen.getByRole('spinbutton');
+    const input = screen.getByRole('textbox');
     await user.clear(input);
 
     expect(onValidation).not.toHaveBeenCalled();

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+
+import { PipelineFloatInput } from './PipelineFloatInput';
+
+jest.mock('src/pages/scientificServices/pipelines/utils/pipeline-input-utils', () => ({
+  INPUT_DESCRIPTIONS: {
+    floatInput: {
+      label: 'Enter a float value',
+      placeholder: 'Enter a number',
+      helpText: 'Must be a valid floating-point number.',
+      validationRegex: '^(?:0(?:\\.\\d+)?|1(?:\\.0+)?|\\.\\d+)$',
+    },
+  },
+}));
+
+const mockInput: PipelineInput = {
+  name: 'floatInput',
+  type: 'FLOAT',
+  isRequired: true,
+};
+
+const optionalInput: PipelineInput = {
+  name: 'optionalFloatInput',
+  type: 'FLOAT',
+  isRequired: false,
+};
+
+describe('PipelineFloatInput', () => {
+  const defaultProps = {
+    input: mockInput,
+    value: '',
+    onChange: jest.fn(),
+    onValidation: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders input label', () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+    expect(screen.getByText('Enter a float value')).toBeInTheDocument();
+  });
+
+  it('shows required indicator for required inputs', () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('does not show required indicator for optional inputs', () => {
+    render(<PipelineFloatInput {...defaultProps} input={optionalInput} />);
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+
+  it('renders input placeholder', () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveAttribute('placeholder', 'Enter a number');
+  });
+
+  it('renders help text', () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+    expect(screen.getByText('Must be a valid floating-point number.')).toBeInTheDocument();
+  });
+
+  it('calls onValidation with undefined for valid float input', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '0.5');
+
+    expect(onValidation).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onValidation with undefined for valid float input without starting 0', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '.5');
+
+    expect(onValidation).toHaveBeenCalledWith(undefined);
+  });
+
+  it('calls onValidation with error for float input out of range', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '10');
+
+    expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+  });
+
+  it('calls onValidation with error for negative float input out of range', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.type(input, '-0.1');
+
+    expect(onValidation).toHaveBeenCalledWith('Invalid float value');
+  });
+
+  it('does not validate empty input', async () => {
+    const user = userEvent.setup();
+    const onValidation = jest.fn();
+    render(<PipelineFloatInput {...defaultProps} onValidation={onValidation} />);
+
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+
+    expect(onValidation).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NumberInput } from 'src/components/input';
+import { ValidatedInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/pipeline-input-utils';
 
@@ -26,11 +26,13 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
         {label || input.name} {input.isRequired ? <span style={{ color: '#DB3214' }}> *</span> : null}
       </h3>
       <div style={{ width: 400 }}>
-        <NumberInput
+        <ValidatedInput
           value={value || ''}
           placeholder={placeholder || ''}
           aria-label={`${input.name} float input`}
           onChange={(e) => {
+            // eslint-disable-next-line no-console
+            console.log(e);
             onChange(e);
             if (validationRegex) {
               const regex = new RegExp(validationRegex);

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -25,27 +25,27 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
       <h3 style={{ marginBottom: '0.5rem' }}>
         {label || input.name} {input.isRequired ? <span style={{ color: '#DB3214' }}> *</span> : null}
       </h3>
-      <div style={{ width: 400 }}>
-        <ValidatedInput
-          value={value || ''}
-          placeholder={placeholder || ''}
-          aria-label={`${input.name} float input`}
-          onChange={(e) => {
-            // eslint-disable-next-line no-console
-            console.log(e);
+      <ValidatedInput
+        width={400}
+        error={validationError}
+        inputProps={{
+          'aria-label': `${input.name} float input`,
+          type: 'text',
+          value: value || '',
+          placeholder: placeholder || '',
+          onChange: (e) => {
             onChange(e);
             if (validationRegex) {
               const regex = new RegExp(validationRegex);
-              if (!regex.test(e) && e !== null) {
+              if (!regex.test(e.trim()) && e.length > 0) {
                 onValidation('Invalid float value');
               } else {
                 onValidation(undefined);
               }
             }
-          }}
-        />
-      </div>
-      {validationError && <div style={{ color: 'red', marginTop: '0.5rem' }}>{validationError}</div>}
+          },
+        }}
+      />
       {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic' }}>{helpText}</div>}
     </>
   );

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -46,7 +46,9 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
           },
         }}
       />
-      {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic', maxWidth: 500 }}>{helpText}</div>}
+      {helpText && (
+        <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic', maxWidth: 500 }}>{helpText}</div>
+      )}
     </>
   );
 };

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ValidatedInput } from 'src/components/input';
+import { NumberInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/pipeline-input-utils';
 
-interface PipelineStringInputProps {
+interface PipelineFloatInputProps {
   input: PipelineInput;
   value: string;
   onChange: (value: string) => void;
@@ -11,7 +11,7 @@ interface PipelineStringInputProps {
   onValidation(error?: string): void;
 }
 
-export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
+export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
   input,
   value,
   onChange,
@@ -25,27 +25,25 @@ export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
       <h3 style={{ marginBottom: '0.5rem' }}>
         {label || input.name} {input.isRequired ? <span style={{ color: '#DB3214' }}> *</span> : null}
       </h3>
-      <ValidatedInput
-        width={400}
-        error={validationError}
-        inputProps={{
-          'aria-label': `${input.name} text input`,
-          type: 'text',
-          value: value || '',
-          placeholder: placeholder || '',
-          onChange: (e) => {
+      <div style={{ width: 400 }}>
+        <NumberInput
+          value={value || ''}
+          placeholder={placeholder || ''}
+          aria-label={`${input.name} float input`}
+          onChange={(e) => {
             onChange(e);
             if (validationRegex) {
               const regex = new RegExp(validationRegex);
-              if (!regex.test(e.trim()) && e.length > 0) {
-                onValidation('This input contains invalid characters');
+              if (!regex.test(e) && e !== null) {
+                onValidation('Invalid float value');
               } else {
                 onValidation(undefined);
               }
             }
-          },
-        }}
-      />
+          }}
+        />
+      </div>
+      {validationError && <div style={{ color: 'red', marginTop: '0.5rem' }}>{validationError}</div>}
       {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic' }}>{helpText}</div>}
     </>
   );

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -46,7 +46,7 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
           },
         }}
       />
-      {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic' }}>{helpText}</div>}
+      {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic', maxWidth: 500 }}>{helpText}</div>}
     </>
   );
 };

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineRunDescription.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineRunDescription.tsx
@@ -9,9 +9,7 @@ interface PipelineRunDescriptionProps {
 export const PipelineRunDescription: React.FC<PipelineRunDescriptionProps> = ({ value, onChange }) => {
   return (
     <>
-      <h3 style={{ marginBottom: '0.5rem' }}>
-        Enter description <span style={{ fontStyle: 'italic', fontWeight: 'normal' }}> - optional</span>
-      </h3>
+      <h3 style={{ marginBottom: '0.5rem' }}>Enter description</h3>
       <TextArea
         rows={4}
         aria-label='description'

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
@@ -70,25 +70,23 @@ describe('PipelineStringInput', () => {
     });
 
     it('calls onValidation with undefined for valid input', async () => {
-      const user = userEvent.setup();
-      const onValidation = jest.fn();
-      render(<PipelineStringInput {...defaultProps} onValidation={onValidation} />);
+      render(<PipelineStringInput {...defaultProps} />);
 
       const input = screen.getByRole('textbox');
-      await user.type(input, 'valid_input-123');
+      fireEvent.change(input, { target: { value: 'valid_input-123' } });
 
-      expect(onValidation).toHaveBeenCalledWith(undefined);
+      expect(defaultProps.onChange).toHaveBeenCalledWith('valid_input-123');
+      expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
     });
 
     it('calls onValidation with error for invalid input', async () => {
-      const user = userEvent.setup();
-      const onValidation = jest.fn();
-      render(<PipelineStringInput {...defaultProps} onValidation={onValidation} />);
+      render(<PipelineStringInput {...defaultProps} />);
 
       const input = screen.getByRole('textbox');
-      await user.type(input, 'invalid input with spaces');
+      fireEvent.change(input, { target: { value: 'invalid input with spaces' } });
 
-      expect(onValidation).toHaveBeenCalledWith('This input contains invalid characters');
+      expect(defaultProps.onChange).toHaveBeenCalledWith('invalid input with spaces');
+      expect(defaultProps.onValidation).toHaveBeenCalledWith('This input contains invalid characters');
     });
 
     it('does not validate empty input', async () => {
@@ -103,27 +101,25 @@ describe('PipelineStringInput', () => {
     });
 
     it('does not perform validation when no validationRegex is provided', async () => {
-      const user = userEvent.setup();
       const onValidation = jest.fn();
       const inputWithoutValidation = { ...mockInput, name: 'noValidationInput' };
 
       render(<PipelineStringInput {...defaultProps} input={inputWithoutValidation} onValidation={onValidation} />);
 
       const input = screen.getByRole('textbox');
-      await user.type(input, 'you can type anything here! 123 @#$ !!!!');
+      fireEvent.change(input, { target: { value: 'type whatever you want! go nuts! $%^&#*(@' } });
 
-      expect(onValidation).not.toHaveBeenCalled();
+      expect(defaultProps.onValidation).not.toHaveBeenCalled();
     });
 
     it('trims input value before validation', async () => {
-      const user = userEvent.setup();
-      const onValidation = jest.fn();
-      render(<PipelineStringInput {...defaultProps} onValidation={onValidation} />);
+      render(<PipelineStringInput {...defaultProps} />);
 
       const input = screen.getByRole('textbox');
-      await user.type(input, ' validInput ');
+      fireEvent.change(input, { target: { value: ' validInput ' } });
 
-      expect(onValidation).toHaveBeenCalledWith(undefined);
+      expect(defaultProps.onChange).toHaveBeenCalledWith(' validInput ');
+      expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.tsx
@@ -46,7 +46,9 @@ export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
           },
         }}
       />
-      {helpText && <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic' }}>{helpText}</div>}
+      {helpText && (
+        <div style={{ marginTop: '0.5rem', marginBottom: '2rem', fontStyle: 'italic', maxWidth: 500 }}>{helpText}</div>
+      )}
     </>
   );
 };

--- a/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
@@ -26,6 +26,6 @@ export const INPUT_DESCRIPTIONS: Record<string, PipelineInputDescription> = {
     placeholder: '0.0',
     helpText:
       'The minimum imputation quality (DR2) for inclusion in output VCF. Value must be between 0 and 1 (inclusive). Default is 0.0',
-    validationRegex: '^(0(\\.\\d+)?|1(\\.0+)?|\\.\\d+)$',
+    validationRegex: '^(0(\\.\\d*)?|1(\\.0*)?|\\.\\d+)$',
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
@@ -21,4 +21,11 @@ export const INPUT_DESCRIPTIONS: Record<string, PipelineInputDescription> = {
     label: 'Select a multi-sample VCF file',
     validationRegex: '^[a-zA-Z0-9_.-]+$',
   },
+  minDr2ForInclusion: {
+    label: 'Enter a minimum imputation quality for inclusion',
+    placeholder: '0.0',
+    helpText:
+      'The minimum imputation quality (DR2) for inclusion in output VCF. Value must be between 0 and 1 (inclusive). Default is 0.0',
+    validationRegex: '^(?:0(?:\\.\\d+)?|1(?:\\.0+)?|\\.\\d+)$',
+  },
 };

--- a/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
@@ -26,6 +26,6 @@ export const INPUT_DESCRIPTIONS: Record<string, PipelineInputDescription> = {
     placeholder: '0.0',
     helpText:
       'The minimum imputation quality (DR2) for inclusion in output VCF. Value must be between 0 and 1 (inclusive). Default is 0.0',
-    validationRegex: '^(0(\\.\\d*)?|1(\\.0*)?|\\.\\d+)$',
+    validationRegex: String.raw`^(0(\.\d*)?|1(\.0*)?|\.\d+)$`,
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-input-utils.ts
@@ -26,6 +26,6 @@ export const INPUT_DESCRIPTIONS: Record<string, PipelineInputDescription> = {
     placeholder: '0.0',
     helpText:
       'The minimum imputation quality (DR2) for inclusion in output VCF. Value must be between 0 and 1 (inclusive). Default is 0.0',
-    validationRegex: '^(?:0(?:\\.\\d+)?|1(?:\\.0+)?|\\.\\d+)$',
+    validationRegex: '^(0(\\.\\d+)?|1(\\.0+)?|\\.\\d+)$',
   },
 };

--- a/src/pages/scientificServices/pipelines/utils/submission-utils.test.ts
+++ b/src/pages/scientificServices/pipelines/utils/submission-utils.test.ts
@@ -34,11 +34,11 @@ describe('submission-utils', () => {
       });
     });
 
-    it('trims input strings and handles file inputs correctly when preparing inputs', async () => {
+    it('handles file and float inputs correctly when preparing inputs', async () => {
       const useInputs = {
         stringInput: 'testValue',
         fileInput: new File(['super cool test vcf!!!'], 'test.vcf.gz'),
-        anotherStringInput: '  thisInputShouldBeTrimmedBeforeSendingToTheBackend  ',
+        floatInput: 23.5,
       };
 
       const result = await preparePipelineRun('array_imputation', 1, useInputs, 'Test description');
@@ -51,7 +51,7 @@ describe('submission-utils', () => {
         {
           stringInput: 'testValue',
           fileInput: 'test.vcf.gz',
-          anotherStringInput: 'thisInputShouldBeTrimmedBeforeSendingToTheBackend',
+          floatInput: 23.5,
         },
         'Test description'
       );

--- a/src/pages/scientificServices/pipelines/utils/submission-utils.test.ts
+++ b/src/pages/scientificServices/pipelines/utils/submission-utils.test.ts
@@ -34,11 +34,12 @@ describe('submission-utils', () => {
       });
     });
 
-    it('handles file and float inputs correctly when preparing inputs', async () => {
+    it('trims input strings and handles file and float inputs correctly when preparing inputs', async () => {
       const useInputs = {
         stringInput: 'testValue',
         fileInput: new File(['super cool test vcf!!!'], 'test.vcf.gz'),
-        floatInput: 23.5,
+        anotherStringInput: ' thisInputShouldBeTrimmedBeforeSendingToTheBackend ',
+        floatInput: '23.5',
       };
 
       const result = await preparePipelineRun('array_imputation', 1, useInputs, 'Test description');
@@ -51,7 +52,8 @@ describe('submission-utils', () => {
         {
           stringInput: 'testValue',
           fileInput: 'test.vcf.gz',
-          floatInput: 23.5,
+          anotherStringInput: 'thisInputShouldBeTrimmedBeforeSendingToTheBackend',
+          floatInput: '23.5',
         },
         'Test description'
       );

--- a/src/pages/scientificServices/pipelines/utils/submission-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/submission-utils.ts
@@ -17,7 +17,7 @@ export async function preparePipelineRun(
   const jobId = crypto.randomUUID();
 
   const finalUserInputs = Object.entries(selectedUserInputs).reduce((acc, [key, value]) => {
-    acc[key] = value instanceof File ? value.name : value;
+    acc[key] = value instanceof File ? value.name : value.trim();
     return acc;
   }, {} as Record<string, any>);
 

--- a/src/pages/scientificServices/pipelines/utils/submission-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/submission-utils.ts
@@ -17,7 +17,7 @@ export async function preparePipelineRun(
   const jobId = crypto.randomUUID();
 
   const finalUserInputs = Object.entries(selectedUserInputs).reduce((acc, [key, value]) => {
-    acc[key] = value instanceof File ? value.name : value.trim();
+    acc[key] = value instanceof File ? value.name : value;
     return acc;
   }, {} as Record<string, any>);
 

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -186,7 +186,7 @@ describe('RunJob Component', () => {
     const minDr2Input = screen.getByLabelText('minDr2ForInclusion float input');
     await user.type(minDr2Input, '0.3');
 
-    expect(minDr2Input).toHaveValue(0.3);
+    expect(minDr2Input).toHaveValue('0.3');
 
     // Enter description
     const descriptionTextArea = screen.getByLabelText('description');

--- a/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.test.tsx
@@ -76,6 +76,11 @@ describe('RunJob Component', () => {
       type: 'STRING',
       isRequired: false,
     },
+    {
+      name: 'minDr2ForInclusion',
+      type: 'FLOAT',
+      isRequired: false,
+    },
   ];
 
   const mockPipelineDetails: PipelineWithDetails = {
@@ -126,6 +131,7 @@ describe('RunJob Component', () => {
     // Check for main headings and form elements
     expect(screen.getByText('Select a pipeline version')).toBeInTheDocument();
     expect(screen.getByText('Enter prefix for output file')).toBeInTheDocument();
+    expect(screen.getByText('Enter a minimum imputation quality for inclusion')).toBeInTheDocument();
     expect(screen.getByText(/Enter description/)).toBeInTheDocument();
     expect(screen.getByText('Select a multi-sample VCF file')).toBeInTheDocument();
 
@@ -175,6 +181,12 @@ describe('RunJob Component', () => {
     await user.type(outputPrefixInput, 'test_output');
 
     expect(outputPrefixInput).toHaveValue('test_output');
+
+    // Enter minDr2ForInclusion
+    const minDr2Input = screen.getByLabelText('minDr2ForInclusion float input');
+    await user.type(minDr2Input, '0.3');
+
+    expect(minDr2Input).toHaveValue(0.3);
 
     // Enter description
     const descriptionTextArea = screen.getByLabelText('description');

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -19,6 +19,7 @@ import {
   PipelineFileInput,
   PipelineInputFileUploadState,
 } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput';
+import { PipelineFloatInput } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput';
 import { PipelineRunDescription } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineRunDescription';
 import { PipelineStringInput } from 'src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput';
 import { useUserQuota } from 'src/pages/scientificServices/pipelines/hooks/useUserQuota';
@@ -236,6 +237,27 @@ export const RunJob = () => {
                 .map((input) => {
                   return (
                     <PipelineStringInput
+                      input={input}
+                      onChange={(value) =>
+                        setSelectedUserInputs((prev) => ({
+                          ...prev,
+                          [input.name]: value,
+                        }))
+                      }
+                      onValidation={(error) => handleInputValidation(input.name, error)}
+                      validationError={validationErrors[input.name]}
+                      value={selectedUserInputs[input.name]}
+                      key={`${input.name}`}
+                    />
+                  );
+                })}
+
+              {/* Displays all FLOAT inputs, one after another */}
+              {pipelineInputs
+                .filter((input) => input.type === 'FLOAT')
+                .map((input) => {
+                  return (
+                    <PipelineFloatInput
                       input={input}
                       onChange={(value) =>
                         setSelectedUserInputs((prev) => ({


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-642, https://broadworkbench.atlassian.net/browse/TSPS-646

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:

### What
- add FLOAT type of PipelineInput
- add `minDr2ForInclusion` FLOAT input for array imputation with validation - must be 0-1
<img width="573" height="129" alt="image" src="https://github.com/user-attachments/assets/ce4a56ba-14fe-43e8-9ab1-87bebc0f21af" />
<img width="520" height="139" alt="image" src="https://github.com/user-attachments/assets/78c2460b-8461-4844-9bb3-8065f5e398db" />
<img width="484" height="136" alt="image" src="https://github.com/user-attachments/assets/55885409-6a4d-41f4-b251-9954aa1ab2c4" />
<img width="517" height="144" alt="image" src="https://github.com/user-attachments/assets/81b7ea34-a974-4c5b-971f-e2efb59492d5" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
