### PR TITLE
[TSPS-784] Add inputSize to Job Details page

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
@@ -107,7 +107,14 @@ export const JobDetailsHeader = ({ pipelineRunResult }: JobDetailsHeaderProps) =
             </>
           }
         />
-
+        {/* {pipelineRunResult.pipelineRunReport.inputSize && ( */}
+        {/*   <HeaderItem */}
+        {/*     label='Input Size' */}
+        {/*     value={`${pipelineRunResult.pipelineRunReport.inputSize} ${ */}
+        {/*       pipelineRunResult.pipelineRunReport.inputSizeUnits || '' */}
+        {/*     }`} */}
+        {/*   /> */}
+        {/* )} */}
         <HeaderItem label='Description' value={pipelineRunResult.jobReport.description || 'No description'} />
       </div>
     </div>

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
@@ -107,14 +107,7 @@ export const JobDetailsHeader = ({ pipelineRunResult }: JobDetailsHeaderProps) =
             </>
           }
         />
-        {/* {pipelineRunResult.pipelineRunReport.inputSize && ( */}
-        {/*   <HeaderItem */}
-        {/*     label='Input Size' */}
-        {/*     value={`${pipelineRunResult.pipelineRunReport.inputSize} ${ */}
-        {/*       pipelineRunResult.pipelineRunReport.inputSizeUnits || '' */}
-        {/*     }`} */}
-        {/*   /> */}
-        {/* )} */}
+
         <HeaderItem label='Description' value={pipelineRunResult.jobReport.description || 'No description'} />
       </div>
     </div>

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
@@ -1,4 +1,4 @@
-import { Icon } from '@terra-ui-packages/components';
+import { Icon, Spinner } from '@terra-ui-packages/components';
 import React from 'react';
 import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
@@ -30,11 +30,14 @@ export const JobIOView = ({ pipelineRunResult }: PipelineRunIOViewProps) => {
         margin: '1rem 0',
       }}
     >
-      <h3 style={{ marginTop: '0.5rem', marginBottom: '1rem' }}>Inputs & Outputs</h3>
+      <h3 style={{ marginTop: '1rem', marginBottom: '1rem' }}>Inputs & Outputs</h3>
       {isLoading ? (
-        <div style={{ color: colors.dark(0.6) }}>Loading...</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', color: colors.dark(0.6) }}>
+          <Spinner size={16} />
+          Loading...
+        </div>
       ) : (
-        <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
+        <div style={{ display: 'flex', gap: '2rem' }}>
           <JobInputsView inputDefinitions={inputDefinitions} pipelineRunResult={pipelineRunResult} />
 
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView.tsx
@@ -35,10 +35,7 @@ export const JobIOView = ({ pipelineRunResult }: PipelineRunIOViewProps) => {
         <div style={{ color: colors.dark(0.6) }}>Loading...</div>
       ) : (
         <div style={{ display: 'flex', gap: '2rem', alignItems: 'center' }}>
-          <JobInputsView
-            inputDefinitions={inputDefinitions}
-            inputs={pipelineRunResult.pipelineRunReport.userInputs || {}}
-          />
+          <JobInputsView inputDefinitions={inputDefinitions} pipelineRunResult={pipelineRunResult} />
 
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <Icon icon='arrowRight' size={24} style={{ color: colors.dark(0.8) }} />

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.test.tsx
@@ -1,7 +1,10 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
-import { mockPipelineWithDetails } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
+import {
+  mockPipelineRunResponse,
+  mockPipelineWithDetails,
+} from 'src/pages/scientificServices/pipelines/utils/mock-utils';
 import { renderWithAppContexts as render } from 'src/testing/test-utils';
 
 import { JobInputsView } from './JobInputsView';
@@ -9,15 +12,25 @@ import { JobInputsView } from './JobInputsView';
 describe('JobInputsView', () => {
   const mockInputDefinitions: PipelineInput[] = mockPipelineWithDetails('array_imputation').inputs;
 
-  const mockInputs = {
-    minDr2ForInclusion: 0.8,
+  const mockInputs: Record<string, string> = {
+    minDr2ForInclusion: '0.8',
     allowChunkFailures: 'true',
     multiSampleVcf: 'gs://bucket/path/to/file.vcf',
     outputBasename: 'outputs',
   };
 
+  const mockRunResponse = mockPipelineRunResponse('SUCCEEDED');
+
+  const mockPipelineRunReport = {
+    ...mockRunResponse,
+    pipelineRunReport: {
+      ...mockRunResponse.pipelineRunReport,
+      userInputs: mockInputs,
+    },
+  };
+
   it('renders all input items when inputs are provided', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={mockInputs} />);
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={mockPipelineRunReport} />);
 
     expect(screen.getByText('minimum imputation quality for inclusion')).toBeInTheDocument();
     expect(screen.getByText('Allow chunk failures')).toBeInTheDocument();
@@ -26,7 +39,7 @@ describe('JobInputsView', () => {
   });
 
   it('renders input values', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={mockInputs} />);
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={mockPipelineRunReport} />);
 
     expect(screen.getByText('gs://bucket/path/to/file.vcf')).toBeInTheDocument();
     expect(screen.getByText('0.8')).toBeInTheDocument();
@@ -35,7 +48,7 @@ describe('JobInputsView', () => {
   });
 
   it('renders input type badges', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={mockInputs} />);
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={mockPipelineRunReport} />);
 
     expect(screen.getByText('file')).toBeInTheDocument();
     expect(screen.getByText('float')).toBeInTheDocument();
@@ -44,7 +57,7 @@ describe('JobInputsView', () => {
   });
 
   it('uses display name when available', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={mockInputs} />);
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={mockPipelineRunReport} />);
 
     expect(screen.getByText('output basename')).toBeInTheDocument();
     expect(screen.queryByText('outputBasename')).not.toBeInTheDocument();
@@ -55,25 +68,57 @@ describe('JobInputsView', () => {
       unknownInput: 'some value',
     };
 
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={inputsWithUnknownKey} />);
+    const reportWithUnknownInput = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        userInputs: inputsWithUnknownKey,
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithUnknownInput} />);
 
     expect(screen.getByText('unknownInput')).toBeInTheDocument();
   });
 
   it('renders "There was an error." when inputs object is empty', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={{}} />);
