### PR TITLE
[TSPS-671] add teaspoons specific service alerts to be shown 

### DIFF
--- a/src/alerts/service-alerts.test.ts
+++ b/src/alerts/service-alerts.test.ts
@@ -1,5 +1,6 @@
 import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
 import { FirecloudBucket, FirecloudBucketAjaxContract } from 'src/libs/ajax/firecloud/FirecloudBucket';
+import * as brandUtils from 'src/libs/brand-utils';
 
 import { getServiceAlerts } from './service-alerts';
 
@@ -98,5 +99,57 @@ describe('getServiceAlerts', () => {
 
     // Assert
     expect(serviceAlerts.map((alert) => alert.severity)).toEqual(['error', 'warn', 'warn', 'info']);
+  });
+});
+
+describe('getServiceAlerts with brand variations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls getTeaspoonsServiceAlerts when isScientificServices is true', async () => {
+    // Arrange
+    const mockGetTeaspoonsServiceAlerts = jest.fn().mockReturnValue(Promise.resolve([]));
+    const mockGetServiceAlerts = jest.fn().mockReturnValue(Promise.resolve([]));
+
+    asMockedFn(FirecloudBucket).mockReturnValue(
+      partial<FirecloudBucketAjaxContract>({
+        getTeaspoonsServiceAlerts: mockGetTeaspoonsServiceAlerts,
+        getServiceAlerts: mockGetServiceAlerts,
+      })
+    );
+
+    // Mock isScientificServices to return true
+    jest.spyOn(brandUtils, 'isScientificServices').mockReturnValue(true);
+
+    // Act
+    await getServiceAlerts();
+
+    // Assert
+    expect(mockGetTeaspoonsServiceAlerts).toHaveBeenCalled();
+    expect(mockGetServiceAlerts).not.toHaveBeenCalled();
+  });
+
+  it('calls getServiceAlerts when isScientificServices is false', async () => {
+    // Arrange
+    const mockGetTeaspoonsServiceAlerts = jest.fn().mockReturnValue(Promise.resolve([]));
+    const mockGetServiceAlerts = jest.fn().mockReturnValue(Promise.resolve([]));
+
+    asMockedFn(FirecloudBucket).mockReturnValue(
+      partial<FirecloudBucketAjaxContract>({
+        getTeaspoonsServiceAlerts: mockGetTeaspoonsServiceAlerts,
+        getServiceAlerts: mockGetServiceAlerts,
+      })
+    );
+
+    // Mock isScientificServices to return false
+    jest.spyOn(brandUtils, 'isScientificServices').mockReturnValue(false);
+
+    // Act
+    await getServiceAlerts();
+
+    // Assert
+    expect(mockGetServiceAlerts).toHaveBeenCalled();
+    expect(mockGetTeaspoonsServiceAlerts).not.toHaveBeenCalled();
   });
 });

--- a/src/alerts/service-alerts.ts
+++ b/src/alerts/service-alerts.ts
@@ -9,7 +9,7 @@ import { Alert } from './Alert';
 
 export const getServiceAlerts = async (): Promise<Alert[]> => {
   const serviceAlerts = isScientificServices()
-    ? await FirecloudBucket().getTeaspoonsAlerts()
+    ? await FirecloudBucket().getTeaspoonsServiceAlerts()
     : await FirecloudBucket().getServiceAlerts();
   const hashes = await Promise.all(_.map(_.flow(JSON.stringify, Utils.sha256), serviceAlerts));
   const severityMap = {

--- a/src/alerts/service-alerts.ts
+++ b/src/alerts/service-alerts.ts
@@ -1,13 +1,16 @@
 import { atom } from '@terra-ui-packages/core-utils';
 import _ from 'lodash/fp';
 import { FirecloudBucket } from 'src/libs/ajax/firecloud/FirecloudBucket';
+import { isScientificServices } from 'src/libs/brand-utils';
 import { useStore } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 
 import { Alert } from './Alert';
 
 export const getServiceAlerts = async (): Promise<Alert[]> => {
-  const serviceAlerts = await FirecloudBucket().getServiceAlerts();
+  const serviceAlerts = isScientificServices()
+    ? await FirecloudBucket().getTeaspoonsAlerts()
+    : await FirecloudBucket().getServiceAlerts();
   const hashes = await Promise.all(_.map(_.flow(JSON.stringify, Utils.sha256), serviceAlerts));
   const severityMap = {
     blocker: 'error',

--- a/src/libs/ajax/firecloud/FirecloudBucket.ts
+++ b/src/libs/ajax/firecloud/FirecloudBucket.ts
@@ -7,6 +7,11 @@ export const FirecloudBucket = (signal?: AbortSignal) => ({
     return res.json();
   },
 
+  getTeaspoonsServiceAlerts: async () => {
+    const res = await fetchOk(`${getConfig().firecloudBucketRoot}/teaspoons-alerts.json`, { signal });
+    return res.json();
+  },
+
   getFeaturedWorkspaces: async () => {
     const res = await fetchOk(`${getConfig().firecloudBucketRoot}/featured-workspaces.json`, { signal });
     return res.json();


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-671

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Adding the ability to display teaspoons specific service alerts for the teaspoons portal

### What
-

### Why
- terra service alerts either may not affect teaspoons users or if they do then they will probably need different messaging so this way we can separate the two.

### Testing strategy
Currently still waiting for some beehive changes to be able to test out the full functionality (beehive will write the teaspoons-alerts.json file)
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
