### PR TITLE
[TSPS-808] Hide entire container div when no output expiration date is given

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
@@ -79,25 +79,25 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
         }}
       >
         <h4 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>Outputs</h4>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '0.5rem',
-            backgroundColor: 'white',
-            padding: '0.5rem 0.75rem',
-            border: '1px solid #D8D9DC',
-            borderRadius: '20px',
-            fontWeight: 500,
-          }}
-        >
-          {outputExpirationDate && (
+        {outputExpirationDate && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              backgroundColor: 'white',
+              padding: '0.5rem 0.75rem',
+              border: '1px solid #D8D9DC',
+              borderRadius: '20px',
+              fontWeight: 500,
+            }}
+          >
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
               <Icon icon='clock' size={16} style={{ color: colors.dark(0.55) }} />
               {outputExpirationText}
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
       {hasOutputs ? (
         <div>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-808

<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

The container div for the output expiration date was still present in cases where it shouldn't have been.

Before
<img width="1098" height="395" alt="Screenshot 2026-02-03 at 3 28 26 PM" src="https://github.com/user-attachments/assets/ed16c469-576c-444a-9d09-cc9e472fa9de" />


After
<img width="1099" height="402" alt="Screenshot 2026-02-03 at 3 28 04 PM" src="https://github.com/user-attachments/assets/1e30dc48-44f6-47f2-bcd3-c51c73971297" />

After (expiration still visible -- there are tests that cover this case)
<img width="1091" height="484" alt="Screenshot 2026-02-03 at 3 30 38 PM" src="https://github.com/user-attachments/assets/9851b624-956a-4432-89ed-0f3fbe4cc79a" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