+    const reportWithEmptyInputs = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        userInputs: {},
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithEmptyInputs} />);
 
     expect(screen.getByText('There was an error.')).toBeInTheDocument();
   });
 
   it('renders "There was an error." when inputs is undefined', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={undefined as any} />);
+    const reportWithUndefinedInputs = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        userInputs: undefined,
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithUndefinedInputs} />);
 
     expect(screen.getByText('There was an error.')).toBeInTheDocument();
   });
 
   it('does not render input items when inputs object is empty', () => {
-    render(<JobInputsView inputDefinitions={mockInputDefinitions} inputs={{}} />);
+    const reportWithEmptyInputs = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        userInputs: {},
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithEmptyInputs} />);
 
     expect(screen.queryByText('minimum imputation quality for inclusion')).not.toBeInTheDocument();
     expect(screen.queryByText('Allow chunk failures')).not.toBeInTheDocument();

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.test.tsx
@@ -125,4 +125,40 @@ describe('JobInputsView', () => {
     expect(screen.queryByText('multi-sample VCF file')).not.toBeInTheDocument();
     expect(screen.queryByText('output basename')).not.toBeInTheDocument();
   });
+
+  it('displays inputSize if available', () => {
+    const reportWithInputSize = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        inputSize: 400,
+        inputSizeUnits: 'samples',
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithInputSize} />);
+
+    expect(screen.getByText('Input Size: 400 samples')).toBeInTheDocument();
+  });
+
+  it('does not display inputSize if not available', () => {
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={mockPipelineRunReport} />);
+
+    expect(screen.queryByText(/Input Size:/)).not.toBeInTheDocument();
+  });
+
+  it('just displays number when inputSizeUnits is not available', () => {
+    const reportWithInputSizeNoUnits = {
+      ...mockRunResponse,
+      pipelineRunReport: {
+        ...mockRunResponse.pipelineRunReport,
+        inputSize: 250,
+        inputSizeUnits: undefined,
+      },
+    };
+
+    render(<JobInputsView inputDefinitions={mockInputDefinitions} pipelineRunResult={reportWithInputSizeNoUnits} />);
+
+    expect(screen.getByText('Input Size: 250')).toBeInTheDocument();
+  });
 });

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.tsx
@@ -38,11 +38,38 @@ export const JobInputsView = ({ inputDefinitions, inputs }: JobInputsProps) => {
 
   return (
     <div style={{ flex: 1 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
-        <h4 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>Inputs</h4>
-        <TooltipTrigger content='Inputs include both values you provided and defaults for any parameters you did not specify.'>
-          <Icon icon='help' size={16} style={{ color: colors.dark(0.55) }} />
-        </TooltipTrigger>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          marginBottom: '1rem',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <h4 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>Inputs</h4>
+          <TooltipTrigger content='Inputs include both values you provided and defaults for any parameters you did not specify.'>
+            <Icon icon='help' size={16} style={{ color: colors.dark(0.55) }} />
+          </TooltipTrigger>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            backgroundColor: 'white',
+            padding: '0.5rem 0.75rem',
+            border: '1px solid #D8D9DC',
+            borderRadius: '20px',
+            fontWeight: 500,
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <Icon icon='tachometer' size={16} style={{ color: colors.dark(0.55) }} />
+            Input Size: 50 samples
+          </div>
+        </div>
       </div>
       {hasInputs ? (
         <div>

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobInputsView.tsx
@@ -1,6 +1,6 @@
 import { Icon, TooltipTrigger } from '@terra-ui-packages/components';
 import React, { ReactNode } from 'react';
-import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { PipelineInput, PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import { PipelineErrorMessage } from 'src/pages/scientificServices/pipelines/common/PipelineErrorMessage';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
@@ -30,11 +30,13 @@ const InputItem = ({
 
 interface JobInputsProps {
   inputDefinitions: PipelineInput[];
-  inputs: Record<string, any>;
+  pipelineRunResult: PipelineRunResponse;
 }
 
-export const JobInputsView = ({ inputDefinitions, inputs }: JobInputsProps) => {
+export const JobInputsView = ({ inputDefinitions, pipelineRunResult }: JobInputsProps) => {
+  const inputs = pipelineRunResult.pipelineRunReport.userInputs || {};
   const hasInputs = inputs && Object.keys(inputs).length > 0;
+  const inputSize = pipelineRunResult.pipelineRunReport.inputSize;
 
   return (
     <div style={{ flex: 1 }}>
@@ -53,23 +55,25 @@ export const JobInputsView = ({ inputDefinitions, inputs }: JobInputsProps) => {
             <Icon icon='help' size={16} style={{ color: colors.dark(0.55) }} />
           </TooltipTrigger>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            backgroundColor: 'white',
-            padding: '0.5rem 0.75rem',
-            border: '1px solid #D8D9DC',
-            borderRadius: '20px',
-            fontWeight: 500,
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-            <Icon icon='tachometer' size={16} style={{ color: colors.dark(0.55) }} />
-            Input Size: 50 samples
+        {inputSize && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              backgroundColor: 'white',
+              padding: '0.5rem 0.75rem',
+              border: '1px solid #D8D9DC',
+              borderRadius: '20px',
+              fontWeight: 500,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+              <Icon icon='tachometer' size={16} style={{ color: colors.dark(0.55) }} />
+              Input Size: {inputSize} {pipelineRunResult.pipelineRunReport.inputSizeUnits || ''}
+            </div>
           </div>
-        </div>
+        )}
       </div>
       {hasInputs ? (
         <div>
@@ -90,7 +94,7 @@ export const JobInputsView = ({ inputDefinitions, inputs }: JobInputsProps) => {
                   label={inputDef?.displayName || key}
                   value={<code>{value}</code>}
                   tooltip={inputDef?.description || 'No description available for this input'}
-                  inputType={inputDef?.type || 'STRING'}
+                  inputType={inputDef?.type || 'Unknown'}
                 />
               </div>
             );

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
@@ -79,12 +79,25 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
         }}
       >
         <h4 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>Outputs</h4>
-        {outputExpirationDate && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-            <Icon icon='clock' size={16} style={{ color: colors.dark(0.55) }} />
-            {outputExpirationText}
-          </div>
-        )}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            backgroundColor: 'white',
+            padding: '0.5rem 0.75rem',
+            border: '1px solid #D8D9DC',
+            borderRadius: '20px',
+            fontWeight: 500,
+          }}
+        >
+          {outputExpirationDate && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+              <Icon icon='clock' size={16} style={{ color: colors.dark(0.55) }} />
+              {outputExpirationText}
+            </div>
+          )}
+        </div>
       </div>
       {hasOutputs ? (
         <div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-784

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds inputSize to the Job Details page, in the Inputs section

### Why
- Users want to be able to see how many samples (or 'things') they submitted, particularly in the case where it's below the minimum quota threshold. 

Before:
<img width="3024" height="1912" alt="screencapture-localhost-3000-2026-01-22-14_52_19" src="https://github.com/user-attachments/assets/3249fdb4-ae4b-4c4b-9449-3ea7d25058f9" />


After:
<img width="3024" height="1960" alt="screencapture-localhost-3000-2026-01-22-21_30_53" src="https://github.com/user-attachments/assets/f9146519-9aff-47c2-bfe5-bfe5481c5ccc" />


### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
