### PR TITLE
[DC-1781] Move notifications from data team channel to tdr channel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 /src/billing/ @DataBiosphere/broad-core-services
 /src/groups/ @DataBiosphere/broad-core-services
 /src/pages/EnvironmentsPage/ @DataBiosphere/dsp-analysis
-/src/constants/datasets.js @DataBiosphere/dsp-data-team-eng
-/src/import-data/ @DataBiosphere/dsp-data-team-eng @DataBiosphere/broad-core-services
+/src/constants/datasets.js @DataBiosphere/jadeteam
+/src/import-data/ @DataBiosphere/jadeteam @DataBiosphere/broad-core-services
 /src/libs/brand*.js @DataBiosphere/terra-cobranding
 /src/libs/colors.js @DataBiosphere/terra-cobranding
 /src/libs/ajax/Apps.ts @DataBiosphere/dsp-analysis
@@ -17,9 +17,9 @@
 /src/libs/ajax/Groups.ts @DataBiosphere/broad-core-services
 /src/libs/ajax/workflows-app/ @DataBiosphere/dsp-analysis
 /src/libs/ajax/workspaces/ @DataBiosphere/broad-core-services
-/src/pages/library/Datasets* @DataBiosphere/dsp-data-team-eng
-/src/pages/library/SearchAndFilterComponent* @DataBiosphere/dsp-data-team-eng
-/src/dataset-builder/ @DataBiosphere/dsp-data-team-eng
+/src/pages/library/Datasets* @DataBiosphere/jadeteam
+/src/pages/library/SearchAndFilterComponent* @DataBiosphere/jadeteam
+/src/dataset-builder/ @DataBiosphere/jadeteam
 /src/pages/LandingPage* @DataBiosphere/terra-cobranding
 /src/pages/billing/ @DataBiosphere/broad-core-services
 /src/pages/groups/ @DataBiosphere/broad-core-services

--- a/integration-tests/slack/slack-notify-channels.json
+++ b/integration-tests/slack/slack-notify-channels.json
@@ -38,8 +38,8 @@
       ]
     },
     {
-      "name": "dsp-data-team",
-      "id": "C07T2DLHD24",
+      "name": "dsp-tdr",
+      "id": "CD4HBRFMG",
       "tests": [
         {
           "name": "preview-drs-uri"


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/DC-1781

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- update codeowners from data team to tdr team (jade) 
- move slack notifications from the data team channel to the tdr channel

### Why
- change in ownership to be reflected by notifications and codeowners

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
