### PR TITLE
[CTM-382] Data Tables UI - Send the Google Project ID when previewing DRS files

### DIFF
--- a/src/components/igv/IGVFileSelector.js
+++ b/src/components/igv/IGVFileSelector.js
@@ -298,11 +298,7 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   const numSelected = _.countBy('isSelected', selections).true;
   const isSelectionValid = !!numSelected;
 
-  const noRowsMessage = Utils.cond(
-    [isSearchingFiles, () => 'Searching for valid files with indices...'],
-    [isReadOnly && selections.length === 0, () => 'No valid files with indices found. DRS URIs are not available for read-only workspace users.'],
-    [() => true, () => 'No valid files with indices found']
-  );
+  const noRowsMessage = isSearchingFiles ? 'Searching for valid files with indices...' : 'No valid files with indices found';
 
   const cache = new CellMeasurerCache({
     fixedWidth: true,

--- a/src/components/igv/IGVFileSelector.js
+++ b/src/components/igv/IGVFileSelector.js
@@ -6,7 +6,9 @@ import ButtonBar from 'src/components/ButtonBar';
 import { ButtonPrimary, LabeledCheckbox, Link } from 'src/components/common';
 import IGVReferenceSelector, { addIgvRecentlyUsedReference, defaultIgvReference } from 'src/components/igv/IGVReferenceSelector';
 import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
+import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
@@ -282,9 +284,15 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
 
       setSelections(selections);
       setIsSearchingFiles(false);
+      if (isReadOnly) {
+        void Metrics().captureEvent(Events.workspaceDataDrsReadOnlyBlocked, {
+          source: 'igv',
+          ...extractWorkspaceDetails(workspace),
+        });
+      }
     }
     fetchData();
-  }, [workspace, entityType, selectedEntities, setSelections, signal]);
+  }, [workspace, entityType, selectedEntities, setSelections, signal, isReadOnly]);
 
   const toggleSelected = (index) => setSelections(_.update([index, 'isSelected'], (v) => !v));
   const numSelected = _.countBy('isSelected', selections).true;

