### PR TITLE
[FE-418] Remove gov shutdown message from BDC branded UI

### DIFF
--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -198,25 +198,8 @@ export const brands: Record<string, BrandConfiguration> = {
     name: 'NHLBI BioData Catalyst',
     queryName: 'nhlbi biodata catalyst',
     welcomeHeader: 'Welcome to NHLBI BioData Catalyst',
-    description: (
-      <>
-        NHLBI BioData Catalyst (BDC) is a project powered by Terra for biomedical researchers to access data, run
-        analysis tools, and collaborate.
-        <br />
-        <br />
-        Because of a lapse in government funding, the information on this website may not be up to date, transactions
-        submitted via the website may not be processed, and the agency may not be able to respond to inquiries until
-        appropriations are enacted. The NIH Clinical Center (the research hospital of NIH) is open. For more details
-        about its operating status, please visit{' '}
-        <a href='https://cc.nih.gov/' target='_blank' rel='noopener noreferrer'>
-          cc.nih.gov.
-        </a>{' '}
-        Updates regarding government operating status and resumption of normal operations can be found at{' '}
-        <a href='https://opm.gov/' target='_blank' rel='noopener noreferrer'>
-          opm.gov.
-        </a>
-      </>
-    ),
+    description:
+      'NHLBI BioData Catalyst (BDC) is a project powered by Terra for biomedical researchers to access data, run analysis tools, and collaborate.',
     hostName: 'terra.biodatacatalyst.nhlbi.nih.gov',
     docLinks: [
       {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/fe-418

## Summary of changes:
removing the message that was added to the BDC brand during the government shutdown

### Before
<img width="1136" height="539" alt="image" src="https://github.com/user-attachments/assets/2ea7710c-5f2d-4de6-8d28-f8a88bc986ac" />

### After
<img width="1676" height="700" alt="image" src="https://github.com/user-attachments/assets/3d338ec8-8bbf-49c6-b66d-2a1dda17e940" />


### Testing strategy
tested on local UI
`window.configOverridesStore.set({ brand: 'bioDataCatalyst' });`

