### PR TITLE
[CORE-520] Change tsv upload threshold to 10MB

### DIFF
--- a/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
+++ b/src/libs/ajax/data-table-providers/EntityServiceDataTableProvider.ts
@@ -111,8 +111,8 @@ export class EntityServiceDataTableProvider implements DataTableProvider {
       return workspace.importEntitiesFile(uploadParams.file, { deleteEmptyValues: uploadParams.deleteEmptyValues });
     }
     const filesize = uploadParams.file?.size || Number.MAX_SAFE_INTEGER;
-    if (filesize < 524288) {
-      // 512k
+    if (filesize < 10485760) {
+      // 10MB
       return workspace.importFlexibleEntitiesFileSynchronous(uploadParams.file, {
         deleteEmptyValues: uploadParams.deleteEmptyValues,
       });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-520

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Changes the threshold for switching from synchronous to asynchronous TSV upload from 512kb to 10Mb.

### Why
- With improvements to batch update, including switching all workspaces to improved data tables, synchronous upload is faster.  Since sync is overall a better user experience than async, we want to use it when possible.  Some testing (see comments in tickets) suggests that uploading a 10Mb file would take about ~13 seconds, which we think is acceptable.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
