### PR TITLE
[CTM-50] Clarify URL on data import

### DIFF
--- a/src/import-data/ImportDataOverview.ts
+++ b/src/import-data/ImportDataOverview.ts
@@ -47,12 +47,25 @@ export interface ImportDataOverviewProps {
 export const ImportDataOverview = (props: ImportDataOverviewProps): ReactNode => {
   const { importRequest } = props;
 
+  const getDisplayUrl = (url: string) => url.replace(/^https?:\/\//, '').split('?')[0];
+
   return div({ style: styles.card }, [
     h2({ style: styles.title }, [getTitleForImportRequest(importRequest)]),
     'url' in importRequest &&
       h(Fragment, [
-        h3({ style: { fontSize: 16 } }, ['Dataset source:']),
-        div({ style: { marginTop: '1rem' } }, [`${importRequest.url.href.split('?')[0]}`]),
+        h3({ style: { fontSize: 16, marginBottom: 2 } }, ['Dataset source:']),
+        div(
+          {
+            style: {
+              fontSize: 13,
+              color: colors.dark(0.7),
+              marginBottom: 8,
+              marginTop: 0,
+            },
+          },
+          ['(For reference only — not a direct link)']
+        ),
+        div({ style: { marginTop: '1rem', marginBottom: '0.5rem' } }, [getDisplayUrl(importRequest.url.href)]),
       ]),
     h(ImportRequirements, { importRequest }),
   ]);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-50

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Adds a message to the import page specifying that the displayed URL is not a valid URL, and removes 'http(s)' from the URL for clarity.

Before:
 
<img width="1455" height="524" alt="beforeChanges" src="https://github.com/user-attachments/assets/c9fc9de4-c7cf-4e52-8faf-da2fcb547e7b" />

After:
<img width="1458" height="475" alt="withChanges" src="https://github.com/user-attachments/assets/4272cad1-9d79-4292-bddd-4b13fda216b4" />


### What
-

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
