### PR TITLE
[CORE-737] Do not refresh submissions history when viewing all submissions

### DIFF
--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -216,7 +216,10 @@ export const SubmissionHistory = _.flow(
       )(await Workspaces(signal).workspace(namespace, name).listSubmissions(params));
       setSubmissions(submissions);
 
-      if (_.some(({ status }) => !isTerminal(status), submissions)) {
+      if (dateRange !== 'all' && _.some(({ status }) => !isTerminal(status), submissions)) {
+        if (scheduledRefresh.current) {
+          clearTimeout(scheduledRefresh.current);
+        }
         scheduledRefresh.current = setTimeout(refresh, 1000 * 60);
       }
     } catch (error) {

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -240,8 +240,6 @@ export const SubmissionHistory = _.flow(
 
   // Lifecycle
   useOnMount(() => {
-    refresh();
-
     return () => {
       if (scheduledRefresh.current) {
         clearTimeout(scheduledRefresh.current);

--- a/src/pages/workspaces/workspace/SubmissionHistory.js
+++ b/src/pages/workspaces/workspace/SubmissionHistory.js
@@ -173,6 +173,9 @@ export const SubmissionHistory = _.flow(
 
   // Helpers
   const refresh = Utils.withBusyState(setLoading, async () => {
+    if (scheduledRefresh.current) {
+      clearTimeout(scheduledRefresh.current);
+    }
     try {
       let startDate;
       if (dateRange === '30') {
@@ -184,7 +187,6 @@ export const SubmissionHistory = _.flow(
 
       const params = {};
       if (startDate) params.startDate = startDate.toISOString().split('T')[0];
-
       const submissions = _.flow(
         _.orderBy('submissionDate', 'desc'),
         _.map((sub) => {
@@ -215,11 +217,7 @@ export const SubmissionHistory = _.flow(
         })
       )(await Workspaces(signal).workspace(namespace, name).listSubmissions(params));
       setSubmissions(submissions);
-
       if (dateRange !== 'all' && _.some(({ status }) => !isTerminal(status), submissions)) {
-        if (scheduledRefresh.current) {
-          clearTimeout(scheduledRefresh.current);
-        }
         scheduledRefresh.current = setTimeout(refresh, 1000 * 60);
       }
     } catch (error) {

--- a/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
+++ b/src/pages/workspaces/workspace/SubmissionHistory.test.tsx
@@ -274,4 +274,28 @@ describe('SubmissionHistory date range filter', () => {
     // Verify the URL parameter is set to default instead of invalid value
     expect(window.location.hash).toContain('?dateRange=30');
   });
+
+  test('does not schedule refresh when "All Submissions" is selected', async () => {
+    // Set the URL to "all" to ensure that the refresh logic is tested correctly
+    window.location.hash = '#workspaces/test-ns/test-ws/submission_history?dateRange=all';
+
+    jest.useFakeTimers();
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const runningSubmission = { ...newerSubmission, status: 'Running' };
+    mockListSubmissions([runningSubmission]);
+    await act(async () => {
+      renderSubmissionHistory();
+    });
+
+    // Wait for UI update
+    await waitFor(() => {
+      expect(screen.getByText('Recent Submission')).toBeInTheDocument();
+    });
+
+    // Assert setTimeout was not called to schedule a refresh
+    expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 1000 * 60);
+
+    setTimeoutSpy.mockRestore();
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-737

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
The UI does not refresh running submissions if all submissions are selected.

### Why
When a user viewed all submissions, the refresh was still scheduled with the original "30 days" filter so if there were any running submissions the page would refresh to only show the last 30 days (while "all submissions" was still selected/displayed in the drop-down).

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

While running the UI locally, I ran a submission and confirmed that the submission history does not refresh when "All Submissions" is selected, but it still refreshes when "30 days" is selected.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
