### PR TITLE
[CORE-747] Enable IGV scrolling when tracks are tall

### DIFF
--- a/src/components/igv/IGVBrowser.js
+++ b/src/components/igv/IGVBrowser.js
@@ -484,7 +484,6 @@ const IGVBrowser = ({ selectedFiles, refGenome: { genome, reference }, workspace
       {
         ref: containerRef,
         style: {
-          overflowY: 'visible',
           padding: '10px 0',
           margin: 8,
           border: `1px solid ${colors.dark(0.25)}`,

--- a/src/workspace-data/Data.js
+++ b/src/workspace-data/Data.js
@@ -74,7 +74,7 @@ const styles = {
   },
   tableViewPanel: {
     position: 'relative',
-    overflow: 'hidden',
+    overflow: 'auto',
     width: '100%',
     flex: 1,
     display: 'flex',

--- a/src/workspace-data/Data.test.ts
+++ b/src/workspace-data/Data.test.ts
@@ -133,4 +133,45 @@ describe('WorkspaceData', () => {
       { timeout: 10000 }
     );
   }, 15000);
+
+  it('has scrollable tableViewPanel to allow vertical scrolling when content is too tall', async () => {
+    // Setup mocks for the test
+    const mockEntityMetadata = jest.fn();
+    mockEntityMetadata.mockResolvedValue(entityMetadata);
+
+    asMockedFn(Workspaces).mockReturnValue({
+      workspace: (_namespace: string, _name: string) => ({
+        entityMetadata: mockEntityMetadata,
+      }),
+    } as any);
+
+    (getIgvUrlParams as jest.Mock).mockReturnValue({
+      igvSession: null,
+      igvGenome: null,
+    });
+
+    const workspaceDataProps = {
+      namespace: 'test-namespace',
+      name: 'test-name',
+      workspace: defaultGoogleWorkspace,
+      refreshWorkspace: () => {},
+      storageDetails: { ...defaultGoogleBucketOptions },
+    };
+
+    await act(async () => {
+      render(h(WorkspaceData, workspaceDataProps));
+    });
+
+    await waitFor(() => {
+      // Find the element with the tableViewPanel styles
+      // The tableViewPanel should have overflow: 'auto' to enable scrolling
+      const tableViewPanels = document.querySelectorAll('[style*="overflow"]');
+      const hasScrollablePanel = Array.from(tableViewPanels).some((el) => {
+        const style = (el as HTMLElement).style;
+        return style.overflow === 'auto' || style.overflowY === 'auto';
+      });
+
+      expect(hasScrollablePanel).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CORE-747

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
Previously, users could not vertically scroll the IGV genome browser when tracks were taller than IGV's viewport container.  Now they can!  This fix restores geneticists ability to e.g. analyze BAMs and CRAMs for family cohorts.

https://github.com/user-attachments/assets/0446d3a3-a1f6-41db-bfe3-db144d9f8c48

## Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

1.  Find a workspace that has multiple BAMs or CRAMs
2. Open them in IGV
3. Confirm you can vertically scroll

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