--- a/src/components/igv/IGVFileSelector.js
+++ b/src/components/igv/IGVFileSelector.js
@@ -82,6 +82,7 @@ const searchDBForIndexFiles = async (workspace, entityType, indexCandidates, sig
 
   const URL_REGEX = /^(gs:\/\/|drs:\/\/|https?:\/\/|ftp:\/\/)/;
 
+  const googleProject = workspace.workspace?.googleProject;
   for (const result of searchResponse.results) {
     const attributeValues = Object.values(result.attributes);
     const match = attributeValues.find((val) => {
@@ -95,7 +96,7 @@ const searchDBForIndexFiles = async (workspace, entityType, indexCandidates, sig
         urlCandidate = attributeValues.find((val) => typeof val === 'string' && URL_REGEX.test(val));
       }
       if (urlCandidate && URL_REGEX.test(urlCandidate)) {
-        return await validateUrl(urlCandidate);
+        return await validateUrl(urlCandidate, signal, googleProject);
       }
     }
   }
@@ -136,9 +137,11 @@ const hasValidIgvExtension = (filename) => {
   return !!base && allFiles.has(extension);
 };
 
-export const getDrsDataObjectMetadata = async (value, fields, signal = undefined) => {
+export const getDrsDataObjectMetadata = async (value, fields, signal = undefined, userProject = undefined) => {
   try {
-    return await DrsUriResolver(signal).getDataObjectMetadata(value, fields);
+    return await DrsUriResolver(signal).getDataObjectMetadata(value, fields, {
+      ...(userProject && { userProject }),
+    });
   } catch {
     return {
       fileName: '',
@@ -147,13 +150,13 @@ export const getDrsDataObjectMetadata = async (value, fields, signal = undefined
   }
 };
 
-export const resolveValidIgvDrsUris = async (values, signal) => {
+export const resolveValidIgvDrsUris = async (values, signal, userProject = undefined) => {
   const igvDrsUris = [];
 
   await Promise.all(
     values.map(async (value) => {
       if (isDrsUri(value)) {
-        const { fileName } = await getDrsDataObjectMetadata(value, ['fileName'], signal);
+        const { fileName } = await getDrsDataObjectMetadata(value, ['fileName'], signal, userProject);
         const isValid = hasValidIgvExtension(fileName);
         if (isValid) {
           igvDrsUris.push(value);
@@ -165,7 +168,7 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
   const igvAccessUrls = [];
   await Promise.all(
     igvDrsUris.map(async (value) => {
-      const { accessUrl } = await getDrsDataObjectMetadata(value, ['accessUrl'], signal);
+      const { accessUrl } = await getDrsDataObjectMetadata(value, ['accessUrl'], signal, userProject);
       igvAccessUrls.push(accessUrl.url);
     })
   );
@@ -173,12 +176,12 @@ export const resolveValidIgvDrsUris = async (values, signal) => {
   return igvAccessUrls;
 };
 
-const validateUrl = async (fileRef) => {
+const validateUrl = async (fileRef, signal = undefined, userProject = undefined) => {
   const isDrs = isDrsUri(fileRef);
   let accessUrl;
 
   if (isDrs) {
-    const result = await getDrsDataObjectMetadata(fileRef, ['accessUrl']);
+    const result = await getDrsDataObjectMetadata(fileRef, ['accessUrl'], signal, userProject);
     accessUrl = result.accessUrl.url;
   } else {
     accessUrl = fileRef;
@@ -219,7 +222,8 @@ export const getValidIgvFiles = async (workspace, entityType, allValues, signal)
     return url;
   });
 
-  const accessUrls = await resolveValidIgvDrsUris(values, signal);
+  const googleProject = workspace.workspace?.googleProject;
+  const accessUrls = await resolveValidIgvDrsUris(values, signal, googleProject);
   for (const accessUrl of accessUrls) {
     const url = new URL(accessUrl);
 

--- a/src/components/igv/IGVFileSelector.js
+++ b/src/components/igv/IGVFileSelector.js
@@ -10,6 +10,7 @@ import { Workspaces } from 'src/libs/ajax/workspaces/Workspaces';
 import { useCancellation } from 'src/libs/react-utils';
 import * as Style from 'src/libs/style';
 import * as Utils from 'src/libs/utils';
+import { canWrite } from 'src/workspaces/utils';
 
 const getStrings = (v) => {
   return Utils.cond([_.isString(v), () => [v]], [!!v?.items, () => _.flatMap(getStrings, v.items)], () => []);
@@ -223,7 +224,8 @@ export const getValidIgvFiles = async (workspace, entityType, allValues, signal)
   });
 
   const googleProject = workspace.workspace?.googleProject;
-  const accessUrls = await resolveValidIgvDrsUris(values, signal, googleProject);
+  const canResolveDrs = canWrite(workspace.accessLevel);
+  const accessUrls = canResolveDrs ? await resolveValidIgvDrsUris(values, signal, googleProject) : [];
   for (const accessUrl of accessUrls) {
     const url = new URL(accessUrl);
 
@@ -271,6 +273,7 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   const [isSearchingFiles, setIsSearchingFiles] = useState(true);
 
   const signal = useCancellation();
+  const isReadOnly = !canWrite(workspace.accessLevel);
 
   useEffect(() => {
     async function fetchData() {
@@ -287,7 +290,11 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   const numSelected = _.countBy('isSelected', selections).true;
   const isSelectionValid = !!numSelected;
 
-  const noRowsMessage = isSearchingFiles ? 'Searching for valid files with indices...' : 'No valid files with indices found';
+  const noRowsMessage = Utils.cond(
+    [isSearchingFiles, () => 'Searching for valid files with indices...'],
+    [isReadOnly && selections.length === 0, () => 'No valid files with indices found. DRS URIs are not available for read-only workspace users.'],
+    [() => true, () => 'No valid files with indices found']
+  );
 
   const cache = new CellMeasurerCache({
     fixedWidth: true,
@@ -295,6 +302,22 @@ const IGVFileSelector = ({ workspace, entityType, selectedEntities, onSuccess })
   });
 
   return div({ style: Style.modalDrawer.content }, [
+    ...(isReadOnly
+      ? [
+          div(
+            {
+              style: {
+                padding: '0.75rem 1rem',
+                marginBottom: '1rem',
+                backgroundColor: '#f5f5f5',
+                borderRadius: '4px',
+                fontSize: '0.9rem',
+              },
+            },
+            ['You have read-only access. DRS URIs cannot be resolved for IGV; only direct storage links (e.g. gs://) from your selection are shown.']
+          ),
+        ]
+      : []),
     h(IGVReferenceSelector, {
       value: refGenome,
       onChange: setRefGenome,

--- a/src/components/igv/IGVFileSelector.test.js
+++ b/src/components/igv/IGVFileSelector.test.js
@@ -22,7 +22,11 @@ jest.mock('src/libs/ajax/workspaces/Workspaces', () => ({
   })),
 }));
 
-const mockWorkspace = { workspace: { namespace: 'ns', name: 'ws' } };
+const mockWorkspace = {
+  workspace: { namespace: 'ns', name: 'ws', googleProject: 'test-project' },
+  accessLevel: 'WRITER',
+};
+const readOnlyWorkspace = { ...mockWorkspace, accessLevel: 'READER' };
 const mockEntityType = 'entityType';
 const mockSignal = undefined;
 
@@ -153,6 +157,29 @@ describe('getValidIgvFiles', () => {
         isSignedUrl: false,
       },
     ]);
+  });
+
+  it('when workspace is read-only, does not resolve DRS URIs and returns only gs:// files', async () => {
+    DrsUriResolver.mockClear();
+    const result = await getValidIgvFiles(
+      readOnlyWorkspace,
+      mockEntityType,
+      [
+        'gs://bucket/test1.bam',
+        'gs://bucket/test1.bam.bai',
+        'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4',
+        'drs://dg.4503:2802a94d-f540-499f-950a-11111111111',
+      ],
+      mockSignal
+    );
+    expect(result).toEqual([
+      {
+        filePath: 'gs://bucket/test1.bam',
+        indexFilePath: 'gs://bucket/test1.bam.bai',
+        isSignedUrl: false,
+      },
+    ]);
+    expect(DrsUriResolver).not.toHaveBeenCalled();
   });
 
   it('condenses duplicate inputs', async () => {
@@ -327,6 +354,51 @@ describe('getValidIgvFilesFromAttributeValues', () => {
     expect(isDrsUri(undefined)).toEqual(false);
   });
 
+  it('when workspace is read-only, does not resolve DRS URIs', async () => {
+    DrsUriResolver.mockClear();
+    const fileDrsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4';
+    const indexFileDrsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-11111111111';
+
+    const result = await getValidIgvFilesFromAttributeValues(
+      readOnlyWorkspace,
+      mockEntityType,
+      [
+        {
+          itemsType: 'AttributeValue',
+          items: [fileDrsUri, indexFileDrsUri],
+        },
+      ],
+      mockSignal
+    );
+
+    expect(result).toEqual([]);
+    expect(DrsUriResolver).not.toHaveBeenCalled();
+  });
+
+  it('when workspace is read-only, returns only gs:// files when selection has both gs:// and DRS URIs', async () => {
+    DrsUriResolver.mockClear();
+    const result = await getValidIgvFilesFromAttributeValues(
+      readOnlyWorkspace,
+      mockEntityType,
+      [
+        {
+          itemsType: 'AttributeValue',
+          items: ['gs://bucket/test.bed', 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4'],
+        },
+      ],
+      mockSignal
+    );
+
+    expect(result).toEqual([
+      {
+        filePath: 'gs://bucket/test.bed',
+        indexFilePath: false,
+        isSignedUrl: false,
+      },
+    ]);
+    expect(DrsUriResolver).not.toHaveBeenCalled();
+  });
+
   it('calls to resolve access URLs when two DRS URIs are found', async () => {
     // An IGV selection generally must have a file (e.g. VCF) and an index file (TBI)
     const fileDrsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4';
@@ -377,6 +449,47 @@ describe('getValidIgvFilesFromAttributeValues', () => {
         isSignedUrl: true,
       },
     ]);
+  });
+
+  it('passes workspace googleProject as userProject when resolving DRS URIs', async () => {
+    const fileDrsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4';
+    const indexFileDrsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-11111111111';
+    const fileAccessUrl = 'https://bucket/foo.vcf.gz';
+    const indexAccessUrl = 'https://bucket/foo.vcf.gz.tbi';
+
+    const getDataObjectMetadataMock = jest.fn((value, fields, _options) => {
+      if (fields.includes('fileName')) {
+        const fileName = value === fileDrsUri ? 'foo.vcf.gz' : 'foo.vcf.gz.tbi';
+        return Promise.resolve({ fileName });
+      }
+      if (fields.includes('accessUrl')) {
+        const url = value === fileDrsUri ? fileAccessUrl : indexAccessUrl;
+        return Promise.resolve({ accessUrl: { url } });
+      }
+      return Promise.resolve({});
+    });
+
+    DrsUriResolver.mockImplementation(() => ({
+      getDataObjectMetadata: getDataObjectMetadataMock,
+    }));
+
+    await getValidIgvFilesFromAttributeValues(
+      mockWorkspace,
+      mockEntityType,
+      [
+        {
+          itemsType: 'AttributeValue',
+          items: [fileDrsUri, indexFileDrsUri],
+        },
+      ],
+      mockSignal
+    );
+
+    expect(getDataObjectMetadataMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ userProject: 'test-project' })
+    );
   });
 
   it('provides relevant component-specific logging metrics', async () => {

--- a/src/libs/ajax/drs/DrsUriResolver.ts
+++ b/src/libs/ajax/drs/DrsUriResolver.ts
@@ -20,10 +20,13 @@ export const DrsUriResolver = (signal?: AbortSignal) => ({
   },
 
   getDataObjectMetadata: async (url, fields, options?: { userProject?: string }) => {
-    const headers = _.merge({}, authOpts().headers, options?.userProject && { 'x-user-project': options.userProject });
+    const headers = {
+      ...authOpts().headers,
+      ...(options?.userProject ? { 'x-user-project': options.userProject } : {}),
+    };
     const res = await fetchDrsHub(
       'api/v4/drs/resolve',
-      _.mergeAll([jsonBody({ url, fields }), { headers }, appIdentifier, { signal, method: 'POST' }])
+      _.mergeAll([authOpts(), jsonBody({ url, fields }), { headers }, appIdentifier, { signal, method: 'POST' }])
     );
     return res.json();
   },

--- a/src/libs/ajax/drs/DrsUriResolver.ts
+++ b/src/libs/ajax/drs/DrsUriResolver.ts
@@ -19,10 +19,11 @@ export const DrsUriResolver = (signal?: AbortSignal) => ({
     return res.json();
   },
 
-  getDataObjectMetadata: async (url, fields) => {
+  getDataObjectMetadata: async (url, fields, options?: { userProject?: string }) => {
+    const headers = _.merge({}, authOpts().headers, options?.userProject && { 'x-user-project': options.userProject });
     const res = await fetchDrsHub(
       'api/v4/drs/resolve',
-      _.mergeAll([jsonBody({ url, fields }), authOpts(), appIdentifier, { signal, method: 'POST' }])
+      _.mergeAll([jsonBody({ url, fields }), { headers }, appIdentifier, { signal, method: 'POST' }])
     );
     return res.json();
   },

--- a/src/libs/ajax/drs/DrsUriResolver.ts
+++ b/src/libs/ajax/drs/DrsUriResolver.ts
@@ -20,13 +20,10 @@ export const DrsUriResolver = (signal?: AbortSignal) => ({
   },
 
   getDataObjectMetadata: async (url, fields, options?: { userProject?: string }) => {
-    const headers = {
-      ...authOpts().headers,
-      ...(options?.userProject ? { 'x-user-project': options.userProject } : {}),
-    };
+    const body = { url, fields, ...(options?.userProject ? { userProject: options.userProject } : {}) };
     const res = await fetchDrsHub(
       'api/v4/drs/resolve',
-      _.mergeAll([authOpts(), jsonBody({ url, fields }), { headers }, appIdentifier, { signal, method: 'POST' }])
+      _.mergeAll([authOpts(), jsonBody(body), appIdentifier, { signal, method: 'POST' }])
     );
     return res.json();
   },

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -180,6 +180,7 @@ const eventsList = {
   workspaceDataEditOne: 'workspace:data:editOne',
   workspaceDataColumnTableSearch: 'workspace:data:columnTableSearch',
   workspaceDataOpenWithIGV: 'workspace:data:igv',
+  workspaceDataDrsReadOnlyBlocked: 'workspace:data:drsReadOnlyBlocked',
   workspaceDataOpenWithWorkflow: 'workspace:data:workflow',
   workspaceDataOpenWithDataExplorer: 'workspace:data:dataexplorer',
   workspaceDataOpenWithNotebook: 'workspace:data:notebook',

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -12,10 +12,12 @@ import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { knownBucketRequesterPaysStatuses, workspaceStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import DownloadPrices from 'src/workspace-data/download-prices';
-import { canWrite } from 'src/workspaces/utils';
 
 import els from './uri-viewer-styles';
 import { isAzureUri, isDrsUri } from './uri-viewer-utils';
+
+// IMPORTANT: Currently, this component is only used in the UriViewer. So, it is unreachable to read only workspace users.
+// If the button is ever used outside of the UriViewer, we need to block read only workspace users.
 
 const getMaxDownloadCostNA = (bytes: number) => {
   const nanos = DownloadPrices.pricingInfo[0].pricingExpression.tieredRates[1].unitPrice.nanos;
@@ -25,12 +27,9 @@ const getMaxDownloadCostNA = (bytes: number) => {
   return Utils.formatUSD(downloadPrice);
 };
 
-const READ_ONLY_MESSAGE = 'Download is not available for read-only workspace users.';
-
 export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, accessUrl, workspace }) => {
   const signal = useCancellation();
   const [url, setUrl] = useState<string | null>();
-  const [blockedReason, setBlockedReason] = useState<string | null>(null);
   const getUrlFromDrsProvider = async (userProject: string) => {
     const { url } = await DrsUriResolver(signal).getSignedUrl({
       bucket,
@@ -57,16 +56,6 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
       setUrl(_.isEmpty(accessUrl.headers) ? accessUrl.url : null);
     } else if (isAzureUri(uri)) {
       setUrl(uri);
-    } else if (isDrsUri(uri) && !canWrite(workspace.accessLevel)) {
-      // Currently, this case will never be hit because this button is only used in the UriViewer
-      // which already blocks read-only workspace users.
-      // Leaving this here in case the button is ever used outside of the UriViewer.
-      void Metrics().captureEvent(Events.workspaceDataDrsReadOnlyBlocked, {
-        source: 'downloadButton',
-        ...extractWorkspaceDetails(workspace),
-      });
-      setBlockedReason(READ_ONLY_MESSAGE);
-      setUrl(null);
     } else {
       try {
         const userProject = await getUserProjectForWorkspace(workspace);
@@ -130,11 +119,10 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
 
   // If URL missing, show error. Otherwise, show the Azure/GCP download button.
   return els.cell([
-    blockedReason ||
-      (_.isEmpty(url)
-        ? 'Unable to generate download link.'
-        : div({ style: { display: 'flex', justifyContent: 'center' } }, [
-            isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton(),
-          ])),
+    _.isEmpty(url)
+      ? 'Unable to generate download link.'
+      : div({ style: { display: 'flex', justifyContent: 'center' } }, [
+          isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton(),
+        ]),
   ]);
 };

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -58,6 +58,13 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
     } else if (isAzureUri(uri)) {
       setUrl(uri);
     } else if (isDrsUri(uri) && !canWrite(workspace.accessLevel)) {
+      // Currently, this case will never be hit because this button is only used in the UriViewer
+      // which already blocks read-only workspace users.
+      // Leaving this here in case the button is ever used outside of the UriViewer.
+      void Metrics().captureEvent(Events.workspaceDataDrsReadOnlyBlocked, {
+        source: 'downloadButton',
+        ...extractWorkspaceDetails(workspace),
+      });
       setBlockedReason(READ_ONLY_MESSAGE);
       setUrl(null);
     } else {

--- a/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
+++ b/src/workspace-data/data-table/uri-viewer/UriDownloadButton.ts
@@ -12,6 +12,7 @@ import { useCancellation, useOnMount } from 'src/libs/react-utils';
 import { knownBucketRequesterPaysStatuses, workspaceStore } from 'src/libs/state';
 import * as Utils from 'src/libs/utils';
 import DownloadPrices from 'src/workspace-data/download-prices';
+import { canWrite } from 'src/workspaces/utils';
 
 import els from './uri-viewer-styles';
 import { isAzureUri, isDrsUri } from './uri-viewer-utils';
@@ -24,9 +25,12 @@ const getMaxDownloadCostNA = (bytes: number) => {
   return Utils.formatUSD(downloadPrice);
 };
 
+const READ_ONLY_MESSAGE = 'Download is not available for read-only workspace users.';
+
 export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, size }, accessUrl, workspace }) => {
   const signal = useCancellation();
   const [url, setUrl] = useState<string | null>();
+  const [blockedReason, setBlockedReason] = useState<string | null>(null);
   const getUrlFromDrsProvider = async (userProject: string) => {
     const { url } = await DrsUriResolver(signal).getSignedUrl({
       bucket,
@@ -53,6 +57,9 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
       setUrl(_.isEmpty(accessUrl.headers) ? accessUrl.url : null);
     } else if (isAzureUri(uri)) {
       setUrl(uri);
+    } else if (isDrsUri(uri) && !canWrite(workspace.accessLevel)) {
+      setBlockedReason(READ_ONLY_MESSAGE);
+      setUrl(null);
     } else {
       try {
         const userProject = await getUserProjectForWorkspace(workspace);
@@ -116,10 +123,11 @@ export const UriDownloadButton = ({ uri, metadata: { bucket, name, fileName, siz
 
   // If URL missing, show error. Otherwise, show the Azure/GCP download button.
   return els.cell([
-    _.isEmpty(url)
-      ? 'Unable to generate download link.'
-      : div({ style: { display: 'flex', justifyContent: 'center' } }, [
-          isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton(),
-        ]),
+    blockedReason ||
+      (_.isEmpty(url)
+        ? 'Unable to generate download link.'
+        : div({ style: { display: 'flex', justifyContent: 'center' } }, [
+            isAzureUri(uri) ? azureDownloadButton() : googleDownloadButton(),
+          ])),
   ]);
 };

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -66,15 +66,11 @@ export const UriViewer = _.flow(
           timeUpdated: updated,
           fileName,
           accessUrl,
-        } = await DrsUriResolver(signal).getDataObjectMetadata(uri, [
-          'bucket',
-          'name',
-          'size',
-          'timeCreated',
-          'timeUpdated',
-          'fileName',
-          'accessUrl',
-        ]);
+        } = await DrsUriResolver(signal).getDataObjectMetadata(
+          uri,
+          ['bucket', 'name', 'size', 'timeCreated', 'timeUpdated', 'fileName', 'accessUrl'],
+          { userProject: googleProject }
+        );
         const metadata = { bucket, name, fileName, size, timeCreated, updated, accessUrl };
         setMetadata(metadata);
       }

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -16,6 +16,7 @@ import colors from 'src/libs/colors';
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/workspaces/common/requester-pays/bucket-utils';
+import { canWrite } from 'src/workspaces/utils';
 
 import { FileProvenance } from '../../provenance/FileProvenance';
 import els from './uri-viewer-styles';
@@ -54,6 +55,10 @@ export const UriViewer = _.flow(
         setMetadata(azureMetadata);
         setLoadingError(false);
       } else {
+        if (!canWrite(workspace.accessLevel)) {
+          setLoadingError({ message: 'DRS resolution is not available for read-only workspace users.' });
+          return;
+        }
         // Fields are mapped from the drshub_v4 fields to those used by google
         // https://github.com/DataBiosphere/terra-drs-hub
         // https://cloud.google.com/storage/docs/json_api/v1/objects#resource-representations
@@ -160,10 +165,11 @@ export const UriViewer = _.flow(
     const errorMsg = isStdLog
       ? 'Log file not found. This may be the result of a task failing to start. Please check relevant docker images and file paths to ensure valid references.'
       : 'Error loading data. This file does not exist or you do not have permission to view it.';
+    const displayError = loadingError?.message || loadingError;
     return loadingError
       ? h(Collapse, { title: 'Details' }, [
           div({ style: { marginTop: '0.5rem', whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [
-            JSON.stringify(loadingError, null, 2),
+            typeof displayError === 'string' ? displayError : JSON.stringify(loadingError, null, 2),
           ]),
         ])
       : h(Fragment, [div({ style: { paddingBottom: '1rem' } }, [errorMsg])]);

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -12,7 +12,9 @@ import { parseGsUri } from 'src/components/data/data-utils';
 import { AzureStorage } from 'src/libs/ajax/AzureStorage';
 import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
 import { GoogleStorage } from 'src/libs/ajax/GoogleStorage';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import colors from 'src/libs/colors';
+import Events, { extractWorkspaceDetails } from 'src/libs/events';
 import { useCancellation, useOnMount, withDisplayName } from 'src/libs/react-utils';
 import * as Utils from 'src/libs/utils';
 import { requesterPaysWrapper, withRequesterPaysHandler } from 'src/workspaces/common/requester-pays/bucket-utils';
@@ -56,6 +58,10 @@ export const UriViewer = _.flow(
         setLoadingError(false);
       } else {
         if (!canWrite(workspace.accessLevel)) {
+          void Metrics().captureEvent(Events.workspaceDataDrsReadOnlyBlocked, {
+            source: 'filePreviewModal',
+            ...extractWorkspaceDetails(workspace),
+          });
           setLoadingError({ message: 'DRS resolution is not available for read-only workspace users.' });
           return;
         }

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.js
@@ -173,10 +173,8 @@ export const UriViewer = _.flow(
       : 'Error loading data. This file does not exist or you do not have permission to view it.';
     const displayError = loadingError?.message || loadingError;
     return loadingError
-      ? h(Collapse, { title: 'Details' }, [
-          div({ style: { marginTop: '0.5rem', whiteSpace: 'pre-wrap', fontFamily: 'monospace', overflowWrap: 'break-word' } }, [
-            typeof displayError === 'string' ? displayError : JSON.stringify(loadingError, null, 2),
-          ]),
+      ? div({ style: { padding: '1rem 0', whiteSpace: 'pre-wrap', overflowWrap: 'break-word' } }, [
+          typeof displayError === 'string' ? displayError : JSON.stringify(loadingError, null, 2),
         ])
       : h(Fragment, [div({ style: { paddingBottom: '1rem' } }, [errorMsg])]);
   };

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
@@ -72,7 +72,7 @@ describe('UriViewer', () => {
     DrsUriResolver.mockClear();
     asMockedFn(Metrics).mockReturnValue(partial({ captureEvent: jest.fn() }));
 
-    const { container } = renderWithAppContexts(
+    renderWithAppContexts(
       h(UriViewer, {
         workspace: readOnlyWorkspace,
         uri: drsUri,
@@ -82,7 +82,7 @@ describe('UriViewer', () => {
     );
 
     await waitFor(() => {
-      expect(container.textContent).toContain('DRS resolution is not available for read-only workspace users.');
+      expect(screen.getByText('DRS resolution is not available for read-only workspace users.')).toBeInTheDocument();
     });
 
     expect(DrsUriResolver).not.toHaveBeenCalled();

--- a/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
+++ b/src/workspace-data/data-table/uri-viewer/UriViewer.test.js
@@ -1,9 +1,18 @@
-import { screen } from '@testing-library/react';
+import { asMockedFn, partial } from '@terra-ui-packages/test-utils';
+import { screen, waitFor } from '@testing-library/react';
 import { h } from 'react-hyperscript-helpers';
 import { bucketBrowserUrl, bucketFileBrowserUrl } from 'src/auth/auth';
 import { Link } from 'src/components/common';
+import { DrsUriResolver } from 'src/libs/ajax/drs/DrsUriResolver';
+import { Metrics } from 'src/libs/ajax/Metrics';
 import * as Utils from 'src/libs/utils';
 import { renderWithAppContexts } from 'src/testing/test-utils';
+import { defaultGoogleWorkspace } from 'src/testing/workspace-fixtures';
+
+import { UriViewer } from './UriViewer';
+
+jest.mock('src/libs/ajax/drs/DrsUriResolver');
+jest.mock('src/libs/ajax/Metrics');
 
 describe('UriViewer Links', () => {
   const gsUri = 'gs://my-bucket/my-file.txt';
@@ -48,5 +57,67 @@ describe('UriViewer Links', () => {
     const link = screen.getByText('View the folder containing this file in Google Cloud Storage Browser');
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', 'https://console.cloud.google.com/storage/browser/my-bucket?authuser=undefined');
+  });
+});
+
+describe('UriViewer', () => {
+  const readOnlyWorkspace = { ...defaultGoogleWorkspace, accessLevel: 'READER' };
+  const drsUri = 'drs://dg.4503:2802a94d-f540-499f-950a-db3c2a9f2dc4';
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('when workspace is read-only and uri is DRS, does not call DrsUriResolver and shows read-only error', async () => {
+    DrsUriResolver.mockClear();
+    asMockedFn(Metrics).mockReturnValue(partial({ captureEvent: jest.fn() }));
+
+    const { container } = renderWithAppContexts(
+      h(UriViewer, {
+        workspace: readOnlyWorkspace,
+        uri: drsUri,
+        onDismiss: () => {},
+        onRequesterPaysError: () => {},
+      })
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('DRS resolution is not available for read-only workspace users.');
+    });
+
+    expect(DrsUriResolver).not.toHaveBeenCalled();
+  });
+
+  it('passes workspace googleProject as userProject when resolving DRS URI', async () => {
+    const getDataObjectMetadataMock = jest.fn().mockResolvedValue({
+      bucket: 'test-bucket',
+      name: 'test-object',
+      fileName: 'test-file.vcf.gz',
+      size: 1000,
+      timeCreated: '2024-01-01T00:00:00Z',
+      timeUpdated: '2024-01-01T00:00:00Z',
+      accessUrl: { url: 'https://example.com/signed' },
+    });
+
+    DrsUriResolver.mockImplementation(() => ({
+      getDataObjectMetadata: getDataObjectMetadataMock,
+    }));
+
+    renderWithAppContexts(
+      h(UriViewer, {
+        workspace: defaultGoogleWorkspace,
+        uri: drsUri,
+        onDismiss: () => {},
+        onRequesterPaysError: () => {},
+      })
+    );
+
+    await waitFor(() => {
+      expect(getDataObjectMetadataMock).toHaveBeenCalledWith(
+        drsUri,
+        expect.any(Array),
+        expect.objectContaining({ userProject: defaultGoogleWorkspace.workspace.googleProject })
+      );
+    });
   });
 });


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-382

### Dependencies
Depends on CTM-382 in terra-drs-hub. 
Also depends on the logs currently being gathered. Wait to merge this until decisions are made based on that info.

## Summary of changes:
1. Always pass in workspace google project to drs hub. It isn't always there because it doesn't exist for azure workspaces.
    * It is passed as part of the request body. This requires the change in terra-drs-hub. See [this slack thread](https://manifoldai.slack.com/archives/C0AFWENAU81/p1773334817634759) for context.
3. Don't allow read only users to initiate calls to drshub. That would cause spend on the workspace google project. 
4. Implement metrics to see how often read only users try to initiate calls to drs hub. If it is a frequent request, we can add a feature to allow them to select a project they can spend on.
    * It is because of the desire to capture metrics that these features on not just fully disabled with an explanatory tooltip for read only users.

### Testing strategy
Unit tests
Testing on UI
Tested locally by connecting to a locally running DRS Hub on branch rj/ctm-382-header-to-body. 
- In the case where the user is a reader, the endpoint was not called.
- In the case where the user is a writer/owner, the endpoint was successfully called with the userProject in the request body. The accessUrl returned contained that userProject. 

### Visual Aids 

https://github.com/user-attachments/assets/77a18139-c410-4eb2-9a92-32abc47abbf7

### Notes on testing with local DrsHub
1. Run DrsHub. I did this:
```
./gradlew generateSwaggerCode
./render_config.sh dev
./gradlew bootRun
```

Note that at this time, DrsHub was having some local javaCompile errors related to java 17 I think. I think it is this issue: https://github.com/immutables/immutables/issues/1331 when the compiler has to put an annotation‑processed (generated) type into a record’s type signature, it can blow up with typeSig ERROR. So we might want to switch to an interface for DrsHubConfig -> DrsHubConfigInterface. That is what I did locally. Ticket here: https://broadworkbench.atlassian.net/browse/CTM-412

2. Modify terra-ui configs.
I added to the server section of vite.config.mjs

```
      // Proxy to local terra-drs-hub when drsHubUrlRoot is set to /drshub-proxy (see config/local.json)
      proxy: {
        '/drshub-proxy': {
          target: 'http://localhost:8080',
          changeOrigin: true,
          rewrite: (path) => path.replace(/^\/drshub-proxy/, ''),
        },
      },
```
Also changed this line in public/config.json:
`  "drsHubUrlRoot": "http://localhost:3000/drshub-proxy",`
3. Start Terra-UI
`yarn start`

