### PR TITLE
[TSPS-805] Add sharing details and instructions for cloud inputs

### DIFF
--- a/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
+++ b/src/pages/scientificServices/pipelines/common/zendeskUtils.tsx
@@ -6,6 +6,7 @@ export enum DocsKey {
   ABOUT_SERVICE = 'ABOUT_SERVICE',
   INPUT_REQ = 'INPUT_REQ',
   QUOTA_DETAILS = 'QUOTA_DETAILS',
+  CLOUD_INPUTS = 'CLOUD_INPUTS',
 }
 
 // Mapping of documentation keys to their respective Zendesk URLs
@@ -14,6 +15,7 @@ const ZENDESK_PAGES: Record<DocsKey, string> = {
   ABOUT_SERVICE: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/39901941351323',
   INPUT_REQ: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/40161675448859',
   QUOTA_DETAILS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/39903092619035',
+  CLOUD_INPUTS: 'https://broadscientificservices.zendesk.com/hc/en-us/articles/47099858889243',
 };
 
 // Retrieve the Zendesk URL based on the provided documentation key

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -270,7 +270,7 @@ describe('RunJob Component', () => {
 
     // Now check the sharing confirmation checkbox
     const sharingConfirmationCheckbox = screen.getByRole('checkbox', {
-      name: /I confirm that I have shared this file with Broad Scientific Services/,
+      name: /I have shared this file with Broad Scientific Services/,
     });
     await user.click(sharingConfirmationCheckbox);
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -208,7 +208,7 @@ describe('RunJob Component', () => {
   it('validates required fields before allowing submission', async () => {
     render(<RunJob />);
 
-    // Wait for submit button to appear, indicating page has loaded
+    // Wait for submit button to appear
     await waitFor(() => {
       expect(screen.getByText('Submit')).toBeInTheDocument();
     });
@@ -234,6 +234,47 @@ describe('RunJob Component', () => {
     await selectAndUploadLocalFile('test.vcf.gz');
 
     // the submit button should be enabled now that all required fields are filled and valid
+    expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('disables the submit button if cloud file is selected without sharing confirmation', async () => {
+    const user = userEvent.setup();
+    render(<RunJob />);
+
+    // Wait for submit button to appear
+    await waitFor(() => {
+      expect(screen.getByText('Submit')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+    });
+
+    const submitButton = screen.getByText('Submit');
+
+    // Fill in the output prefix (required field)
+    const outputPrefixInput = screen.getByLabelText('output basename text input');
+    await user.type(outputPrefixInput, 'test_output');
+    expect(outputPrefixInput).toHaveValue('test_output');
+
+    // Select cloud storage as the source
+    const selectCloudInputButton = screen.getByText('Google Cloud Storage');
+    await user.click(selectCloudInputButton);
+
+    // Enter a valid GCS path
+    const gcsPathInput = screen.getByPlaceholderText('gs://bucket/path/to/file.vcf.gz');
+    await user.type(gcsPathInput, 'gs://my-bucket/data/multiSampleVcf.vcf.gz');
+
+    // At this point, submit button should still be disabled because sharing confirmation is unchecked
+    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+
+    // Now check the sharing confirmation checkbox
+    const sharingConfirmationCheckbox = screen.getByRole('checkbox', {
+      name: /I confirm that I have shared this file with Broad Scientific Services/,
+    });
+    await user.click(sharingConfirmationCheckbox);
+
+    // Now the submit button should be enabled
     expect(submitButton).not.toHaveAttribute('aria-disabled', 'true');
   });
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -47,6 +47,7 @@ export const RunJob = () => {
   const [runDescription, setRunDescription] = useState<string>('');
   const [selectedUserInputs, setSelectedUserInputs] = useState<Record<string, any>>({});
   const [validationErrors, setValidationErrors] = useState<Record<string, ReactNode | undefined>>({});
+  const [sharingConfirmedFiles, setSharingConfirmedFiles] = useState<Record<string, boolean>>({});
 
   // Submission state
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
@@ -70,7 +71,12 @@ export const RunJob = () => {
         if (input.type === 'FILE') {
           // Allow either a File object (local upload) or a string (gs cloud path)
           if (typeof value === 'string') {
-            return value.startsWith('gs://') && value.endsWith(input.fileSuffix || '');
+            // For GCS paths, require sharing confirmation
+            return (
+              value.startsWith('gs://') &&
+              value.endsWith(input.fileSuffix || '') &&
+              sharingConfirmedFiles[input.name] === true
+            );
           }
           return value instanceof File && value.name && value.name.endsWith(input.fileSuffix || '');
         }
@@ -92,6 +98,13 @@ export const RunJob = () => {
         [inputName]: error,
       };
     });
+  };
+
+  const handleSharingConfirmationChange = (inputName: string, isConfirmed: boolean) => {
+    setSharingConfirmedFiles((prev) => ({
+      ...prev,
+      [inputName]: isConfirmed,
+    }));
   };
 
   async function onUploadComplete(jobId: string) {
@@ -343,6 +356,7 @@ export const RunJob = () => {
                           [input.name]: file,
                         }));
                       }}
+                      onSharingConfirmationChange={handleSharingConfirmationChange}
                     />
                   );
                 })}

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -33,6 +33,7 @@ import {
   startPipelineRun,
   uploadPipelineFiles,
 } from 'src/pages/scientificServices/pipelines/utils/submission-utils';
+import { GCS_PATH_VALIDATION_REGEX } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 
 export const RunJob = () => {
   const [pipelineVersionOptions, setPipelineVersionOptions] = useState<{ value: Pipeline; label: string }[]>([]);
@@ -73,9 +74,9 @@ export const RunJob = () => {
           if (typeof value === 'string') {
             // For GCS paths, require sharing confirmation
             return (
-              value.startsWith('gs://') &&
+              GCS_PATH_VALIDATION_REGEX.test(value) &&
               value.endsWith(input.fileSuffix || '') &&
-              sharingConfirmedFiles[input.name] === true
+              sharingConfirmedFiles[input.name]
             );
           }
           return value instanceof File && value.name && value.name.endsWith(input.fileSuffix || '');

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { BucketConsoleLink } from './BucketConsoleLink';
+
+describe('BucketConsoleLink', () => {
+  it('renders nothing when cloudPath is undefined', () => {
+    const { container } = render(<BucketConsoleLink />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when cloudPath is empty string', () => {
+    const { container } = render(<BucketConsoleLink cloudPath='' />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when cloudPath does not have a slash after bucket name', () => {
+    const { container } = render(<BucketConsoleLink cloudPath='gs://my-bucket' />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders console link when cloudPath is valid', () => {
+    render(<BucketConsoleLink cloudPath='gs://my-bucket/path/to/file' />);
+    const link = screen.getByText(/View bucket in Google Cloud Console/);
+    expect(link).toBeInTheDocument();
+  });
+
+  it('creates correct Google Cloud Console URL', () => {
+    render(<BucketConsoleLink cloudPath='gs://my-bucket/path/to/file' />);
+    const link = screen.getByRole('link') as HTMLAnchorElement;
+    expect(link.href).toBe('https://console.cloud.google.com/storage/browser/my-bucket');
+  });
+});

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink.tsx
@@ -1,0 +1,39 @@
+import { Icon } from '@terra-ui-packages/components';
+import React from 'react';
+
+interface RenderBucketConsoleLinkProps {
+  cloudPath?: string;
+}
+
+const extractBucketName = (path: string): string | null => {
+  const match = path.match(/^gs:\/\/([a-z0-9._-]+)\/.*$/);
+  return match ? match[1] : null;
+};
+
+export const BucketConsoleLink: React.FC<RenderBucketConsoleLinkProps> = ({ cloudPath }) => {
+  const bucketName = cloudPath ? extractBucketName(cloudPath) : null;
+  const consoleUrl = bucketName ? `https://console.cloud.google.com/storage/browser/${bucketName}` : null;
+
+  if (!consoleUrl) {
+    return null;
+  }
+
+  return (
+    <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid #d0d0d0' }}>
+      <a
+        href={consoleUrl}
+        target='_blank'
+        rel='noreferrer'
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          color: '#46A3E9',
+          textDecoration: 'none',
+        }}
+      >
+        View bucket in Google Cloud Console <Icon icon='pop-out' />
+      </a>
+    </div>
+  );
+};

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.test.tsx
@@ -274,7 +274,7 @@ describe('GcsFileInput', () => {
       renderWithAppContexts(<GcsFileInput {...defaultProps} />);
 
       const checkbox = screen.getByRole('checkbox', {
-        name: /I confirm that I have shared this file with Broad Scientific Services/,
+        name: /I have shared this file with Broad Scientific Services/,
       });
       expect(checkbox).toBeInTheDocument();
       expect(checkbox).not.toBeChecked();
@@ -291,7 +291,7 @@ describe('GcsFileInput', () => {
       );
 
       const checkbox = screen.getByRole('checkbox', {
-        name: /I confirm that I have shared this file with Broad Scientific Services/,
+        name: /I have shared this file with Broad Scientific Services/,
       });
 
       await userEvent.click(checkbox);

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.test.tsx
@@ -2,8 +2,25 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { renderWithAppContexts } from 'src/testing/test-utils';
 
 import { GcsFileInput } from './GcsFileInput';
+
+jest.mock('src/profile/personal-info/useProxyGroup', () => ({
+  useProxyGroup: () => ({
+    proxyGroup: {
+      status: 'Ready' as const,
+      state: 'PROXY_1234567890@example.com',
+    },
+  }),
+}));
+
+jest.mock('src/libs/state', () => ({
+  ...jest.requireActual('src/libs/state'),
+  getTerraUser: () => ({
+    email: 'test@example.com',
+  }),
+}));
 
 const mockInput: PipelineInput = {
   name: 'multiSampleVcf',
@@ -201,6 +218,91 @@ describe('GcsFileInput', () => {
       await userEvent.type(input, testPath);
 
       expect(input.value).toBe(testPath);
+    });
+  });
+
+  describe('sharing instructions', () => {
+    it('renders the sharing instructions button', () => {
+      render(<GcsFileInput {...defaultProps} />);
+      expect(screen.getByText('View sharing instructions')).toBeInTheDocument();
+    });
+
+    it('expands sharing instructions when button is clicked', async () => {
+      renderWithAppContexts(<GcsFileInput {...defaultProps} />);
+      const button = screen.getByText('View sharing instructions');
+
+      await userEvent.click(button);
+
+      expect(
+        screen.getByText(
+          'To ensure that your input file can be properly accessed by Broad Scientific Services, please share your input file with the following accounts:'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByText('Service account')).toBeInTheDocument();
+      expect(screen.getByText('Your proxy group')).toBeInTheDocument();
+    });
+
+    it('displays service account email', async () => {
+      renderWithAppContexts(<GcsFileInput {...defaultProps} />);
+      const button = screen.getByText('View sharing instructions');
+
+      await userEvent.click(button);
+
+      expect(screen.getByText('broad-scientific-services@dev.test.firecloud.org')).toBeInTheDocument();
+    });
+
+    it('displays proxy group email', async () => {
+      renderWithAppContexts(<GcsFileInput {...defaultProps} />);
+      const button = screen.getByText('View sharing instructions');
+
+      await userEvent.click(button);
+
+      expect(screen.getByText('PROXY_1234567890@example.com')).toBeInTheDocument();
+    });
+
+    it('renders the "Learn more" link', async () => {
+      renderWithAppContexts(<GcsFileInput {...defaultProps} />);
+      const button = screen.getByText('View sharing instructions');
+
+      await userEvent.click(button);
+
+      expect(screen.getByText('Learn more')).toBeInTheDocument();
+      expect(screen.getByText(/about file sharing requirements/)).toBeInTheDocument();
+    });
+
+    it('renders checkbox for sharing confirmation', () => {
+      renderWithAppContexts(<GcsFileInput {...defaultProps} />);
+
+      const checkbox = screen.getByRole('checkbox', {
+        name: /I confirm that I have shared this file with Broad Scientific Services/,
+      });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it('calls onSharingConfirmationChange when checkbox is toggled', async () => {
+      const onSharingConfirmationChange = jest.fn();
+      const { rerender } = renderWithAppContexts(
+        <GcsFileInput
+          {...defaultProps}
+          onSharingConfirmationChange={onSharingConfirmationChange}
+          sharingConfirmed={false}
+        />
+      );
+
+      const checkbox = screen.getByRole('checkbox', {
+        name: /I confirm that I have shared this file with Broad Scientific Services/,
+      });
+
+      await userEvent.click(checkbox);
+      expect(onSharingConfirmationChange).toHaveBeenLastCalledWith(true);
+
+      rerender(
+        <GcsFileInput {...defaultProps} onSharingConfirmationChange={onSharingConfirmationChange} sharingConfirmed />
+      );
+
+      await userEvent.click(checkbox);
+      expect(onSharingConfirmationChange).toHaveBeenLastCalledWith(false);
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -44,7 +44,7 @@ const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | n
   return (
     <div style={{ color: '#d00', display: 'flex', alignItems: 'center' }}>
       <Icon icon='warning-standard' size={16} style={{ color: '#d00', marginRight: '0.25rem' }} />
-      Failed to load proxy group information
+      Failed to load proxy group information. Please refresh the page.
     </div>
   );
 };

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -54,15 +54,24 @@ interface SharingInstructionsProps {
   onToggleExpand: () => void;
   proxyGroupEmail: string | null;
   isLoadingProxyGroup: boolean;
+  cloudPath?: string;
 }
+
+const extractBucketName = (path: string): string | null => {
+  const match = path.match(/^gs:\/\/([a-z0-9._-]+)(\/|$)/);
+  return match ? match[1] : null;
+};
 
 const SharingInstructions: React.FC<SharingInstructionsProps> = ({
   isExpanded,
   onToggleExpand,
   proxyGroupEmail,
   isLoadingProxyGroup,
+  cloudPath,
 }) => {
   const serviceAccountEmail = getTeaspoonsServiceAccountEmail();
+  const bucketName = cloudPath ? extractBucketName(cloudPath) : null;
+  const consoleUrl = bucketName ? `https://console.cloud.google.com/storage/browser/${bucketName}` : null;
 
   return (
     <>
@@ -151,6 +160,24 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
               Copy all
             </ClipboardButton>
           </div>
+          {consoleUrl && (
+            <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid #d0d0d0' }}>
+              <a
+                href={consoleUrl}
+                target='_blank'
+                rel='noreferrer'
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  color: '#46A3E9',
+                  textDecoration: 'none',
+                }}
+              >
+                View bucket in Google Cloud Console <Icon icon='pop-out' />
+              </a>
+            </div>
+          )}
         </div>
       )}
     </>
@@ -275,6 +302,7 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
             onToggleExpand={() => setShowDetails(!showDetails)}
             proxyGroupEmail={proxyGroupEmail}
             isLoadingProxyGroup={isLoadingProxyGroup}
+            cloudPath={cloudPath}
           />
         </div>
       </div>

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -142,7 +142,7 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
             }}
           >
             <div style={{ fontSize: '14px', color: '#666' }}>
-              <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more</ZendeskLink> about file sharing requirements.
+              <ZendeskLink docsKey={DocsKey.CLOUD_INPUTS}>Learn more</ZendeskLink> about file sharing requirements.
             </div>
             <ClipboardButton
               text={`${serviceAccountEmail}, ${proxyGroupEmail || ''}`}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -11,9 +11,9 @@ const SERVICE_ACCOUNT_EMAIL = 'broad-scientific-services@firecloud.org';
 const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | null) => {
   if (isLoading) {
     return (
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flex: 1 }}>
+      <div style={{ display: 'flex', alignItems: 'center', flex: 1 }}>
         <Spinner size={16} />
-        <span style={{ fontSize: '12px', color: '#666' }}>Loading proxy group...</span>
+        <span style={{ color: '#666' }}>Loading proxy group...</span>
       </div>
     );
   }
@@ -40,7 +40,12 @@ const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | n
     );
   }
 
-  return <span style={{ fontSize: '12px', color: '#d00' }}>Failed to load proxy group email</span>;
+  return (
+    <div style={{ color: '#d00', display: 'flex', alignItems: 'center' }}>
+      <Icon icon='warning-standard' size={16} style={{ color: '#d00', marginRight: '0.25rem' }} />
+      Failed to load proxy group information
+    </div>
+  );
 };
 
 interface SharingInstructionsProps {
@@ -111,7 +116,7 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
               fontWeight: 600,
             }}
           >
-            Your proxy group:
+            Your proxy group
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
             {renderProxyGroupContent(isLoadingProxyGroup, proxyGroupEmail)}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -3,11 +3,10 @@ import React, { ReactNode, useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
+import { getConfig } from 'src/libs/config';
 import { getTerraUser } from 'src/libs/state';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
 import { useProxyGroup } from 'src/profile/personal-info/useProxyGroup';
-
-const SERVICE_ACCOUNT_EMAIL = 'broad-scientific-services@firecloud.org';
 
 const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | null) => {
   if (isLoading) {
@@ -62,6 +61,8 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
   proxyGroupEmail,
   isLoadingProxyGroup,
 }) => {
+  const serviceAccountEmail = getTeaspoonsServiceAccountEmail();
+
   return (
     <>
       <div style={{ marginTop: '0.5rem' }}>
@@ -86,12 +87,20 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
         </button>
       </div>
       {isExpanded && (
-        <div style={{ marginTop: '0.5rem', padding: '0.75rem', backgroundColor: '#f5f5f5', borderRadius: '4px' }}>
+        <div
+          style={{
+            marginTop: '0.5rem',
+            padding: '0.75rem',
+            backgroundColor: '#f5f5f5',
+            borderRadius: '4px',
+            border: '1px solid #e0e0e0',
+          }}
+        >
           <div style={{ fontSize: '14px', color: '#333', marginBottom: '1rem' }}>
             To ensure that your input file can be properly accessed by Broad Scientific Services, please share your
             input file with the following accounts:
           </div>
-          <div style={{ fontSize: '14px', marginBottom: '0.25rem', fontWeight: 600 }}>Service account</div>
+          <div style={{ fontSize: '14px', fontWeight: 600, marginBottom: '0.5rem' }}>Service account</div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <code
               style={{
@@ -105,14 +114,14 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
                 textOverflow: 'ellipsis',
               }}
             >
-              {SERVICE_ACCOUNT_EMAIL}
+              {serviceAccountEmail}
             </code>
-            <ClipboardButton text={SERVICE_ACCOUNT_EMAIL} />
+            <ClipboardButton text={serviceAccountEmail} />
           </div>
           <div
             style={{
               fontSize: '14px',
-              marginBottom: '0.25rem',
+              marginBottom: '0.5rem',
               marginTop: '1rem',
               fontWeight: 600,
             }}
@@ -122,8 +131,24 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
             {renderProxyGroupContent(isLoadingProxyGroup, proxyGroupEmail)}
           </div>
-          <div style={{ fontSize: '14px', color: '#666' }}>
-            <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more</ZendeskLink> about file sharing requirements.
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingTop: '0.5rem',
+              gap: '0.5rem',
+            }}
+          >
+            <div style={{ fontSize: '14px', color: '#666' }}>
+              <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more</ZendeskLink> about file sharing requirements.
+            </div>
+            <ClipboardButton
+              text={`${serviceAccountEmail}, ${proxyGroupEmail || ''}`}
+              style={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}
+            >
+              Copy all
+            </ClipboardButton>
           </div>
         </div>
       )}
@@ -254,4 +279,12 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
       </div>
     </div>
   );
+};
+
+const getTeaspoonsServiceAccountEmail = (): string => {
+  if (getConfig().isProd) {
+    return 'broad-scientific-services@firecloud.org';
+  }
+
+  return 'broad-scientific-services@dev.test.firecloud.org';
 };

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -1,10 +1,11 @@
 import { Icon, Spinner } from '@terra-ui-packages/components';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
