### PR TITLE
CTM-351: Update App Engine to nodejs24

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs24
 default_expiration: 2m
 
 handlers:


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-351

The Node 20 App Engine runtime has reached the end of support. This updates to the Node 24 runtime. Node 24 is the current LTS version.

