### PR TITLE
[CTM-321] Load both summary and policies on button click

### DIFF
--- a/src/support/LookupSummaryAndPolicies.tsx
+++ b/src/support/LookupSummaryAndPolicies.tsx
@@ -49,11 +49,8 @@ export const LookupSummaryAndPolicies = (props: ResourceTypeSummaryProps) => {
       };
     }
     // Default behavior for workspace ID lookup
-    return {
-      ...props,
-      fqResourceId: { resourceId, resourceTypeName: props.fqResourceId.resourceTypeName },
-    };
-  }, [props, resourceId, googleProjectId, isGoogleProjectLookup, currentResourceType]);
+    return props;
+  }, [props, googleProjectId, isGoogleProjectLookup, currentResourceType]);
 
   // event hook to clear the resourceId when resourceType changes
   React.useEffect(() => {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-321

**What:**
In the support summary page, load both summary and policy info when the "Load by" button is clicked (instead of loading summary info after a resource id is typed in and policy info on button click).

**How:**
Summary from Claude code:
 - The supportSummaryProps memo now returns the original props for the default case instead of creating a new object with the local resourceId state
 - Removed resourceId from the memo's dependency array since it's no longer used
 - The local resourceId state now only controls the input field value
 - Both SupportSummary and ResourcePolicies will wait for the button click to update the URL, which triggers the actual data loading

The new UX flow:
 1. User types in the ID field → input updates but nothing loads
 2. User clicks "Load By ID" or presses Enter → URL updates → both summary and policies load together

**Why:**
It was not clear that you had to click "Load by Id" to see policy information because the summary information was loaded immediately after typing in an id.

**Testing strategy**
Manual testing running this branch locally