### PR TITLE
[CORE-722] Add Dropdown to filter submissions by date

### DIFF
--- a/src/libs/ajax/workspaces/Workspaces.ts
+++ b/src/libs/ajax/workspaces/Workspaces.ts
@@ -276,8 +276,9 @@ export const Workspaces = (signal?: AbortSignal) => ({
         };
       },
 
-      listSubmissions: async () => {
-        const res = await fetchRawls(`${root}/submissions`, _.merge(authOpts(), { signal }));
+      listSubmissions: async (params?: { startDate?: string; endDate?: string }) => {
+        const query = params ? `?${qs.stringify(params)}` : '';
+        const res = await fetchRawls(`${root}/submissions${query}`, _.merge(authOpts(), { signal }));
         return res.json();
       },
 

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -115,23 +115,24 @@ const statusCell = (workflowStatuses, status) => {
   );
 };
 
-const noJobsMessage = div({ style: { fontSize: 20, margin: '1rem' } }, [
-  div([
-    'You have not run any submissions yet. To get started, go to the ',
-    span({ style: { fontWeight: 600 } }, ['Workflows']),
-    ' tab and select a workflow to run.',
-  ]),
-  div({ style: { marginTop: '1rem', fontSize: 16 } }, [
-    h(
-      Link,
-      {
-        ...Utils.newTabLinkProps,
-        href: 'https://support.terra.bio/hc/en-us/articles/360037096272',
-      },
-      ['What is a submission?']
-    ),
-  ]),
-]);
+const noJobsMessage = (dateRange) =>
+  div({ style: { fontSize: 20, margin: '1rem' } }, [
+    div([
+      `You have not run any submissions ${dateRange === '30' ? 'in the last 30 days' : 'yet'}. To get started, go to the `,
+      span({ style: { fontWeight: 600 } }, ['Workflows']),
+      ' tab and select a workflow to run.',
+    ]),
+    div({ style: { marginTop: '1rem', fontSize: 16 } }, [
+      h(
+        Link,
+        {
+          ...Utils.newTabLinkProps,
+          href: 'https://support.terra.bio/hc/en-us/articles/360037096272',
+        },
+        ['What is a submission?']
+      ),
+    ]),
+  ]);
 
 export const SubmissionHistory = _.flow(
   forwardRefWithName('SubmissionHistory'),
@@ -499,7 +500,7 @@ export const SubmissionHistory = _.flow(
               ],
             }),
         ]),
-      !loading && !hasJobs && noJobsMessage,
+      !loading && !hasJobs && noJobsMessage(dateRange),
       !!abortingId &&
         h(
           Modal,

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -5,7 +5,7 @@ import { div, h, span, table, tbody, td, tr } from 'react-hyperscript-helpers';
 import { AutoSizer } from 'react-virtualized';
 import { bucketBrowserUrl } from 'src/auth/auth';
 import * as breadcrumbs from 'src/components/breadcrumbs';
-import { Clickable, Link, spinnerOverlay } from 'src/components/common';
+import { Clickable, Link, Select, spinnerOverlay } from 'src/components/common';
 import { icon } from 'src/components/icons';
 import { DelayedSearchInput } from 'src/components/input';
 import { collapseStatus, statusType } from 'src/components/job-common';
@@ -37,6 +37,15 @@ const styles = {
   },
   multiLineCellText: {
     fontSize: 12,
+  },
+  dropdownStyle: {
+    padding: '0.5rem 0.5rem',
+    borderRadius: 4,
+    border: `1px solid ${colors.dark(0.2)}`,
+    background: colors.light(0.1),
+    fontSize: 14,
+    height: 36,
+    cursor: 'pointer',
   },
 };
 
@@ -124,7 +133,7 @@ const noJobsMessage = div({ style: { fontSize: 20, margin: '1rem' } }, [
   ]),
 ]);
 
