### PR TITLE
[FE-420] Remove gov shutdown message from BDC branded UI

### DIFF
--- a/src/libs/brands.tsx
+++ b/src/libs/brands.tsx
@@ -202,6 +202,7 @@ export const brands: Record<string, BrandConfiguration> = {
       <>
         NHLBI BioData Catalyst (BDC) is a project powered by Terra for biomedical researchers to access data, run
         analysis tools, and collaborate.
+        {/** The language below is added during a government shutdown as requested by NIH. Uncomment when needed.
         <br />
         <br />
         Because of a lapse in government funding, the information on this website may not be up to date, transactions
@@ -215,6 +216,7 @@ export const brands: Record<string, BrandConfiguration> = {
         <a href='https://opm.gov/' target='_blank' rel='noopener noreferrer'>
           opm.gov.
         </a>
+        */}
       </>
     ),
     hostName: 'terra.biodatacatalyst.nhlbi.nih.gov',


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/fe-420

## Summary of changes:
removing the message that was added to the BDC brand during the government shutdown

instead of removing the actual message from the code, i just commented it out so it's easier to re-add next time we need it.

### Before
<img width="1136" height="539" alt="image" src="https://github.com/user-attachments/assets/2ea7710c-5f2d-4de6-8d28-f8a88bc986ac" />

### After
<img width="1676" height="700" alt="image" src="https://github.com/user-attachments/assets/3d338ec8-8bbf-49c6-b66d-2a1dda17e940" />


### Testing strategy
tested on local UI
`window.configOverridesStore.set({ brand: 'bioDataCatalyst' });`

