### PR TITLE
[CTM-392] Bug: Parsing file paths for File Modal

### DIFF
--- a/src/workspace-data/provenance/workspace-data-provenance-utils.js
+++ b/src/workspace-data/provenance/workspace-data-provenance-utils.js
@@ -129,7 +129,12 @@ export const getFileProvenance = async (workspace, fileUrl, { signal } = {}) => 
 
   // Previously, submission roots were `gs://<workspace bucket>/<submission ID>`.
   // Now, they are `gs://<workspace bucket>/submissions/<submission ID>`.
-  if (!(validateUUID(pathParts[0]) || (pathParts[0] === 'submissions' && validateUUID(pathParts[1])))) {
+  // With intermediates/final-outputs split: `gs://<workspace bucket>/submissions/final-outputs/<submission ID>/...` or `.../submissions/intermediates/<submission ID>/...`.
+  const isLegacySubmissionPath = validateUUID(pathParts[0]);
+  const isSubmissionsUuidPath = pathParts[0] === 'submissions' && validateUUID(pathParts[1]);
+  const isSubmissionsSplitPath =
+    pathParts[0] === 'submissions' && (pathParts[1] === 'final-outputs' || pathParts[1] === 'intermediates') && validateUUID(pathParts[2]);
+  if (!(isLegacySubmissionPath || isSubmissionsUuidPath || isSubmissionsSplitPath)) {
     return { type: fileProvenanceTypes.unknown };
   }
 

--- a/src/workspace-data/provenance/workspace-data-provenance-utils.test.js
+++ b/src/workspace-data/provenance/workspace-data-provenance-utils.test.js
@@ -70,6 +70,18 @@ describe('getFileProvenance', () => {
     expect(await getFileProvenance(workspace, 'gs://workspace-bucket/folder/file.txt')).toEqual({ type: fileProvenanceTypes.unknown });
   });
 
+  it('recognizes submission paths under intermediates/final-outputs split', async () => {
+    const submissionId = '8d79470f-7042-4e79-bf67-971adf4e5a4a';
+    expect(await getFileProvenance(workspace, `gs://workspace-bucket/submissions/final-outputs/${submissionId}/file.txt`)).toEqual({
+      type: fileProvenanceTypes.maybeSubmission,
+      submissionId,
+    });
+    expect(await getFileProvenance(workspace, `gs://workspace-bucket/submissions/intermediates/${submissionId}/file.txt`)).toEqual({
+      type: fileProvenanceTypes.maybeSubmission,
+      submissionId,
+    });
+  });
+
   it('returns maybeSubmission for files in a submission directory that are not workflow outputs', async () => {
     expect(await getFileProvenance(workspace, 'gs://workspace-bucket/submissions/8d79470f-7042-4e79-bf67-971adf4e5a4a/file.txt')).toEqual({
       type: fileProvenanceTypes.maybeSubmission,


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-392

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Context: https://broadinstitute.slack.com/archives/CBJJ7U293/p1772741539507429 

### What
- Add support for additional path structure in file parsing for file modal 

### Why
- Users getting unknown message for files that should be known

### Testing strategy
Unit tests
I also checked the workspace where this problem was reported and confirmed that the file URL has this path structure with 'final_outputs' in it

<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
