### PR TITLE
[TSPS-667] Use standard color utility functions instead of hex values

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/history/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/JobHistory.tsx
@@ -356,7 +356,7 @@ const DataDeletionDateCell = ({ pipelineRun }: CellProps): ReactNode => {
       style={
         isDeletionSoon
           ? {
-              color: '#DB3214',
+              color: colors.danger(),
               fontWeight: 600,
             }
           : {}
@@ -502,7 +502,7 @@ const getRunStatusIcon = (pipelineRun: PipelineRun): ReactNode => {
   switch (pipelineRun.status) {
     case 'SUCCEEDED':
       return (
-        <div style={{ display: 'flex', alignItems: 'center', color: '#74AE43', gap: '0.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', color: colors.success(), gap: '0.5rem' }}>
           <Icon icon='success-standard' /> Done
         </div>
       );
@@ -520,7 +520,7 @@ const getRunStatusIcon = (pipelineRun: PipelineRun): ReactNode => {
 
       if (hoursElapsed > PREPARING_JOB_CUTOFF_HOURS) {
         return (
-          <div style={{ display: 'flex', alignItems: 'center', color: '#DB3214', gap: '0.5rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', color: colors.danger(), gap: '0.5rem' }}>
             <Icon icon='warning-standard' /> Failed
           </div>
         );
@@ -538,7 +538,7 @@ const getRunStatusIcon = (pipelineRun: PipelineRun): ReactNode => {
     }
     case 'FAILED':
       return (
-        <div style={{ display: 'flex', alignItems: 'center', color: '#DB3214', gap: '0.5rem' }}>
+        <div style={{ display: 'flex', alignItems: 'center', color: colors.danger(), gap: '0.5rem' }}>
           <Icon icon='warning-standard' /> Failed
         </div>
       );

--- a/src/pages/scientificServices/pipelines/tabs/history/controls/TableFilters.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/controls/TableFilters.tsx
@@ -2,6 +2,7 @@ import { ButtonPrimary, Icon, Select } from '@terra-ui-packages/components';
 import React, { useEffect, useState } from 'react';
 import { DelayedSearchInput } from 'src/components/input';
 import { Pipeline, PipelineRunStatus } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 
 export interface FilterValues {
   description?: string;
@@ -134,7 +135,7 @@ const JobIdFilterControl = ({
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
         <div style={{ fontWeight: 600, fontSize: '14px' }}>Job ID</div>
         {showValidationWarning && (
-          <div style={{ color: '#DB3214', fontSize: '14px' }}>
+          <div style={{ color: colors.danger(), fontSize: '14px' }}>
             <Icon icon='warning-standard' size={14} /> Enter a valid job ID
           </div>
         )}

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -6,6 +6,7 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { getPopupRoot } from 'src/components/popup-utils';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
@@ -198,7 +199,7 @@ export const RunJob = () => {
       <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem 2rem' }}>
         <div style={{ flex: 1, marginRight: '2rem' }}>
           <h3 style={{ marginBottom: '0.5rem' }}>
-            Select a pipeline version <span style={{ color: '#DB3214' }}>*</span>
+            Select a pipeline version <span style={{ color: colors.danger() }}>*</span>
           </h3>
           <div style={{ marginBottom: '2rem' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
@@ -321,7 +322,11 @@ export const RunJob = () => {
                           alignItems: 'center',
                         }}
                       >
-                        <Icon icon='warning-standard' size={36} style={{ color: '#DB3214', marginRight: '1rem' }} />
+                        <Icon
+                          icon='warning-standard'
+                          size={36}
+                          style={{ color: colors.danger(), marginRight: '1rem' }}
+                        />
                         <div>
                           You do not have enough quota remaining to run this pipeline. Please{' '}
                           <Link
@@ -372,7 +377,7 @@ export const RunJob = () => {
                         alignItems: 'center',
                       }}
                     >
-                      <Icon icon='success-standard' size={36} style={{ color: '#74AE43', margin: '0 1rem' }} />
+                      <Icon icon='success-standard' size={36} style={{ color: colors.success(), margin: '0 1rem' }} />
                       <div>
                         Your job has been submitted. You can check the status of that job by going to the{' '}
                         <Link style={{ color: '#46A3E9' }} href={Nav.getLink('pipelines-history')}>

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineFileInput.tsx
@@ -142,7 +142,7 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
   return (
     <div>
       <h3 style={{ marginBottom: '0.5rem' }}>
-        Select a {displayName || name} {isRequired ? <span style={{ color: '#DB3214' }}>*</span> : null}
+        Select a {displayName || name} {isRequired ? <span style={{ color: colors.danger() }}>*</span> : null}
       </h3>
       <div
         style={{
@@ -209,9 +209,17 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
                         }}
                       >
                         {validationError ? (
-                          <Icon icon='warning-standard' size={36} style={{ color: '#DB3214', marginLeft: '1rem' }} />
+                          <Icon
+                            icon='warning-standard'
+                            size={36}
+                            style={{ color: colors.danger(), marginLeft: '1rem' }}
+                          />
                         ) : (
-                          <Icon icon='success-standard' size={36} style={{ color: '#74AE43', marginLeft: '1rem' }} />
+                          <Icon
+                            icon='success-standard'
+                            size={36}
+                            style={{ color: colors.success(), marginLeft: '1rem' }}
+                          />
                         )}
                         <div
                           style={{
@@ -295,7 +303,11 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
                     }}
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                      <Icon icon='warning-standard' size={24} style={{ color: '#DB3214', verticalAlign: 'middle' }} />{' '}
+                      <Icon
+                        icon='warning-standard'
+                        size={24}
+                        style={{ color: colors.danger(), verticalAlign: 'middle' }}
+                      />{' '}
                       <div>There was an error uploading the file.</div>
                     </div>
                     <ButtonPrimary type='button' onClick={handleResumeUpload}>
@@ -337,13 +349,13 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
               </>
             ) : (
               <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                <Icon icon='success-standard' size={24} style={{ color: '#74AE43' }} />{' '}
+                <Icon icon='success-standard' size={24} style={{ color: colors.success() }} />{' '}
                 <span style={{ fontWeight: 'bold' }}>Upload successful.</span>
               </div>
             )}
           </>
         )}
-        {validationError && <div style={{ color: '#DB3214', paddingTop: '0.5rem' }}>{validationError}</div>}
+        {validationError && <div style={{ color: colors.danger(), paddingTop: '0.5rem' }}>{validationError}</div>}
       </div>
     </div>
   );

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineFloatInput.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { ValidatedInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 
 interface PipelineFloatInputProps {
   input: PipelineInput;
@@ -22,7 +23,7 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
   return (
     <>
       <h3 style={{ marginBottom: '0.5rem' }}>
-        Enter {displayName || name} {isRequired ? <span style={{ color: '#DB3214' }}> *</span> : null}
+        Enter {displayName || name} {isRequired ? <span style={{ color: colors.danger() }}> *</span> : null}
       </h3>
       <ValidatedInput
         width={400}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineStringInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineStringInput.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { ValidatedInput } from 'src/components/input';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 
 interface PipelineStringInputProps {
   input: PipelineInput;
@@ -22,7 +23,7 @@ export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
   return (
     <>
       <h3 style={{ marginBottom: '0.5rem' }}>
-        Enter {displayName || name} {isRequired ? <span style={{ color: '#DB3214' }}> *</span> : null}
+        Enter {displayName || name} {isRequired ? <span style={{ color: colors.danger() }}> *</span> : null}
       </h3>
       <ValidatedInput
         width={400}


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-667

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
This PR replaces below hardcoded hex values with color utility functions. Both the colors of success and failure were part of [base color palette in brands.tsx](https://github.com/DataBiosphere/terra-ui/blob/a8b60a8379ecc043c0eace04cbfca545d319db4f/src/libs/brands.tsx#L136-L147) and hence I have directly used them.
- #DB3214 --> colors.danger()
- #74AE43 --> colors.success()

### Why
To replace hardcoded values with standard utility methods

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] manual testing

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