-import { User } from 'src/libs/ajax/User';
 import colors from 'src/libs/colors';
+import { getTerraUser } from 'src/libs/state';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
+import { useProxyGroup } from 'src/profile/personal-info/useProxyGroup';
 
 const SERVICE_ACCOUNT_EMAIL = 'broad-scientific-services@firecloud.org';
 
@@ -151,31 +152,14 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
 }) => {
   const [cloudPath, setCloudPath] = useState('');
   const [showDetails, setShowDetails] = useState(false);
-  const [proxyGroupEmail, setProxyGroupEmail] = useState<string | null>(null);
-  const [isLoadingProxyGroup, setIsLoadingProxyGroup] = useState(true);
   const { isRequired, fileSuffix } = input;
   const GCS_PATH_VALIDATION_REGEX = /^gs:\/\/[a-z0-9._-]+\/.+/;
 
-  // Fetch the proxy group email on component mount
-  useEffect(() => {
-    const fetchProxyGroup = async () => {
-      try {
-        setIsLoadingProxyGroup(true);
-        const userApi = User();
-        const profile = await userApi.profile.get();
-        const email = profile.contactEmail || '';
-        const result = await userApi.getProxyGroup(email);
-        setProxyGroupEmail(result);
-      } catch (error) {
-        console.error('Failed to fetch proxy group email:', error);
-        setProxyGroupEmail(null);
-      } finally {
-        setIsLoadingProxyGroup(false);
-      }
-    };
+  const userEmail = getTerraUser().email;
+  const { proxyGroup } = useProxyGroup(userEmail);
 
-    fetchProxyGroup();
-  }, []);
+  const proxyGroupEmail = proxyGroup.status === 'Ready' ? proxyGroup.state : null;
+  const isLoadingProxyGroup = proxyGroup.status === 'Loading';
 
   const validateCloudPath = (path: string) => {
     if (!path) {

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -265,8 +265,8 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
               onChange={(e) => onSharingConfirmationChange?.(e.target.checked)}
               style={{ marginTop: '0.25rem', cursor: 'pointer' }}
             />
-            <span style={{ fontSize: '14px', lineHeight: '1.4', flex: 1 }}>
-              I confirm that I have shared this file with Broad Scientific Services.{' '}
+            <span style={{ fontSize: '14px', flex: 1 }}>
+              I have shared this file with Broad Scientific Services.{' '}
               <span style={{ color: colors.danger(), fontWeight: 'bold' }}>*</span>
             </span>
           </label>

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -1,7 +1,129 @@
-import React, { ReactNode, useState } from 'react';
+import { Icon, Spinner } from '@terra-ui-packages/components';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { ClipboardButton } from 'src/components/ClipboardButton';
 import { PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { User } from 'src/libs/ajax/User';
 import colors from 'src/libs/colors';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
+
+const SERVICE_ACCOUNT_EMAIL = 'broad-scientific-services@firecloud.org';
+
+const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | null) => {
+  if (isLoading) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flex: 1 }}>
+        <Spinner size={16} />
+        <span style={{ fontSize: '12px', color: '#666' }}>Loading proxy group...</span>
+      </div>
+    );
+  }
+
+  if (proxyGroupEmail) {
+    return (
+      <>
+        <code
+          style={{
+            flex: 1,
+            padding: '0.5rem',
+            backgroundColor: '#fff',
+            border: '1px solid #e0e0e0',
+            borderRadius: '4px',
+            fontSize: '12px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {proxyGroupEmail}
+        </code>
+        <ClipboardButton text={proxyGroupEmail} />
+      </>
+    );
+  }
+
+  return <span style={{ fontSize: '12px', color: '#d00' }}>Failed to load proxy group email</span>;
+};
+
+interface SharingInstructionsProps {
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  proxyGroupEmail: string | null;
+  isLoadingProxyGroup: boolean;
+}
+
+const SharingInstructions: React.FC<SharingInstructionsProps> = ({
+  isExpanded,
+  onToggleExpand,
+  proxyGroupEmail,
+  isLoadingProxyGroup,
+}) => {
+  return (
+    <>
+      <div style={{ marginTop: '0.5rem' }}>
+        <button
+          type='button'
+          onClick={onToggleExpand}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#46A3E9',
+            cursor: 'pointer',
+            fontSize: '14px',
+            textDecoration: 'underline',
+            padding: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+          }}
+        >
+          <Icon icon={isExpanded ? 'angle-down' : 'angle-right'} size={16} style={{ flexShrink: 0 }} />
+          View sharing instructions
+        </button>
+      </div>
+      {isExpanded && (
+        <div style={{ marginTop: '0.5rem', padding: '0.75rem', backgroundColor: '#f5f5f5', borderRadius: '4px' }}>
+          <div style={{ fontSize: '14px', color: '#333', marginBottom: '1rem' }}>
+            To ensure that your input file can be properly accessed by Broad Scientific Services, please share your
+            input file with the following accounts:
+          </div>
+          <div style={{ fontSize: '14px', marginBottom: '0.25rem', fontWeight: 600 }}>Service account</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <code
+              style={{
+                flex: 1,
+                padding: '0.5rem',
+                backgroundColor: '#fff',
+                border: '1px solid #e0e0e0',
+                borderRadius: '4px',
+                fontSize: '12px',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {SERVICE_ACCOUNT_EMAIL}
+            </code>
+            <ClipboardButton text={SERVICE_ACCOUNT_EMAIL} />
+          </div>
+          <div
+            style={{
+              fontSize: '14px',
+              marginBottom: '0.25rem',
+              marginTop: '1rem',
+              fontWeight: 600,
+            }}
+          >
+            Your proxy group:
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '1rem' }}>
+            {renderProxyGroupContent(isLoadingProxyGroup, proxyGroupEmail)}
+          </div>
+          <div style={{ fontSize: '14px', color: '#666' }}>
+            <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more</ZendeskLink> about file sharing requirements.
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
 
 interface GcsFileInputProps {
   input: PipelineInput;
@@ -9,6 +131,8 @@ interface GcsFileInputProps {
   onFileSelect: (file: string | null) => void;
   onValidation: (error?: ReactNode) => void;
   onBackToSelection: () => void;
+  onSharingConfirmationChange?: (isConfirmed: boolean) => void;
+  sharingConfirmed?: boolean;
 }
 
 export const GcsFileInput: React.FC<GcsFileInputProps> = ({
@@ -17,10 +141,36 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
   onFileSelect,
   onValidation,
   onBackToSelection,
+  onSharingConfirmationChange,
+  sharingConfirmed,
 }) => {
   const [cloudPath, setCloudPath] = useState('');
+  const [showDetails, setShowDetails] = useState(false);
+  const [proxyGroupEmail, setProxyGroupEmail] = useState<string | null>(null);
+  const [isLoadingProxyGroup, setIsLoadingProxyGroup] = useState(true);
   const { isRequired, fileSuffix } = input;
   const GCS_PATH_VALIDATION_REGEX = /^gs:\/\/[a-z0-9._-]+\/.+/;
+
+  // Fetch the proxy group email on component mount
+  useEffect(() => {
+    const fetchProxyGroup = async () => {
+      try {
+        setIsLoadingProxyGroup(true);
+        const userApi = User();
+        const profile = await userApi.profile.get();
+        const email = profile.contactEmail || '';
+        const result = await userApi.getProxyGroup(email);
+        setProxyGroupEmail(result);
+      } catch (error) {
+        console.error('Failed to fetch proxy group email:', error);
+        setProxyGroupEmail(null);
+      } finally {
+        setIsLoadingProxyGroup(false);
+      }
+    };
+
+    fetchProxyGroup();
+  }, []);
 
   const validateCloudPath = (path: string) => {
     if (!path) {
@@ -88,9 +238,30 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
           boxSizing: 'border-box',
         }}
       />
-      <div style={{ marginTop: '0.5rem', color: '#666' }}>
-        <ZendeskLink docsKey={DocsKey.INPUT_REQ}>Learn more</ZendeskLink> about providing a valid Google Cloud Storage
-        path.
+      <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'flex-start', gap: '0.5rem' }}>
+        <div style={{ flex: 1 }}>
+          <label
+            htmlFor='sharing-confirmation'
+            style={{ display: 'flex', alignItems: 'flex-start', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              type='checkbox'
+              id='sharing-confirmation'
+              checked={sharingConfirmed || false}
+              onChange={(e) => onSharingConfirmationChange?.(e.target.checked)}
+              style={{ marginTop: '0.25rem', cursor: 'pointer' }}
+            />
+            <span style={{ fontSize: '14px', lineHeight: '1.4', flex: 1 }}>
+              I confirm that I have shared this file with Broad Scientific Services.
+            </span>
+          </label>
+          <SharingInstructions
+            isExpanded={showDetails}
+            onToggleExpand={() => setShowDetails(!showDetails)}
+            proxyGroupEmail={proxyGroupEmail}
+            isLoadingProxyGroup={isLoadingProxyGroup}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -6,6 +6,7 @@ import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { getTerraUser } from 'src/libs/state';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
+import { GCS_PATH_VALIDATION_REGEX } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 import { useProxyGroup } from 'src/profile/personal-info/useProxyGroup';
 
 const renderProxyGroupContent = (isLoading: boolean, proxyGroupEmail: string | null) => {
@@ -178,7 +179,6 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
   const [cloudPath, setCloudPath] = useState('');
   const [showDetails, setShowDetails] = useState(false);
   const { isRequired, fileSuffix } = input;
-  const GCS_PATH_VALIDATION_REGEX = /^gs:\/\/[a-z0-9._-]+\/.+/;
 
   const userEmail = getTerraUser().email;
   const { proxyGroup } = useProxyGroup(userEmail);

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -266,7 +266,8 @@ export const GcsFileInput: React.FC<GcsFileInputProps> = ({
               style={{ marginTop: '0.25rem', cursor: 'pointer' }}
             />
             <span style={{ fontSize: '14px', lineHeight: '1.4', flex: 1 }}>
-              I confirm that I have shared this file with Broad Scientific Services.
+              I confirm that I have shared this file with Broad Scientific Services.{' '}
+              <span style={{ color: colors.danger(), fontWeight: 'bold' }}>*</span>
             </span>
           </label>
           <SharingInstructions

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/GcsFileInput.tsx
@@ -6,6 +6,7 @@ import colors from 'src/libs/colors';
 import { getConfig } from 'src/libs/config';
 import { getTerraUser } from 'src/libs/state';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
+import { BucketConsoleLink } from 'src/pages/scientificServices/pipelines/tabs/run/inputs/file/BucketConsoleLink';
 import { GCS_PATH_VALIDATION_REGEX } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 import { useProxyGroup } from 'src/profile/personal-info/useProxyGroup';
 
@@ -57,11 +58,6 @@ interface SharingInstructionsProps {
   cloudPath?: string;
 }
 
-const extractBucketName = (path: string): string | null => {
-  const match = path.match(/^gs:\/\/([a-z0-9._-]+)(\/|$)/);
-  return match ? match[1] : null;
-};
-
 const SharingInstructions: React.FC<SharingInstructionsProps> = ({
   isExpanded,
   onToggleExpand,
@@ -70,8 +66,6 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
   cloudPath,
 }) => {
   const serviceAccountEmail = getTeaspoonsServiceAccountEmail();
-  const bucketName = cloudPath ? extractBucketName(cloudPath) : null;
-  const consoleUrl = bucketName ? `https://console.cloud.google.com/storage/browser/${bucketName}` : null;
 
   return (
     <>
@@ -160,24 +154,7 @@ const SharingInstructions: React.FC<SharingInstructionsProps> = ({
               Copy all
             </ClipboardButton>
           </div>
-          {consoleUrl && (
-            <div style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid #d0d0d0' }}>
-              <a
-                href={consoleUrl}
-                target='_blank'
-                rel='noreferrer'
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '0.5rem',
-                  color: '#46A3E9',
-                  textDecoration: 'none',
-                }}
-              >
-                View bucket in Google Cloud Console <Icon icon='pop-out' />
-              </a>
-            </div>
-          )}
+          <BucketConsoleLink cloudPath={cloudPath} />
         </div>
       )}
     </>

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileInput.tsx
@@ -93,6 +93,7 @@ interface PipelineInputSelectorProps {
   validationError?: ReactNode;
   onUploadComplete?: () => void;
   setUploadState?: Dispatch<SetStateAction<Record<string, PipelineInputFileUploadState>>>;
+  onSharingConfirmationChange?: (inputName: string, isConfirmed: boolean) => void;
 }
 
 export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
@@ -104,9 +105,16 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
   validationError,
   onUploadComplete,
   setUploadState,
+  onSharingConfirmationChange,
 }) => {
   const { name, displayName, isRequired } = input;
   const [sourceType, setSourceType] = useState<'local' | 'cloud' | null>(null);
+  const [sharingConfirmed, setSharingConfirmed] = useState(false);
+
+  const handleSharingConfirmationChange = (isConfirmed: boolean) => {
+    setSharingConfirmed(isConfirmed);
+    onSharingConfirmationChange?.(name, isConfirmed);
+  };
 
   const handleSourceSelect = (source: 'local' | 'cloud') => {
     setSourceType(source);
@@ -145,6 +153,8 @@ export const PipelineFileInput: React.FC<PipelineInputSelectorProps> = ({
             onFileSelect={onFileSelect}
             onValidation={onValidation}
             onBackToSelection={handleBackToSelection}
+            onSharingConfirmationChange={handleSharingConfirmationChange}
+            sharingConfirmed={sharingConfirmed}
           />
         )}
         {sourceType === 'local' && (

--- a/src/pages/scientificServices/pipelines/utils/upload-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/upload-utils.ts
@@ -2,6 +2,8 @@ import pluralize from 'pluralize';
 import { Dispatch, SetStateAction } from 'react';
 import { PipelineInputFileUploadState } from 'src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileInput';
 
+export const GCS_PATH_VALIDATION_REGEX = /^gs:\/\/[a-z0-9._-]+\/.+/;
+
 // Returns a function that handles progress events for file uploads
 // This function updates the upload state with progress percentage and
 // estimated time remaining using a moving average of upload rates


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-805

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

* Adds a confirmation checkbox that users have to check to confirm that they've followed the sharing instructions
* Adds collapsible instructions to the cloud input component that allows the user to copy the 2 groups to share their file with. Also adds a Copy All button that copies a comma-separated list which the users can paste directly into the GCS console.

Unconfirmed input (submit disabled):
<img width="537" height="317" alt="Screenshot 2026-02-25 at 4 44 18 PM" src="https://github.com/user-attachments/assets/49426c62-6c46-46bc-a1cf-bb08988ef8f5" />


Confirmed input:
<img width="544" height="315" alt="Screenshot 2026-02-25 at 4 44 24 PM" src="https://github.com/user-attachments/assets/98d83889-a6a6-4ad5-9070-41b357aea21c" />


Expanded view of instructions:
<img width="524" height="513" alt="Screenshot 2026-02-25 at 4 44 41 PM" src="https://github.com/user-attachments/assets/9ca966f7-e074-4ed2-afcc-a23c3fcfefe8" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
