### PR TITLE
[TSPS-309] Enforce a max file upload size for Teaspoons file inputs

### DIFF
--- a/src/pages/scientificServices/pipelines/common/teaspoons-service-constants.tsx
+++ b/src/pages/scientificServices/pipelines/common/teaspoons-service-constants.tsx
@@ -1,0 +1,9 @@
+// This file contains constants related to the Teaspoons service.
+// Ideally, these would be fetched from the backend, but for now they are hardcoded here
+// until we've decided on a good way to expose them via the API.
+
+/* the maximum file input upload size, in bytes */
+export const TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES = 50 * 1024 * 1024 * 1024; // 50 GiB
+
+/* the default TTL for file outputs in days */
+export const TEASPOONS_FILE_OUTPUT_TTL_DAYS = 14;

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES } from 'src/pages/scientificServices/pipelines/common/teaspoons-service-constants';
 import { renderWithAppContexts } from 'src/testing/test-utils';
 
 import { PipelineFileInput, PipelineInputFileUploadState } from './PipelineFileInput';
@@ -230,14 +231,18 @@ describe('PipelineFileInput', () => {
 
       const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
 
-      // Upload a file larger than the 50 GiB limit
+      // Upload a file larger than the size limit
       const fileLargerThanMax = new File(['test'], 'test.vcf.gz');
-      Object.defineProperty(fileLargerThanMax, 'size', { value: 51 * 1024 * 1024 * 1024, writable: false }); // 51 GiB
+      Object.defineProperty(fileLargerThanMax, 'size', {
+        value: TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES * 2,
+      }); // double the max size
 
       await userEvent.upload(fileInput, fileLargerThanMax);
 
       expect(onFileSelect).toHaveBeenCalledWith(fileLargerThanMax);
-      expect(onValidation).toHaveBeenCalledWith('File size exceeds the 50.0 GiB limit. Please upload a smaller file.');
+      expect(onValidation).toHaveBeenCalledWith(
+        expect.stringMatching(/^File size exceeds the .+ limit\. Please upload a smaller file\.$/)
+      );
     });
 
     it('does not display a validation error when the input file is within the maximum file size limit', async () => {
@@ -256,9 +261,11 @@ describe('PipelineFileInput', () => {
 
       const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
 
-      // Upload a file smaller than the 50 GiB limit
+      // Upload a file smaller than the size limit
       const fileWithinMax = new File(['test'], 'test.vcf.gz');
-      Object.defineProperty(fileWithinMax, 'size', { value: 10 * 1024 * 1024 * 1024, writable: false }); // 10 GiB
+      Object.defineProperty(fileWithinMax, 'size', {
+        value: TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES / 2,
+      }); // half the max size
 
       await userEvent.upload(fileInput, fileWithinMax);
 

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -77,13 +77,13 @@ describe('PipelineFileInput', () => {
     );
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     expect(fileInput).toBeInTheDocument();
-    const file = new File(['test'], 'test.vcf.gz', { type: 'text/plain' });
+    const file = new File(['test'], 'test.vcf.gz');
     await waitFor(() => userEvent.upload(fileInput, file));
     expect(onFileSelect).toHaveBeenCalledWith(file);
   });
 
   it('shows valid file icon and info for valid file', () => {
-    const file = new File(['test'], 'test.vcf.gz', { type: 'text/plain' });
+    const file = new File(['test'], 'test.vcf.gz');
     render(
       <PipelineFileInput
         input={mockInput}
@@ -99,7 +99,7 @@ describe('PipelineFileInput', () => {
   });
 
   it('shows invalid file icon and error for files with validation errors', () => {
-    const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+    const file = new File(['test'], 'test.txt');
     render(
       <PipelineFileInput
         input={mockInput}
@@ -114,7 +114,7 @@ describe('PipelineFileInput', () => {
   });
 
   it('clears file when clear button is clicked', () => {
-    const file = new File(['test'], 'test.vcf.gz', { type: 'text/plain' });
+    const file = new File(['test'], 'test.vcf.gz');
     const onFileSelect = jest.fn();
     render(
       <PipelineFileInput
@@ -211,5 +211,183 @@ describe('PipelineFileInput', () => {
 
     expect(screen.getByText(/There was an error uploading/)).toBeInTheDocument();
     expect(screen.getByText(/Retry/)).toBeInTheDocument();
+  });
+
+  describe('validateFile', () => {
+    it('displays a validation error when the input file exceeds the maximum file size limit', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      // Upload a file larger than the 50 GiB limit
+      const fileLargerThanMax = new File(['test'], 'test.vcf.gz');
+      Object.defineProperty(fileLargerThanMax, 'size', { value: 51 * 1024 * 1024 * 1024, writable: false }); // 51 GiB
+
+      await userEvent.upload(fileInput, fileLargerThanMax);
+
+      expect(onFileSelect).toHaveBeenCalledWith(fileLargerThanMax);
+      expect(onValidation).toHaveBeenCalledWith('File size exceeds the 50.0 GiB limit. Please upload a smaller file.');
+    });
+
+    it('does not display a validation error when the input file is within the maximum file size limit', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      // Upload a file smaller than the 50 GiB limit
+      const fileWithinMax = new File(['test'], 'test.vcf.gz');
+      Object.defineProperty(fileWithinMax, 'size', { value: 10 * 1024 * 1024 * 1024, writable: false }); // 10 GiB
+
+      await userEvent.upload(fileInput, fileWithinMax);
+
+      expect(onFileSelect).toHaveBeenCalledWith(fileWithinMax);
+      expect(onValidation).toHaveBeenCalledWith(undefined);
+    });
+
+    it('displays a validation error when the input file suffix is incorrect', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const wrongSuffixFile = new File(['test'], 'test.txt');
+
+      await userEvent.upload(fileInput, wrongSuffixFile);
+
+      expect(onValidation).toHaveBeenCalledWith(`Invalid file type. Please upload a ${mockInput.fileSuffix} file.`);
+    });
+
+    it('does not display a validation error when the input file suffix is correct', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const correctSuffixFile = new File(['test'], 'test.vcf.gz');
+
+      await userEvent.upload(fileInput, correctSuffixFile);
+
+      expect(onFileSelect).toHaveBeenCalledWith(correctSuffixFile);
+      expect(onValidation).toHaveBeenCalledWith(undefined);
+    });
+
+    it('displays a validation error when the input file name does not pass validation', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const invalidNameFile = new File(['test'], 'really bad file name !#$.vcf.gz');
+
+      await userEvent.upload(fileInput, invalidNameFile);
+
+      expect(onFileSelect).toHaveBeenCalledWith(invalidNameFile);
+      expect(onValidation).toHaveBeenCalledWith(
+        'File names may only contain alphanumeric characters, dashes, underscores, and periods.'
+      );
+    });
+
+    it('does not display a validation error when the input file name passes validation', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const validFile = new File(['test'], 'valid_file-name.123.vcf.gz');
+
+      await userEvent.upload(fileInput, validFile);
+
+      expect(onFileSelect).toHaveBeenCalledWith(validFile);
+      expect(onValidation).toHaveBeenCalledWith(undefined);
+    });
+
+    it('clears existing validation error when a new valid file is selected', async () => {
+      const onValidation = jest.fn();
+      const onFileSelect = jest.fn();
+
+      render(
+        <PipelineFileInput
+          input={mockInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={onValidation}
+        />
+      );
+
+      // First upload an invalid file to trigger a validation error
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const invalidFile = new File(['test'], 'test.txt');
+
+      await userEvent.upload(fileInput, invalidFile);
+
+      expect(onValidation).toHaveBeenCalledWith(`Invalid file type. Please upload a ${mockInput.fileSuffix} file.`);
+      expect(onFileSelect).toHaveBeenCalledWith(invalidFile);
+
+      // Now upload a valid file
+      const validFile = new File(['test'], 'valid_file.vcf.gz');
+
+      await userEvent.upload(fileInput, validFile);
+      expect(onValidation).toHaveBeenCalledWith(undefined);
+      expect(onFileSelect).toHaveBeenCalledWith(validFile);
+    });
   });
 });

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.test.tsx
@@ -240,9 +240,9 @@ describe('PipelineFileInput', () => {
       await userEvent.upload(fileInput, fileLargerThanMax);
 
       expect(onFileSelect).toHaveBeenCalledWith(fileLargerThanMax);
-      expect(onValidation).toHaveBeenCalledWith(
-        expect.stringMatching(/^File size exceeds the .+ limit\. Please upload a smaller file\.$/)
-      );
+      // Here we're just asserting that the onValidation callback was called with some error
+      // message because it's a ReactNode and those are hard to assert against directly
+      expect(onValidation).toHaveBeenCalledWith(expect.any(Object));
     });
 
     it('does not display a validation error when the input file is within the maximum file size limit', async () => {

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -72,7 +72,7 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
       return;
     }
 
-    // If all validations pass, clear any existing error
+    // All validations have passed
     onValidation(undefined);
   };
 

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -5,6 +5,7 @@ import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import { notify } from 'src/libs/notifications';
 import { formatBytes } from 'src/libs/utils';
+import { TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES } from 'src/pages/scientificServices/pipelines/common/teaspoons-service-constants';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/pipeline-input-utils';
 import {
   resumeUpload,
@@ -42,8 +43,6 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { label, validationRegex } = INPUT_DESCRIPTIONS[input.name] || {};
 
-  const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024 * 1024; // 50 GiB
-
   const validateFile = (file: File | null) => {
     // Check if a file is selected, if required
     if (!file) {
@@ -52,8 +51,12 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
     }
 
     // Validate file size
-    if (file.size > MAX_FILE_SIZE_BYTES) {
-      onValidation(`File size exceeds the ${formatBytes(MAX_FILE_SIZE_BYTES)} limit. Please upload a smaller file.`);
+    if (file.size > TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES) {
+      onValidation(
+        `File size exceeds the ${formatBytes(
+          TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES
+        )} limit. Please upload a smaller file.`
+      );
       return;
     }
 

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -1,5 +1,5 @@
 import { ButtonPrimary, Icon } from '@terra-ui-packages/components';
-import React, { Dispatch, SetStateAction, useRef } from 'react';
+import React, { Dispatch, ReactNode, SetStateAction, useRef } from 'react';
 import Dropzone from 'src/components/Dropzone';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
@@ -24,8 +24,8 @@ interface PipelineInputSelectorProps {
   selectedFile: File | null;
   uploadState?: PipelineInputFileUploadState;
   onFileSelect: (file: File | null) => void;
-  onValidation(error?: string): void;
-  validationError?: string;
+  onValidation(error?: ReactNode): void;
+  validationError?: ReactNode;
   onUploadComplete?: () => void;
   setUploadState?: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>;
 }
@@ -53,9 +53,23 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
     // Validate file size
     if (file.size > TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES) {
       onValidation(
-        `File size exceeds the ${formatBytes(
-          TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES
-        )} limit. Please upload a smaller file.`
+        <>
+          <span>
+            File size exceeds the {formatBytes(TEASPOONS_MAX_FILE_UPLOAD_SIZE_BYTES)} limit. Please upload a smaller
+            file.{' '}
+          </span>
+          <div style={{ marginTop: '0.5rem' }}>
+            <Icon icon='info-circle' size={16} style={{ color: colors.primary(), verticalAlign: 'middle' }} />{' '}
+            <a
+              href='https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859'
+              target='_blank'
+              style={{ color: '#46A3E9', textDecoration: 'underline' }}
+              rel='noreferrer'
+            >
+              Learn more about how to reduce your file size.
+            </a>
+          </div>
+        </>
       );
       return;
     }

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFileInput.tsx
@@ -42,31 +42,35 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { label, validationRegex } = INPUT_DESCRIPTIONS[input.name] || {};
 
+  const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024 * 1024; // 50 GiB
+
   const validateFile = (file: File | null) => {
-    // Check for required file
-    if (input.isRequired && !file) {
-      onValidation('This file is required.');
+    // Check if a file is selected, if required
+    if (!file) {
+      onValidation(input.isRequired ? 'This file is required.' : undefined);
       return;
     }
 
-    // Check for valid file type
-    // N.B. this suffix is supplied separately by the backend, which is why it's not included in the validationRegex
-    if (file && input.fileSuffix && !file.name.endsWith(input.fileSuffix)) {
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      onValidation(`File size exceeds the ${formatBytes(MAX_FILE_SIZE_BYTES)} limit. Please upload a smaller file.`);
+      return;
+    }
+
+    // Validate file type based on suffix
+    if (input.fileSuffix && !file.name.endsWith(input.fileSuffix)) {
       onValidation(`Invalid file type. Please upload a ${input.fileSuffix} file.`);
       return;
     }
 
-    // Check for valid file name using validation expression
-    if (file && validationRegex) {
-      const regex = new RegExp(validationRegex);
-      if (regex.test(file.name)) {
-        onValidation(undefined);
-      } else {
-        onValidation('File names may only contain alphanumeric characters, dashes, underscores, and periods.');
-      }
-    } else if (!input.isRequired) {
-      onValidation(undefined);
+    // Validate file name against regex
+    if (validationRegex && !new RegExp(validationRegex).test(file.name)) {
+      onValidation('File names may only contain alphanumeric characters, dashes, underscores, and periods.');
+      return;
     }
+
+    // If all validations pass, clear any existing error
+    onValidation(undefined);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineFloatInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ValidatedInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/pipeline-input-utils';
@@ -7,8 +7,8 @@ interface PipelineFloatInputProps {
   input: PipelineInput;
   value: string;
   onChange: (value: string) => void;
-  validationError?: string;
-  onValidation(error?: string): void;
+  validationError?: ReactNode;
+  onValidation(error?: ReactNode): void;
 }
 
 export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({

--- a/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.tsx
+++ b/src/pages/scientificServices/pipelines/components/inputs/PipelineStringInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ValidatedInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { INPUT_DESCRIPTIONS } from 'src/pages/scientificServices/pipelines/utils/pipeline-input-utils';
@@ -7,8 +7,8 @@ interface PipelineStringInputProps {
   input: PipelineInput;
   value: string;
   onChange: (value: string) => void;
-  validationError?: string;
-  onValidation(error?: string): void;
+  validationError?: ReactNode;
+  onValidation(error?: ReactNode): void;
 }
 
 export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -16,6 +16,7 @@ import {
   pipelinesTopBar,
   SCIENTIFIC_SERVICES_SUPPORT_EMAIL,
 } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { TEASPOONS_FILE_OUTPUT_TTL_DAYS } from 'src/pages/scientificServices/pipelines/common/teaspoons-service-constants';
 import { ViewErrorModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewErrorModal';
 import { ViewOutputsModal } from 'src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal';
 
@@ -288,7 +289,7 @@ const DataDeletionDateCell = ({ pipelineRun }: CellProps): ReactNode => {
 
   const completionDate = new Date(pipelineRun?.timeCompleted);
   const deletionDate = new Date(completionDate);
-  deletionDate.setDate(deletionDate.getDate() + 14);
+  deletionDate.setDate(deletionDate.getDate() + TEASPOONS_FILE_OUTPUT_TTL_DAYS);
 
   const today = new Date();
   const threeDaysFromNow = new Date();
@@ -338,7 +339,8 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
   });
 
   const jobOutputsDeleted =
-    pipelineRun.status === 'SUCCEEDED' && (hoursElapsedSinceCompletion(pipelineRun) ?? -1) > 24 * 14; // 24 hours * 14 days
+    pipelineRun.status === 'SUCCEEDED' &&
+    (hoursElapsedSinceCompletion(pipelineRun) ?? -1) > 24 * TEASPOONS_FILE_OUTPUT_TTL_DAYS; // 24 hours * 14 days
 
   return (
     <div>

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -80,8 +80,8 @@ export const JobHistory = () => {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
           <h3>Job History</h3>
           <div style={{ marginBottom: '0.25rem' }}>
-            All files associated with jobs will be automatically deleted after {TEASPOONS_FILE_OUTPUT_TTL_DAYS / 7}{' '}
-            weeks from completion.
+            All files associated with jobs will be automatically deleted after {TEASPOONS_FILE_OUTPUT_TTL_DAYS} days
+            from completion.
           </div>
           <div>
             For support, email{' '}
@@ -350,9 +350,7 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
           <TooltipTrigger
             content={
               jobOutputsDeleted
-                ? `The outputs for this job have been deleted. Outputs are available for ${
-                    TEASPOONS_FILE_OUTPUT_TTL_DAYS / 7
-                  } weeks after job completion.`
+                ? `The outputs for this job have been deleted. Outputs are available for ${TEASPOONS_FILE_OUTPUT_TTL_DAYS} days after job completion.`
                 : undefined
             }
             side='top'

--- a/src/pages/scientificServices/pipelines/views/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/views/JobHistory.tsx
@@ -80,7 +80,8 @@ export const JobHistory = () => {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
           <h3>Job History</h3>
           <div style={{ marginBottom: '0.25rem' }}>
-            All files associated with jobs will be automatically deleted after 2 weeks from completion.
+            All files associated with jobs will be automatically deleted after {TEASPOONS_FILE_OUTPUT_TTL_DAYS / 7}{' '}
+            weeks from completion.
           </div>
           <div>
             For support, email{' '}
@@ -349,7 +350,9 @@ const ActionCell = ({ pipelineRun }: CellProps): ReactNode => {
           <TooltipTrigger
             content={
               jobOutputsDeleted
-                ? 'The outputs for this job have been deleted. Outputs are available for 2 weeks after job completion.'
+                ? `The outputs for this job have been deleted. Outputs are available for ${
+                    TEASPOONS_FILE_OUTPUT_TTL_DAYS / 7
+                  } weeks after job completion.`
                 : undefined
             }
             side='top'

--- a/src/pages/scientificServices/pipelines/views/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/views/RunJob.tsx
@@ -1,6 +1,6 @@
 import { ButtonPrimary, Icon, Link, Select, Spinner } from '@terra-ui-packages/components';
 import { isEmpty } from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import FooterWrapper from 'src/components/FooterWrapper';
 import { getPopupRoot } from 'src/components/popup-utils';
@@ -49,7 +49,7 @@ export const RunJob = () => {
   const [selectedPipeline, setSelectedPipeline] = useState<Pipeline>();
   const [runDescription, setRunDescription] = useState<string>('');
   const [selectedUserInputs, setSelectedUserInputs] = useState<Record<string, any>>({});
-  const [validationErrors, setValidationErrors] = useState<Record<string, string | undefined>>({});
+  const [validationErrors, setValidationErrors] = useState<Record<string, ReactNode | undefined>>({});
 
   // Submission state
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -80,7 +80,7 @@ export const RunJob = () => {
   };
 
   // Handles updating the input validation map
-  const handleInputValidation = (inputName: string, error?: string) => {
+  const handleInputValidation = (inputName: string, error?: ReactNode) => {
     setValidationErrors((prev) => {
       if (!error) {
         const { [inputName]: _, ...rest } = prev;

--- a/src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal.tsx
+++ b/src/pages/scientificServices/pipelines/views/modals/ViewOutputsModal.tsx
@@ -6,6 +6,7 @@ import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import Events from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
+import { TEASPOONS_FILE_OUTPUT_TTL_DAYS } from 'src/pages/scientificServices/pipelines/common/teaspoons-service-constants';
 
 /**
  * Modal component for displaying pipeline outputs
@@ -148,8 +149,8 @@ export const ViewOutputsModal = ({ jobId, onDismiss }: OutputsModalProps): React
               </div>
             ) : (
               <div style={{ padding: '1rem', textAlign: 'center' }}>
-                No output information found for this job. If this job completed more than 14 days ago, the outputs have
-                been deleted.
+                No output information found for this job. If this job completed more than $
+                {TEASPOONS_FILE_OUTPUT_TTL_DAYS} days ago, the outputs have been deleted.
               </div>
             )}
           </div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-309

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Enforces a maximum file size for file input uploads


Screenshot has max file size reduced to 4 gigs because I didn't want to generate a >50gig file on my computer to test with 😃 but the real value is currently set to 50 (although we discussed that maybe we want to think about that a bit more)
<img width="542" height="235" alt="Screenshot 2025-10-10 at 3 00 22 PM" src="https://github.com/user-attachments/assets/4d8524e4-ec2b-4f41-bbe8-ab6322b68e3a" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