-const SubmissionHistory = _.flow(
+export const SubmissionHistory = _.flow(
   forwardRefWithName('SubmissionHistory'),
   wrapWorkspace({
     breadcrumbs: (props) => breadcrumbs.commonPaths.workspaceDashboard(props),
@@ -137,6 +146,7 @@ const SubmissionHistory = _.flow(
   const [loading, setLoading] = useState(false);
   const [abortingId, setAbortingId] = useState(undefined);
   const [textFilter, setTextFilter] = useState('');
+  const [dateRange, setDateRange] = useState('30');
   const [sort, setSort] = useState({ field: 'submissionDate', direction: 'desc' });
   const [updatingCommentId, setUpdatingCommentId] = useState(undefined);
 
@@ -151,6 +161,19 @@ const SubmissionHistory = _.flow(
   // Helpers
   const refresh = Utils.withBusyState(setLoading, async () => {
     try {
+      let startDate;
+      const endDate = new Date();
+      if (dateRange === '30') {
+        startDate = new Date();
+        startDate.setDate(endDate.getDate() - 30);
+      } else {
+        startDate = undefined;
+      }
+
+      const params = {};
+      if (startDate) params.startDate = startDate.toISOString().split('T')[0];
+      params.endDate = endDate.toISOString().split('T')[0];
+
       const submissions = _.flow(
         _.orderBy('submissionDate', 'desc'),
         _.map((sub) => {
@@ -179,7 +202,7 @@ const SubmissionHistory = _.flow(
 
           return _.set('asText', subAsText, sub);
         })
-      )(await Workspaces(signal).workspace(namespace, name).listSubmissions());
+      )(await Workspaces(signal).workspace(namespace, name).listSubmissions(params));
       setSubmissions(submissions);
 
       if (_.some(({ status }) => !isTerminal(status), submissions)) {
@@ -214,6 +237,11 @@ const SubmissionHistory = _.flow(
     };
   });
 
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dateRange]);
+
   useImperativeHandle(ref, () => ({ refresh }));
 
   // Render
@@ -244,6 +272,19 @@ const SubmissionHistory = _.flow(
 
   return h(Fragment, [
     div({ style: { display: 'flex', alignItems: 'center', margin: '1rem 1rem 0' } }, [
+      div({ style: { display: 'flex', alignItems: 'center' } }, [
+        span({ style: { marginRight: '0.5rem', fontWeight: 'bold' } }, ['Date range']),
+        h(Select, {
+          id: 'submission-date-range-select',
+          isSearchable: false,
+          value: dateRange,
+          onChange: (option) => setDateRange(option.value),
+          options: [
+            { value: '30', label: 'Last 30 Days' },
+            { value: 'all', label: 'All Submissions' },
+          ],
+        }),
+      ]),
       div({ style: { flexGrow: 1 } }),
       h(DelayedSearchInput, {
         'aria-label': 'Search',
@@ -474,7 +515,7 @@ const SubmissionHistory = _.flow(
                 refresh();
               } catch (e) {
                 setLoading(false);
-                reportError('Error aborting submission', e);
+                // reportError('Error aborting submission', e);
               }
             },
           },

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -163,17 +163,15 @@ export const SubmissionHistory = _.flow(
   const refresh = Utils.withBusyState(setLoading, async () => {
     try {
       let startDate;
-      const endDate = new Date();
       if (dateRange === '30') {
         startDate = new Date();
-        startDate.setDate(endDate.getDate() - 30);
+        startDate.setDate(new Date().getDate() - 30);
       } else {
         startDate = undefined;
       }
 
       const params = {};
       if (startDate) params.startDate = startDate.toISOString().split('T')[0];
-      params.endDate = endDate.toISOString().split('T')[0];
 
       const submissions = _.flow(
         _.orderBy('submissionDate', 'desc'),

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -248,11 +248,6 @@ export const SubmissionHistory = _.flow(
     };
   });
 
-  useEffect(() => {
-    refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dateRange]);
-
   // Set dateRange in URL if missing on mount
   useEffect(() => {
     const hashParts = window.location.hash.split('?');
@@ -273,6 +268,7 @@ export const SubmissionHistory = _.flow(
       params.set('dateRange', dateRange);
       window.history.replaceState({}, '', `${window.location.pathname}${hashParts[0]}?${params.toString()}`);
     }
+    refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dateRange]);
 

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -134,6 +134,12 @@ const noJobsMessage = (dateRange) =>
     ]),
   ]);
 
+const getInitialDateRange = () => {
+  const hashParts = window.location.hash.split('?');
+  const params = new URLSearchParams(hashParts[1] || '');
+  return params.get('dateRange') || '30';
+};
+
 export const SubmissionHistory = _.flow(
   forwardRefWithName('SubmissionHistory'),
   wrapWorkspace({
@@ -147,7 +153,7 @@ export const SubmissionHistory = _.flow(
   const [loading, setLoading] = useState(false);
   const [abortingId, setAbortingId] = useState(undefined);
   const [textFilter, setTextFilter] = useState('');
-  const [dateRange, setDateRange] = useState('30');
+  const [dateRange, setDateRange] = useState(getInitialDateRange);
   const [sort, setSort] = useState({ field: 'submissionDate', direction: 'desc' });
   const [updatingCommentId, setUpdatingCommentId] = useState(undefined);
 
@@ -238,6 +244,29 @@ export const SubmissionHistory = _.flow(
 
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dateRange]);
+
+  // Set dateRange in URL if missing on mount
+  useEffect(() => {
+    const hashParts = window.location.hash.split('?');
+    const params = new URLSearchParams(hashParts[1] || '');
+    if (!params.has('dateRange')) {
+      params.set('dateRange', dateRange);
+      window.history.replaceState({}, '', `${window.location.pathname}${hashParts[0]}?${params.toString()}`);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Update URL when dateRange changes
+  useEffect(() => {
+    const hashParts = window.location.hash.split('?');
+    const params = new URLSearchParams(hashParts[1] || '');
+    const urlDateRange = params.get('dateRange');
+    if (dateRange !== urlDateRange) {
+      params.set('dateRange', dateRange);
+      window.history.replaceState({}, '', `${window.location.pathname}${hashParts[0]}?${params.toString()}`);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dateRange]);
 
@@ -514,7 +543,7 @@ export const SubmissionHistory = _.flow(
                 refresh();
               } catch (e) {
                 setLoading(false);
-                // reportError('Error aborting submission', e);
+                reportError('Error aborting submission', e);
               }
             },
           },

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -259,8 +259,20 @@ export const SubmissionHistory = _.flow(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Update URL when dateRange changes
   useEffect(() => {
+    // Sync dateRange state with URL changes
+    const handleHashChange = () => {
+      const hashParts = window.location.hash.split('?');
+      const params = new URLSearchParams(hashParts[1] || '');
+      const urlDateRange = params.get('dateRange');
+
+      if ((urlDateRange === 'all' || urlDateRange === '30') && urlDateRange !== dateRange) {
+        setDateRange(urlDateRange);
+        // eslint-disable-next-line
+        return; // return to avoid duplicate refresh
+      }
+    };
+    // Update URL when dateRange changes
     const hashParts = window.location.hash.split('?');
     const params = new URLSearchParams(hashParts[1] || '');
     const urlDateRange = params.get('dateRange');
@@ -269,6 +281,10 @@ export const SubmissionHistory = _.flow(
       window.history.replaceState({}, '', `${window.location.pathname}${hashParts[0]}?${params.toString()}`);
     }
     refresh();
+
+    // Listen for URL changes
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dateRange]);
 

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -137,7 +137,13 @@ const noJobsMessage = (dateRange) =>
 const getInitialDateRange = () => {
   const hashParts = window.location.hash.split('?');
   const params = new URLSearchParams(hashParts[1] || '');
-  return params.get('dateRange') || '30';
+  const urlDateRange = params.get('dateRange');
+
+  // Only return valid values, otherwise default to 30
+  if (urlDateRange === 'all' || urlDateRange === '30') {
+    return urlDateRange;
+  }
+  return '30';
 };
 
 export const SubmissionHistory = _.flow(

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -257,4 +257,21 @@ describe('SubmissionHistory date range filter', () => {
     // Verify the URL parameter is preserved
     expect(window.location.hash).toContain('?dateRange=all');
   });
+
+  test('should default dateRange to 30 when URL parameter is invalid', async () => {
+    // Set the URL before rendering
+    window.location.hash = '#workspaces/test-ns/test-ws/submission_history?dateRange=45';
+
+    mockListSubmissions(allSubmissions);
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+    });
+
+    // Verify the URL parameter is set to default instead of invalid value
+    expect(window.location.hash).toContain('?dateRange=30');
+  });
 });

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -47,7 +47,7 @@ asMockedFn(useWorkspace).mockReturnValue({
     canShare: true,
     canCompute: true,
     policies: [],
-    workspaceInitialized: true,
+    workspaceInitialized: false,
   },
   accessError: false,
   loadingWorkspace: false,
@@ -98,35 +98,34 @@ describe('SubmissionHistory date range filter', () => {
   const now = new Date();
   const recentSubmissionTime = now.toISOString();
   const oldSubmissionTime = new Date(new Date().setDate(now.getDate() - 45)).toISOString();
-  const mockSubmissions = [
-    {
-      submissionDate: recentSubmissionTime, // 10 days ago
-      methodConfigurationName: 'Recent Submission',
-      methodConfigurationNamespace: 'Test',
-      submissionId: 'recent-1',
-      submissionRoot: 'gs://test-bucket/recent-1',
-      workflowStatuses: { running: 1 },
-      status: 'Done',
-      submitter: 'user1',
-      submissionEntity: { entityName: 'entity1', entityType: 'type1' },
-      userComment: 'Recent',
-    },
-    {
-      submissionDate: oldSubmissionTime, // 40 days ago
-      methodConfigurationName: 'Old Submission',
-      methodConfigurationNamespace: 'Test',
-      submissionId: 'old-1',
-      submissionRoot: 'gs://test-bucket/old-1',
-      workflowStatuses: { succeeded: 1 },
-      status: 'Done',
-      submitter: 'user2',
-      submissionEntity: { entityName: 'entity2', entityType: 'type2' },
-      userComment: 'Old',
-    },
-  ];
+  const newerSubmission = {
+    submissionDate: recentSubmissionTime, // 10 days ago
+    methodConfigurationName: 'Recent Submission',
+    methodConfigurationNamespace: 'Test',
+    submissionId: 'recent-1',
+    submissionRoot: 'gs://test-bucket/recent-1',
+    workflowStatuses: { running: 1 },
+    status: 'Done',
+    submitter: 'user1',
+    submissionEntity: { entityName: 'entity1', entityType: 'type1' },
+    userComment: 'Recent',
+  };
+  const oldSubmission = {
+    submissionDate: oldSubmissionTime, // 40 days ago
+    methodConfigurationName: 'Old Submission',
+    methodConfigurationNamespace: 'Test',
+    submissionId: 'old-1',
+    submissionRoot: 'gs://test-bucket/old-1',
+    workflowStatuses: { succeeded: 1 },
+    status: 'Done',
+    submitter: 'user2',
+    submissionEntity: { entityName: 'entity2', entityType: 'type2' },
+    userComment: 'Old',
+  };
+  const allSubmissions = [newerSubmission, oldSubmission];
   const listSubmissions = jest.fn();
 
-  beforeEach(() => {
+  const mockListSubmissions = (mockSubmissions: any[]) => {
     listSubmissions.mockImplementation((params) => {
       if (params?.startDate) {
         return Promise.resolve(mockSubmissions.filter((s) => s.submissionDate >= params.startDate));
@@ -138,9 +137,20 @@ describe('SubmissionHistory date range filter', () => {
         listSubmissions,
       }),
     } as unknown as ReturnType<typeof Workspaces>);
-  });
+  };
+
+  async function selectAllSubmissionsOption() {
+    const user = userEvent.setup();
+    const selectElement = document.getElementById('submission-date-range-select');
+    if (!selectElement) {
+      fail('Select element not found');
+    }
+    const selectHelper = new SelectHelper(selectElement, user);
+    await selectHelper.selectOption('All Submissions');
+  }
 
   test('shows only submissions from the past 30 days by default', async () => {
+    mockListSubmissions(allSubmissions);
     await act(async () => {
       renderSubmissionHistory();
     });
@@ -153,6 +163,7 @@ describe('SubmissionHistory date range filter', () => {
   });
 
   test('shows all submissions when "All Submissions" is selected', async () => {
+    mockListSubmissions(allSubmissions);
     await act(async () => {
       renderSubmissionHistory();
     });
@@ -163,17 +174,50 @@ describe('SubmissionHistory date range filter', () => {
     });
 
     // Open the select dropdown and choose "All Submissions"
-    const user = userEvent.setup();
-    const selectElement = document.getElementById('submission-date-range-select');
-    if (!selectElement) {
-      fail('Select element not found');
-    }
-    const selectHelper = new SelectHelper(selectElement, user);
-    await selectHelper.selectOption('All Submissions');
+    await selectAllSubmissionsOption();
 
     await waitFor(() => {
       expect(screen.getByText('Old Submission')).toBeInTheDocument();
       expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+    });
+  });
+
+  test('shows no submissions for the past 30 days when only old submissions exist', async () => {
+    mockListSubmissions([oldSubmission]);
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Recent Submission')).not.toBeInTheDocument();
+      expect(screen.queryByText('Old Submission')).not.toBeInTheDocument();
+      expect(screen.getByText(/You have not run any submissions in the last 30 days/)).toBeInTheDocument();
+    });
+
+    await selectAllSubmissionsOption();
+
+    await waitFor(() => {
+      expect(screen.getByText('Old Submission')).toBeInTheDocument();
+    });
+  });
+
+  test('shows no submissions message when no submissions exist', async () => {
+    mockListSubmissions([]);
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Recent Submission')).not.toBeInTheDocument();
+      expect(screen.queryByText('Old Submission')).not.toBeInTheDocument();
+      expect(screen.getByText(/You have not run any submissions in the last 30 days/)).toBeInTheDocument();
+    });
+
+    // Open the select dropdown and choose "All Submissions"
+    await selectAllSubmissionsOption();
+
+    await waitFor(() => {
+      expect(screen.getByText(/You have not run any submissions yet/)).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -149,6 +149,23 @@ describe('SubmissionHistory date range filter', () => {
     await selectHelper.selectOption('All Submissions');
   }
 
+  beforeEach(() => {
+    window.location.hash = '#workspaces/test-ns/test-ws/submission_history';
+    jest.spyOn(window.history, 'replaceState').mockImplementation((_data, _unused, url) => {
+      if (url) {
+        const urlString = url.toString();
+        const match = urlString.match(/#.*/);
+        if (match) {
+          window.location.hash = match[0];
+        }
+      }
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('shows only submissions from the past 30 days by default', async () => {
     mockListSubmissions(allSubmissions);
     await act(async () => {
@@ -160,6 +177,7 @@ describe('SubmissionHistory date range filter', () => {
       expect(recentSubmission).toBeInTheDocument();
     });
     expect(screen.queryByText('Old Submission')).not.toBeInTheDocument();
+    expect(window.location.hash).toContain('?dateRange=30');
   });
 
   test('shows all submissions when "All Submissions" is selected', async () => {
@@ -179,6 +197,7 @@ describe('SubmissionHistory date range filter', () => {
     await waitFor(() => {
       expect(screen.getByText('Old Submission')).toBeInTheDocument();
       expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+      expect(window.location.hash).toContain('?dateRange=all');
     });
   });
 
@@ -219,5 +238,23 @@ describe('SubmissionHistory date range filter', () => {
     await waitFor(() => {
       expect(screen.getByText(/You have not run any submissions yet/)).toBeInTheDocument();
     });
+  });
+
+  test('should initialize dateRange from URL parameter', async () => {
+    // Set the URL before rendering
+    window.location.hash = '#workspaces/test-ns/test-ws/submission_history?dateRange=all';
+
+    mockListSubmissions(allSubmissions);
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Old Submission')).toBeInTheDocument();
+      expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+    });
+
+    // Verify the URL parameter is preserved
+    expect(window.location.hash).toContain('?dateRange=all');
   });
 });

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -29,22 +29,34 @@ jest.mock(
 jest.mock('src/workspaces/common/state/useWorkspace');
 jest.mock('src/libs/ajax/workspaces/Workspaces');
 asMockedFn(useWorkspace).mockReturnValue({
-  loadingWorkspace: false,
   workspace: {
     workspace: {
       namespace: 'test-ns',
       name: 'test-ws',
-      cloudPlatform: 'Gcp',
-      bucketName: 'test-bucket',
+      workspaceId: 'ws-123',
       authorizationDomain: [],
+      createdDate: '2025-01-01T00:00:00.000Z',
+      createdBy: 'test-user',
+      lastModified: '2025-01-02T00:00:00.000Z',
+      cloudPlatform: 'Gcp',
+      googleProject: 'test-project',
+      billingAccount: 'test-billing-account',
+      bucketName: 'test-bucket',
     },
+    accessLevel: 'OWNER',
+    canShare: true,
+    canCompute: true,
+    policies: [],
+    workspaceInitialized: true,
   },
+  accessError: false,
+  loadingWorkspace: false,
   storageDetails: {
     googleBucketLocation: 'US',
     googleBucketType: 'multi-region',
     fetchedGoogleBucketLocation: 'SUCCESS',
   },
-  refresh: jest.fn(),
+  refreshWorkspace: jest.fn(),
 });
 
 describe('Route Accessibility', () => {
@@ -153,6 +165,9 @@ describe('SubmissionHistory date range filter', () => {
     // Open the select dropdown and choose "All Submissions"
     const user = userEvent.setup();
     const selectElement = document.getElementById('submission-date-range-select');
+    if (!selectElement) {
+      fail('Select element not found');
+    }
     const selectHelper = new SelectHelper(selectElement, user);
     await selectHelper.selectOption('All Submissions');
 

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -1,4 +1,51 @@
-import { navPaths } from 'src/pages/workspaces/workspace/SubmissionHistory';
+import { Theme, ThemeProvider } from '@terra-ui-packages/components';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
+import { navPaths, SubmissionHistory } from 'src/pages/workspaces/workspace/SubmissionHistory';
+import { asMockedFn, SelectHelper } from 'src/testing/test-utils';
+import { useWorkspace } from 'src/workspaces/common/state/useWorkspace';
+
+jest.mock('react-virtualized', () => {
+  const actual = jest.requireActual('react-virtualized');
+  return {
+    ...actual,
+    AutoSizer: ({ children }: any) => children({ width: 1000, height: 600 }),
+  };
+});
+type NavExports = typeof import('src/libs/nav');
+jest.mock(
+  'src/libs/nav',
+  (): NavExports => ({
+    ...jest.requireActual<NavExports>('src/libs/nav'),
+    getLink: jest.fn(() => '/'),
+    goToPath: jest.fn(),
+    useRoute: jest.fn().mockReturnValue({ params: { namespace: 'test-ns', name: 'test-ws' } }),
+    updateSearch: jest.fn(),
+  })
+);
+jest.mock('src/workspaces/common/state/useWorkspace');
+jest.mock('src/libs/ajax/workspaces/Workspaces');
+asMockedFn(useWorkspace).mockReturnValue({
+  loadingWorkspace: false,
+  workspace: {
+    workspace: {
+      namespace: 'test-ns',
+      name: 'test-ws',
+      cloudPlatform: 'Gcp',
+      bucketName: 'test-bucket',
+      authorizationDomain: [],
+    },
+  },
+  storageDetails: {
+    googleBucketLocation: 'US',
+    googleBucketType: 'multi-region',
+    fetchedGoogleBucketLocation: 'SUCCESS',
+  },
+  refresh: jest.fn(),
+});
 
 describe('Route Accessibility', () => {
   test('should contain valid paths for SubmissionHistory', () => {
@@ -10,5 +57,108 @@ describe('Route Accessibility', () => {
     const actualPaths = navPaths.map((route) => route.path);
 
     expect(actualPaths).toEqual(expect.arrayContaining(expectedPaths));
+  });
+});
+
+const renderSubmissionHistory = () => {
+  const terraTheme: Theme = {
+    colorPalette: {
+      primary: '#74ae43',
+      secondary: '#6d6e70',
+      accent: '#4d72aa',
+      success: '#74ae43',
+      warning: '#f7981c',
+      danger: '#db3214',
+      light: '#e9ecef',
+      dark: '#333f52',
+      grey: '#808080',
+      disabled: '#b6b7b8',
+    },
+  };
+  return render(
+    <ThemeProvider theme={terraTheme}>
+      <SubmissionHistory namespace='test-ns' name='test-ws' />
+    </ThemeProvider>
+  );
+};
+
+describe('SubmissionHistory date range filter', () => {
+  const now = new Date();
+  const recentSubmissionTime = now.toISOString();
+  const oldSubmissionTime = new Date(new Date().setDate(now.getDate() - 45)).toISOString();
+  const mockSubmissions = [
+    {
+      submissionDate: recentSubmissionTime, // 10 days ago
+      methodConfigurationName: 'Recent Submission',
+      methodConfigurationNamespace: 'Test',
+      submissionId: 'recent-1',
+      submissionRoot: 'gs://test-bucket/recent-1',
+      workflowStatuses: { running: 1 },
+      status: 'Done',
+      submitter: 'user1',
+      submissionEntity: { entityName: 'entity1', entityType: 'type1' },
+      userComment: 'Recent',
+    },
+    {
+      submissionDate: oldSubmissionTime, // 40 days ago
+      methodConfigurationName: 'Old Submission',
+      methodConfigurationNamespace: 'Test',
+      submissionId: 'old-1',
+      submissionRoot: 'gs://test-bucket/old-1',
+      workflowStatuses: { succeeded: 1 },
+      status: 'Done',
+      submitter: 'user2',
+      submissionEntity: { entityName: 'entity2', entityType: 'type2' },
+      userComment: 'Old',
+    },
+  ];
+  const listSubmissions = jest.fn();
+
+  beforeEach(() => {
+    listSubmissions.mockImplementation((params) => {
+      if (params?.startDate) {
+        return Promise.resolve(mockSubmissions.filter((s) => s.submissionDate >= params.startDate));
+      }
+      return Promise.resolve(mockSubmissions);
+    });
+    asMockedFn(Workspaces).mockReturnValue({
+      workspace: () => ({
+        listSubmissions,
+      }),
+    } as unknown as ReturnType<typeof Workspaces>);
+  });
+
+  test('shows only submissions from the past 30 days by default', async () => {
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      const recentSubmission = screen.getByText('Recent Submission');
+      expect(recentSubmission).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Old Submission')).not.toBeInTheDocument();
+  });
+
+  test('shows all submissions when "All Submissions" is selected', async () => {
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    await waitFor(() => {
+      const recentSubmission = screen.getByText('Recent Submission');
+      expect(recentSubmission).toBeInTheDocument();
+    });
+
+    // Open the select dropdown and choose "All Submissions"
+    const user = userEvent.setup();
+    const selectElement = document.getElementById('submission-date-range-select');
+    const selectHelper = new SelectHelper(selectElement, user);
+    await selectHelper.selectOption('All Submissions');
+
+    await waitFor(() => {
+      expect(screen.getByText('Old Submission')).toBeInTheDocument();
+      expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
### Jira Ticket: [https://broadworkbench.atlassian.net/browse/CORE-722](https://broadworkbench.atlassian.net/browse/CORE-722)

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Add a dropdown menu to the submission history page to filter by date range. By default show submissions from the past 30 days. The dateRange is also a query param in the url so if a user bookmarks or shares the page it will show the correct 

### What
<img width="1255" height="380" alt="Screenshot 2025-10-21 at 3 37 58 PM" src="https://github.com/user-attachments/assets/04961e12-082a-4414-8b84-1c3b66f4a4bc" />
<img width="994" height="425" alt="Screenshot 2025-10-21 at 3 26 05 PM" src="https://github.com/user-attachments/assets/0d07001d-20b1-4615-b9be-1555fedf474c" />


### Why
If a workspace has a lot of submissions, the submissions history page will be slow to load. Just loading the lat 30 days to start will speed this up

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

Manual testing in the UI to confirm:
- Submissions from the past 30 days are shown by defauly
- Selecting "All submissions" reloads the submission history table and displays all submissions

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
