### PR TITLE
[CTM-317] Use settings2/profile/loadIdentities endpoint for all RAS environments

### DIFF
--- a/src/profile/external-identities/OAuth2Account.tsx
+++ b/src/profile/external-identities/OAuth2Account.tsx
@@ -75,8 +75,7 @@ export const OAuth2Account = (props: OAuth2AccountProps) => {
     additionalProperties: undefined,
   };
   const eraUserId = additionalProperties?.era_user_id ?? 'none';
-  const nihSettings = getConfig().terraDeploymentEnv === 'prod' ? 'settings' : 'settings2';
-  const nihSettingsPage = `${getConfig().nihAuthRoot}/${nihSettings}/profile/loadIdentities`;
+  const nihSettingsPage = `${getConfig().nihAuthRoot}/settings2/profile/loadIdentities`;
 
   const signal = useCancellation();
   const callbacks: Array<OAuth2Callback['name']> = ['oauth-callback', 'ecm-callback', 'fence-callback']; // ecm-callback is deprecated, but still needs to be supported

--- a/src/profile/external-identities/OAuth2Providers.ts
+++ b/src/profile/external-identities/OAuth2Providers.ts
@@ -55,16 +55,12 @@ export const oauth2Provider = (providerKey: OAuth2ProviderKey): OAuth2Provider =
         isFence: false,
       };
     case 'ras':
-      const scopes = ['openid', 'email', 'ga4gh_passport_v1'];
-      if (getConfig().terraDeploymentEnv !== 'prod') {
-        scopes.push('federated_identities_ial2');
-      }
       return {
         key: providerKey,
         name: 'NIH Researcher Auth Service (RAS)',
         short: 'RAS',
         queryParams: {
-          scopes,
+          scopes: ['openid', 'email', 'ga4gh_passport_v1', 'federated_identities_ial2'],
           redirectUri: createRedirectUri('ecm-callback'),
         },
         supportsAccessToken: false,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-317

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Now that the RAS prod client is IAL2 enabled, update the settings url to be consistent with dev and staging.

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] Manual testing in the PR deployment site

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
