### PR TITLE
[TSPS-875] Add service unavailable view for Teaspoons

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -18,7 +18,7 @@
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
-  "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
+  "teaspoonsUrlRoot": "http://localhost:8080",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -18,7 +18,7 @@
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
-  "teaspoonsUrlRoot": "http://localhost:8080",
+  "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/src/pages/scientificServices/pipelines/account/AccountAndQuotas.tsx
+++ b/src/pages/scientificServices/pipelines/account/AccountAndQuotas.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import FooterWrapper from 'src/components/FooterWrapper';
 import { BasicAccountInfoDisplay } from 'src/pages/scientificServices/pipelines/account/sections/BasicAccountInfoDisplay';
 import { PipelineQuotaDisplay } from 'src/pages/scientificServices/pipelines/account/sections/PipelineQuotaDisplay';
 import { ProxyGroupDisplay } from 'src/pages/scientificServices/pipelines/account/sections/ProxyGroupDisplay';
-import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { PipelineWidgetContainer } from 'src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineWidgetContainer';
 
 export const AccountAndQuotas = () => {
   return (
-    <FooterWrapper alwaysShow>
-      {pipelinesTopBar()}
+    <PipelinesLayout>
       <div style={{ margin: '1rem 2rem' }}>
         <h3>Account & Quotas</h3>
 
@@ -27,6 +25,6 @@ export const AccountAndQuotas = () => {
           <PipelineQuotaDisplay />
         </PipelineWidgetContainer>
       </div>
-    </FooterWrapper>
+    </PipelinesLayout>
   );
 };

--- a/src/pages/scientificServices/pipelines/common/PipelinesLayout.test.tsx
+++ b/src/pages/scientificServices/pipelines/common/PipelinesLayout.test.tsx
@@ -1,0 +1,132 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { usePipelinesList } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
+import { mockPipeline } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
+import { asMockedFn, renderWithAppContexts } from 'src/testing/test-utils';
+
+import { PipelinesLayout } from './PipelinesLayout';
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn(() => '/'),
+  getPath: jest.fn(() => '/test/'),
+  useRoute: jest.fn().mockImplementation(() => ({ params: {}, query: {} })),
+}));
+
+jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList');
+const mockUsePipelinesList = asMockedFn(usePipelinesList);
+
+describe('PipelinesLayout', () => {
+  it('does not render content while loading', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: true,
+      error: undefined,
+    });
+
+    renderWithAppContexts(
+      <PipelinesLayout>
+        <div>Page content</div>
+      </PipelinesLayout>
+    );
+
+    expect(screen.queryByText('Page content')).not.toBeInTheDocument();
+  });
+
+  it('shows ServiceUnavailableView when there is an error', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: false,
+      error: new Error('Connection failed'),
+    });
+
+    renderWithAppContexts(<PipelinesLayout />);
+
+    expect(screen.getByText('Service Unavailable')).toBeInTheDocument();
+  });
+
+  it('does not show ServiceUnavailableView when there is no error', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithAppContexts(<PipelinesLayout />);
+
+    expect(screen.queryByText('Service Unavailable')).not.toBeInTheDocument();
+  });
+
+  it('renders children when loaded successfully', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithAppContexts(
+      <PipelinesLayout>
+        <div>Page content</div>
+      </PipelinesLayout>
+    );
+
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+  });
+
+  it('passes pipelines data to the render prop', () => {
+    const pipelines = [mockPipeline('array_imputation'), mockPipeline('wgs_imputation')];
+    mockUsePipelinesList.mockReturnValue({
+      pipelines,
+      uniquePipelines: pipelines,
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithAppContexts(
+      <PipelinesLayout
+        render={({ uniquePipelines }) => (
+          <ul>
+            {uniquePipelines.map((p) => (
+              <li key={p.pipelineName}>{p.displayName}</li>
+            ))}
+          </ul>
+        )}
+      />
+    );
+
+    expect(screen.getByText('array_imputation display name')).toBeInTheDocument();
+    expect(screen.getByText('wgs_imputation display name')).toBeInTheDocument();
+  });
+
+  it('does not call the render prop while loading', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: true,
+      error: undefined,
+    });
+
+    const renderProp = jest.fn(() => <div>Rendered content</div>);
+    renderWithAppContexts(<PipelinesLayout render={renderProp} />);
+
+    expect(renderProp).not.toHaveBeenCalled();
+  });
+
+  it('does not call the render prop when there is an error', () => {
+    mockUsePipelinesList.mockReturnValue({
+      pipelines: [],
+      uniquePipelines: [],
+      isLoading: false,
+      error: new Error('Connection failed'),
+    });
+
+    const renderProp = jest.fn(() => <div>Rendered content</div>);
+    renderWithAppContexts(<PipelinesLayout render={renderProp} />);
+
+    expect(renderProp).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/scientificServices/pipelines/common/PipelinesLayout.tsx
+++ b/src/pages/scientificServices/pipelines/common/PipelinesLayout.tsx
@@ -4,7 +4,6 @@ import FooterWrapper from 'src/components/FooterWrapper';
 import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { ServiceUnavailableView } from 'src/pages/scientificServices/pipelines/common/ServiceUnavailableView';
 import {
-  PipelinesListContext,
   usePipelinesList,
   UsePipelinesListResult,
 } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
@@ -28,11 +27,7 @@ export const PipelinesLayout = ({ activeTab, children, render }: PipelinesLayout
         </div>
       )}
       {!isLoading && error && <ServiceUnavailableView />}
-      {!isLoading && !error && (
-        <PipelinesListContext.Provider value={pipelinesResult}>
-          {render ? render(pipelinesResult) : children}
-        </PipelinesListContext.Provider>
-      )}
+      {!isLoading && !error && (render ? render(pipelinesResult) : children)}
     </FooterWrapper>
   );
 };

--- a/src/pages/scientificServices/pipelines/common/PipelinesLayout.tsx
+++ b/src/pages/scientificServices/pipelines/common/PipelinesLayout.tsx
@@ -1,0 +1,38 @@
+import { Spinner } from '@terra-ui-packages/components';
+import React, { ReactNode } from 'react';
+import FooterWrapper from 'src/components/FooterWrapper';
+import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { ServiceUnavailableView } from 'src/pages/scientificServices/pipelines/common/ServiceUnavailableView';
+import {
+  PipelinesListContext,
+  usePipelinesList,
+  UsePipelinesListResult,
+} from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
+
+interface PipelinesLayoutProps {
+  activeTab?: string;
+  children?: ReactNode;
+  render?: (result: UsePipelinesListResult) => ReactNode;
+}
+
+export const PipelinesLayout = ({ activeTab, children, render }: PipelinesLayoutProps) => {
+  const pipelinesResult = usePipelinesList();
+  const { isLoading, error } = pipelinesResult;
+
+  return (
+    <FooterWrapper alwaysShow>
+      {pipelinesTopBar(activeTab)}
+      {isLoading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '3rem' }}>
+          <Spinner />
+        </div>
+      )}
+      {!isLoading && error && <ServiceUnavailableView />}
+      {!isLoading && !error && (
+        <PipelinesListContext.Provider value={pipelinesResult}>
+          {render ? render(pipelinesResult) : children}
+        </PipelinesListContext.Provider>
+      )}
+    </FooterWrapper>
+  );
+};

--- a/src/pages/scientificServices/pipelines/common/ServiceUnavailableView.tsx
+++ b/src/pages/scientificServices/pipelines/common/ServiceUnavailableView.tsx
@@ -1,0 +1,30 @@
+import { Icon } from '@terra-ui-packages/components';
+import React from 'react';
+import colors from 'src/libs/colors';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+
+export const ServiceUnavailableView = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '4rem 2rem',
+        textAlign: 'center',
+      }}
+    >
+      <Icon icon='warning-standard' size={64} style={{ color: colors.warning(), marginBottom: '1.5rem' }} />
+      <h2 style={{ marginBottom: '0.75rem', color: colors.dark() }}>Service Unavailable</h2>
+      <p style={{ maxWidth: 500, color: colors.dark(0.7), marginBottom: '1rem' }}>
+        We&apos;re having trouble connecting to our services right now. Please try refreshing the page. If the problem
+        persists, contact us at{' '}
+        <a href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`} style={{ color: '#46A3E9' }}>
+          {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+        </a>
+        .
+      </p>
+    </div>
+  );
+};

--- a/src/pages/scientificServices/pipelines/hooks/usePipelinesList.ts
+++ b/src/pages/scientificServices/pipelines/hooks/usePipelinesList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { notify } from 'src/libs/notifications';
@@ -11,32 +11,44 @@ export interface UsePipelinesListResult {
   error: Error | undefined;
 }
 
+// Allows PipelinesLayout to provide the already-fetched result so child
+// components that call usePipelinesList() don't trigger a second request.
+export const PipelinesListContext = createContext<UsePipelinesListResult | undefined>(undefined);
+
 export const usePipelinesList = (): UsePipelinesListResult => {
+  const contextValue = useContext(PipelinesListContext);
+
   const signal = useCancellation();
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | undefined>(undefined);
 
-  const fetchPipelines = async () => {
-    setIsLoading(true);
-    setError(undefined);
-
-    try {
-      const response = await Teaspoons(signal).getPipelines();
-      setPipelines(response.results);
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error('Failed to fetch pipelines');
-      setError(error);
-      notify('error', error.message);
-      setPipelines([]);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
+    if (contextValue !== undefined) return;
+
+    const fetchPipelines = async () => {
+      setIsLoading(true);
+      setError(undefined);
+
+      try {
+        const response = await Teaspoons(signal).getPipelines();
+        setPipelines(response.results);
+      } catch (err) {
+        const fetchError = err instanceof Error ? err : new Error('Failed to fetch pipelines');
+        setError(fetchError);
+        notify('error', fetchError.message);
+        setPipelines([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
     fetchPipelines();
-  }, [signal]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [signal, contextValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (contextValue !== undefined) {
+    return contextValue;
+  }
 
   const uniquePipelines = pipelines.reduce((acc: Pipeline[], pipeline) => {
     if (!acc.some((p) => p.pipelineName === pipeline.pipelineName)) {

--- a/src/pages/scientificServices/pipelines/tabs/about/About.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/about/About.tsx
@@ -1,52 +1,45 @@
-import { Spinner } from '@terra-ui-packages/components';
 import React from 'react';
-import FooterWrapper from 'src/components/FooterWrapper';
-import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
-import { usePipelinesList } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
 import { AoUStylizedString } from 'src/pages/scientificServices/pipelines/utils/AoUStylizedString';
 
 export const About = () => {
-  const { isLoading, error, uniquePipelines } = usePipelinesList();
-
   return (
-    <FooterWrapper alwaysShow>
-      {pipelinesTopBar('about')}
-      <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
-        <h1>Scientific Services from the Broad Data Sciences Platform</h1>
-        <h2 style={{ marginTop: '2rem' }}>Pipelines</h2>
+    <PipelinesLayout
+      activeTab='about'
+      render={({ uniquePipelines }) => (
+        <div style={{ marginLeft: '2rem', marginTop: '1rem' }}>
+          <h1>Scientific Services from the Broad Data Sciences Platform</h1>
+          <h2 style={{ marginTop: '2rem' }}>Pipelines</h2>
 
-        {isLoading && <Spinner />}
-
-        {error && <div style={{ color: 'red' }}>{error.message}</div>}
-
-        {uniquePipelines?.map((pipeline) => (
-          <div key={pipeline.pipelineName}>
-            <h3>
-              <AoUStylizedString text={pipeline.displayName} />
-            </h3>
-            <div style={{ width: '50%' }}>
-              {pipeline.description ? (
-                <AoUStylizedString text={pipeline.description} />
-              ) : (
-                <em>No description available</em>
-              )}
+          {uniquePipelines?.map((pipeline) => (
+            <div key={pipeline.pipelineName}>
+              <h3>
+                <AoUStylizedString text={pipeline.displayName} />
+              </h3>
+              <div style={{ width: '50%' }}>
+                {pipeline.description ? (
+                  <AoUStylizedString text={pipeline.description} />
+                ) : (
+                  <em>No description available</em>
+                )}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
 
-        <h2 style={{ marginTop: '2rem' }}>User Documentation</h2>
-        <div style={{ marginTop: '1rem' }}>
-          <ZendeskLink docsKey={DocsKey.GETTING_STARTED} additionalStyle={{ fontWeight: 'bold' }}>
-            Get Started
-          </ZendeskLink>
+          <h2 style={{ marginTop: '2rem' }}>User Documentation</h2>
+          <div style={{ marginTop: '1rem' }}>
+            <ZendeskLink docsKey={DocsKey.GETTING_STARTED} additionalStyle={{ fontWeight: 'bold' }}>
+              Get Started
+            </ZendeskLink>
+          </div>
+          <div style={{ marginTop: '1rem' }}>
+            <ZendeskLink docsKey={DocsKey.ABOUT_SERVICE} additionalStyle={{ fontWeight: 'bold' }}>
+              About this Service
+            </ZendeskLink>
+          </div>
         </div>
-        <div style={{ marginTop: '1rem' }}>
-          <ZendeskLink docsKey={DocsKey.ABOUT_SERVICE} additionalStyle={{ fontWeight: 'bold' }}>
-            About this Service
-          </ZendeskLink>
-        </div>
-      </div>
-    </FooterWrapper>
+      )}
+    />
   );
 };

--- a/src/pages/scientificServices/pipelines/tabs/history/JobHistory.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/JobHistory.tsx
@@ -4,21 +4,17 @@ import _, { capitalize } from 'lodash';
 import pluralize from 'pluralize';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { AutoSizer } from 'react-virtualized';
-import FooterWrapper from 'src/components/FooterWrapper';
 import { FlexTable, HeaderCell, Paginator, Sortable, TooltipCell } from 'src/components/table';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
-import { GetPipelineRunsResponse, PipelineRun } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { GetPipelineRunsResponse, Pipeline, PipelineRun } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { useCancellation } from 'src/libs/react-utils';
-import {
-  pipelinesTopBar,
-  SCIENTIFIC_SERVICES_SUPPORT_EMAIL,
-} from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { TEASPOONS_FILE_OUTPUT_TTL_DAYS } from 'src/pages/scientificServices/pipelines/common/teaspoons-service-constants';
-import { usePipelinesList } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
 import { FilterValues, TableFilters } from 'src/pages/scientificServices/pipelines/tabs/history/controls/TableFilters';
 import { ViewErrorModal } from 'src/pages/scientificServices/pipelines/tabs/history/modals/ViewErrorModal';
 import { ViewOutputsModal } from 'src/pages/scientificServices/pipelines/tabs/history/modals/ViewOutputsModal';
@@ -35,7 +31,11 @@ interface SortProperties {
   direction: 'asc' | 'desc';
 }
 
-export const JobHistory = () => {
+interface JobHistoryContentProps {
+  pipelines: Pipeline[];
+}
+
+const JobHistoryContent = ({ pipelines: pipelinesList }: JobHistoryContentProps) => {
   const signal = useCancellation();
   const [pageNumber, setPageNumber] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -51,8 +51,6 @@ export const JobHistory = () => {
     field: 'created',
     direction: 'desc',
   });
-
-  const { isLoading: isLoadingPipelines, uniquePipelines: pipelinesList } = usePipelinesList();
 
   // Fetch pipeline runs when the component mounts or when pagination/sorting/filtering controls change
   useEffect(() => {
@@ -80,128 +78,131 @@ export const JobHistory = () => {
   };
 
   return (
-    <FooterWrapper alwaysShow>
-      {pipelinesTopBar('job history')}
-      <main
-        style={{
-          paddingLeft: '2rem',
-          paddingRight: '2rem',
-          paddingTop: '1rem',
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          rowGap: '1rem',
-        }}
-      >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-          <h3>Job History</h3>
+    <main
+      style={{
+        paddingLeft: '2rem',
+        paddingRight: '2rem',
+        paddingTop: '1rem',
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: '1rem',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+        <h3>Job History</h3>
 
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
-              <div style={{ marginBottom: '0.25rem' }}>
-                All files associated with jobs will be automatically deleted after {TEASPOONS_FILE_OUTPUT_TTL_DAYS} days
-                from completion.
-              </div>
-              <div>
-                For support, email{' '}
-                <a
-                  style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
-                  href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
-                >
-                  {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
-                </a>
-              </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+            <div style={{ marginBottom: '0.25rem' }}>
+              All files associated with jobs will be automatically deleted after {TEASPOONS_FILE_OUTPUT_TTL_DAYS} days
+              from completion.
             </div>
-            <div style={{ display: 'flex', flexDirection: 'row', gap: '0.5rem', alignItems: 'center' }}>
-              {isLoadingPipelines && <Spinner size={20} />}
-              <ButtonPrimary
-                type='button'
-                disabled={isLoadingPipelines}
-                onClick={() => setShowFilters(!showFilters)}
-                aria-label={showFilters ? 'Hide filters' : 'Show filters'}
-                style={{ minWidth: '140px' }}
+            <div>
+              For support, email{' '}
+              <a
+                style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
+                href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`}
               >
-                <Icon icon='search' size={16} style={{ marginRight: '0.5rem' }} />
-                {showFilters ? 'Hide Filters' : 'Show Filters'}
-              </ButtonPrimary>
+                {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+              </a>
             </div>
           </div>
-        </div>
-
-        {showFilters && (
-          <TableFilters filters={filters} onFilterChange={handleFilterChange} pipelinesList={pipelinesList} />
-        )}
-
-        <div style={{ flex: 1, marginTop: '0.75rem' }}>
-          {pipelineRunsResponse && !isLoading ? (
-            <AutoSizer>
-              {({ width, height }) => (
-                <FlexTable
-                  aria-label='job history table'
-                  width={width}
-                  height={height}
-                  rowHeight={55}
-                  rowCount={pipelineRunsResponse.results.length}
-                  columns={getColumns(pipelineRunsResponse.results, sort, (sort) => {
-                    setSort(sort);
-                    setPageNumber(1);
-                  })}
-                  noContentMessage={
-                    filters ? (
-                      <div>
-                        No results match the selected filters.{' '}
-                        <button
-                          type='button'
-                          style={{
-                            color: '#46A3E9',
-                            fontWeight: 700,
-                            textDecoration: 'underline',
-                            cursor: 'pointer',
-                            background: 'none',
-                            border: 'none',
-                            padding: 0,
-                            fontStyle: 'italic',
-                          }}
-                          onClick={() => setFilters({})}
-                        >
-                          Clear filters
-                        </button>{' '}
-                        to see all jobs.
-                      </div>
-                    ) : (
-                      'Nothing to display'
-                    )
-                  }
-                  tabIndex={-1}
-                  variant={undefined}
-                  styleHeader={() => ({ backgroundColor: '#eff0f1' })}
-                />
-              )}
-            </AutoSizer>
-          ) : (
-            <Spinner />
-          )}
-        </div>
-        {!_.isEmpty(pipelineRunsResponse?.results) && (
-          <div style={{ marginBottom: '0.5rem' }}>
-            {/* @ts-ignore */}
-            <Paginator
-              filteredDataLength={pipelineRunsResponse?.totalFilteredResults ?? 0}
-              unfilteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
-              pageNumber={pageNumber}
-              setPageNumber={(v) => {
-                setPageNumber(v);
-              }}
-              itemsPerPage={itemsPerPage}
-              setItemsPerPage={(v) => {
-                setPageNumber(1);
-                setItemsPerPage(v);
-              }}
-            />
+          <div style={{ display: 'flex', flexDirection: 'row', gap: '0.5rem', alignItems: 'center' }}>
+            {isLoading && <Spinner size={20} />}
+            <ButtonPrimary
+              type='button'
+              disabled={isLoading}
+              onClick={() => setShowFilters(!showFilters)}
+              aria-label={showFilters ? 'Hide filters' : 'Show filters'}
+              style={{ minWidth: '140px' }}
+            >
+              <Icon icon='search' size={16} style={{ marginRight: '0.5rem' }} />
+              {showFilters ? 'Hide Filters' : 'Show Filters'}
+            </ButtonPrimary>
           </div>
+        </div>
+      </div>
+
+      {showFilters && (
+        <TableFilters filters={filters} onFilterChange={handleFilterChange} pipelinesList={pipelinesList} />
+      )}
+
+      <div style={{ flex: 1, marginTop: '0.75rem' }}>
+        {pipelineRunsResponse && !isLoading ? (
+          <AutoSizer>
+            {({ width, height }) => (
+              <FlexTable
+                aria-label='job history table'
+                width={width}
+                height={height}
+                rowHeight={55}
+                rowCount={pipelineRunsResponse.results.length}
+                columns={getColumns(pipelineRunsResponse.results, sort, (sort) => {
+                  setSort(sort);
+                  setPageNumber(1);
+                })}
+                noContentMessage={
+                  filters ? (
+                    <div>
+                      No results match the selected filters.{' '}
+                      <button
+                        type='button'
+                        style={{
+                          color: '#46A3E9',
+                          fontWeight: 700,
+                          textDecoration: 'underline',
+                          cursor: 'pointer',
+                          background: 'none',
+                          border: 'none',
+                          padding: 0,
+                          fontStyle: 'italic',
+                        }}
+                        onClick={() => setFilters({})}
+                      >
+                        Clear filters
+                      </button>{' '}
+                      to see all jobs.
+                    </div>
+                  ) : (
+                    'Nothing to display'
+                  )
+                }
+                tabIndex={-1}
+                variant={undefined}
+                styleHeader={() => ({ backgroundColor: '#eff0f1' })}
+              />
+            )}
+          </AutoSizer>
+        ) : (
+          <Spinner />
         )}
-      </main>
-    </FooterWrapper>
+      </div>
+      {!_.isEmpty(pipelineRunsResponse?.results) && (
+        <div style={{ marginBottom: '0.5rem' }}>
+          {/* @ts-ignore */}
+          <Paginator
+            filteredDataLength={pipelineRunsResponse?.totalFilteredResults ?? 0}
+            unfilteredDataLength={pipelineRunsResponse?.totalResults ?? 0}
+            pageNumber={pageNumber}
+            setPageNumber={(v) => {
+              setPageNumber(v);
+            }}
+            itemsPerPage={itemsPerPage}
+            setItemsPerPage={(v) => {
+              setPageNumber(1);
+              setItemsPerPage(v);
+            }}
+          />
+        </div>
+      )}
+    </main>
+  );
+};
+
+export const JobHistory = () => {
+  return (
+    <PipelinesLayout activeTab='job history' render={({ pipelines }) => <JobHistoryContent pipelines={pipelines} />} />
   );
 };
 

--- a/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.test.tsx
@@ -13,6 +13,14 @@ jest.mock('src/libs/ajax/teaspoons/Teaspoons');
 jest.mock('src/libs/nav');
 jest.mock('src/libs/notifications');
 jest.mock('src/pages/scientificServices/pipelines/utils/file-utils');
+jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList', () => ({
+  usePipelinesList: jest.fn(() => ({
+    pipelines: [],
+    uniquePipelines: [],
+    isLoading: false,
+    error: undefined,
+  })),
+}));
 
 describe('JobDetails', () => {
   const mockGetPipelineRunResult = jest.fn();

--- a/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/JobDetails.tsx
@@ -1,11 +1,10 @@
 import { ButtonSecondary, Icon, Spinner } from '@terra-ui-packages/components';
 import React, { useEffect, useState } from 'react';
-import FooterWrapper from 'src/components/FooterWrapper';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
-import { pipelinesTopBar } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { DataDeliveryView } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/datadelivery/DataDeliveryView';
 import { JobDetailsHeader } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader';
 import { JobIOView } from 'src/pages/scientificServices/pipelines/tabs/history/details/sections/JobIOView';
@@ -36,8 +35,7 @@ export const JobDetails = ({ jobId }: JobDetailsProps) => {
   }, [jobId]);
 
   return (
-    <FooterWrapper alwaysShow>
-      {pipelinesTopBar('job history')}
+    <PipelinesLayout>
       <main
         style={{
           padding: '1rem 2rem 2rem',
@@ -80,6 +78,6 @@ export const JobDetails = ({ jobId }: JobDetailsProps) => {
           </div>
         )}
       </main>
-    </FooterWrapper>
+    </PipelinesLayout>
   );
 };

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { Pipeline, PipelineInput, PipelineList } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { notify } from 'src/libs/notifications';
+import { usePipelinesList } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
 import {
   mockPipelineWithDetails,
   mockUserPipelineQuotaDetails,
@@ -19,6 +20,10 @@ import { RunJob } from './RunJob';
 
 // Mock dependencies
 jest.mock('src/libs/ajax/teaspoons/Teaspoons');
+
+jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList', () => ({
+  usePipelinesList: jest.fn(),
+}));
 
 // Mock page navigation functions
 jest.mock('src/libs/nav', () => ({
@@ -106,6 +111,12 @@ describe('RunJob Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     asMockedFn(Teaspoons).mockReturnValue(mockTeaspoonsContract);
+    asMockedFn(usePipelinesList).mockReturnValue({
+      pipelines: [mockPipeline],
+      uniquePipelines: [mockPipeline],
+      isLoading: false,
+      error: undefined,
+    });
     asMockedFn(fetch).mockResolvedValue({
       ok: true,
       status: 200,
@@ -130,18 +141,13 @@ describe('RunJob Component', () => {
     expect(screen.getByText('Select a multi-sample VCF file')).toBeInTheDocument();
     expect(screen.getByText('Allow chunk failures')).toBeInTheDocument();
     expect(screen.getByText('Select a manifest file')).toBeInTheDocument();
-
-    // Wait for pipeline options to load
-    await waitFor(() => {
-      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
-    });
   });
 
   it('loads and displays pipeline options', async () => {
     render(<RunJob />);
 
     await waitFor(() => {
-      expect(mockTeaspoonsContract.getPipelines).toHaveBeenCalled();
+      expect(screen.getByText('Array Imputation - v1')).toBeInTheDocument();
     });
 
     // Check that pipeline details are fetched for each pipeline

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -152,17 +152,15 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
 
   useEffect(() => {
     if (pipelinesList && pipelinesList.length > 0) {
-      const options = pipelinesList
-        .map((pipeline) => ({
-          value: pipeline,
-          label: `${pipeline.displayName} - v${pipeline.pipelineVersion}`,
-        }))
-        .reverse();
+      const options = pipelinesList.map((pipeline) => ({
+        value: pipeline,
+        label: `${pipeline.displayName} - v${pipeline.pipelineVersion}`,
+      }));
 
       setPipelineVersionOptions(options);
 
       // Automatically select the most recent pipeline
-      setSelectedPipeline(pipelinesList.at(-1));
+      setSelectedPipeline(pipelinesList[0]);
     }
   }, [pipelinesList]);
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -2,7 +2,6 @@ import { ButtonPrimary, Icon, Link, Select, Spinner } from '@terra-ui-packages/c
 import { isEmpty } from 'lodash';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { ClipboardButton } from 'src/components/ClipboardButton';
-import FooterWrapper from 'src/components/FooterWrapper';
 import { getPopupRoot } from 'src/components/popup-utils';
 import { Metrics } from 'src/libs/ajax/Metrics';
 import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-models';
@@ -10,11 +9,8 @@ import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
-import {
-  pipelinesTopBar,
-  SCIENTIFIC_SERVICES_SUPPORT_EMAIL,
-} from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
-import { usePipelinesList } from 'src/pages/scientificServices/pipelines/hooks/usePipelinesList';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { useUserQuota } from 'src/pages/scientificServices/pipelines/hooks/useUserQuota';
 import { PipelineBooleanInput } from 'src/pages/scientificServices/pipelines/tabs/run/inputs/boolean/PipelineBooleanInput';
 import {
@@ -36,7 +32,11 @@ import {
 } from 'src/pages/scientificServices/pipelines/utils/submission-utils';
 import { GCS_PATH_VALIDATION_REGEX } from 'src/pages/scientificServices/pipelines/utils/upload-utils';
 
-export const RunJob = () => {
+interface RunJobContentProps {
+  pipelines: Pipeline[];
+}
+
+const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
   const [pipelineVersionOptions, setPipelineVersionOptions] = useState<{ value: Pipeline; label: string }[]>([]);
   const [uploadState, setUploadState] = useState<Record<string, PipelineInputFileUploadState>>({});
   const [preparedJobId, setPreparedJobId] = useState<string>();
@@ -55,7 +55,6 @@ export const RunJob = () => {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [submittedJobId, setSubmittedJobId] = useState<string>();
 
-  const { isLoading: isLoadingPipelines, pipelines: pipelinesList } = usePipelinesList();
   const { quota, pipelineDetails, meetsMinimumQuota, isLoading: isLoadingQuota } = useUserQuota(selectedPipeline);
 
   const resetSelectedUserInputs = () => {
@@ -238,255 +237,249 @@ export const RunJob = () => {
   };
 
   return (
-    <FooterWrapper alwaysShow>
-      {pipelinesTopBar('run job')}
-      <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem 2rem' }}>
-        <div style={{ flex: 1, marginRight: '2rem' }}>
-          <h3 style={{ marginBottom: '0.5rem' }}>
-            Select a pipeline version <span style={{ color: colors.danger() }}>*</span>
-          </h3>
-          <div style={{ marginBottom: '2rem' }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <div style={{ width: 400 }}>
-                <Select
-                  aria-label={`selected pipeline ${selectedPipeline?.displayName}`}
-                  isDisabled={isEmpty(pipelineVersionOptions)}
-                  value={selectedPipeline}
-                  options={pipelineVersionOptions}
-                  getOptionLabel={(r) => r.label}
-                  onChange={(r) => {
-                    if (r === null) {
-                      return;
-                    }
-                    setSelectedPipeline(r.value);
-                  }}
-                  menuPortalTarget={getPopupRoot()}
-                />
-              </div>
-              {isEmpty(pipelineVersionOptions) && <Spinner />}
-            </div>
-            {selectedPipeline && (
-              <div style={{ width: '400px', marginTop: '0.5rem' }}>
-                <AoUStylizedString
-                  text={
-                    pipelinesList.find((pipeline) => pipeline.pipelineVersion === selectedPipeline.pipelineVersion)
-                      ?.description
+    <div style={{ display: 'flex', justifyContent: 'space-between', margin: '1rem 2rem' }}>
+      <div style={{ flex: 1, marginRight: '2rem' }}>
+        <h3 style={{ marginBottom: '0.5rem' }}>
+          Select a pipeline version <span style={{ color: colors.danger() }}>*</span>
+        </h3>
+        <div style={{ marginBottom: '2rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <div style={{ width: 400 }}>
+              <Select
+                aria-label={`selected pipeline ${selectedPipeline?.displayName}`}
+                isDisabled={isEmpty(pipelineVersionOptions)}
+                value={selectedPipeline}
+                options={pipelineVersionOptions}
+                getOptionLabel={(r) => r.label}
+                onChange={(r) => {
+                  if (r === null) {
+                    return;
                   }
-                />
-              </div>
-            )}
+                  setSelectedPipeline(r.value);
+                }}
+                menuPortalTarget={getPopupRoot()}
+              />
+            </div>
+            {isEmpty(pipelineVersionOptions) && <Spinner />}
           </div>
+          {selectedPipeline && (
+            <div style={{ width: '400px', marginTop: '0.5rem' }}>
+              <AoUStylizedString
+                text={
+                  pipelinesList.find((pipeline) => pipeline.pipelineVersion === selectedPipeline.pipelineVersion)
+                    ?.description
+                }
+              />
+            </div>
+          )}
+        </div>
 
-          {!isLoadingPipelines && !isLoadingQuota && (
-            <>
-              {/* Displays all STRING inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => input.type === 'STRING')
-                .map((input) => {
-                  return (
-                    <PipelineStringInput
-                      input={input}
-                      onChange={(value) =>
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: value,
-                        }))
-                      }
-                      onValidation={(error) => handleInputValidation(input.name, error)}
-                      validationError={validationErrors[input.name]}
-                      value={selectedUserInputs[input.name]}
-                      key={`${input.name}`}
-                    />
-                  );
-                })}
-
-              {/* Displays all FLOAT inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => input.type === 'FLOAT')
-                .map((input) => {
-                  return (
-                    <PipelineFloatInput
-                      input={input}
-                      onChange={(value) =>
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: value,
-                        }))
-                      }
-                      onValidation={(error) => handleInputValidation(input.name, error)}
-                      validationError={validationErrors[input.name]}
-                      value={selectedUserInputs[input.name]}
-                      key={`${input.name}`}
-                    />
-                  );
-                })}
-
-              {/* Displays optional run description */}
-              {selectedPipeline && <PipelineRunDescription value={runDescription} onChange={setRunDescription} />}
-
-              {/* Displays all BOOLEAN inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => input.type === 'BOOLEAN')
-                .map((input) => {
-                  return (
-                    <PipelineBooleanInput
-                      value={selectedUserInputs[input.name]}
-                      input={input}
-                      key={`${input.name}`}
-                      onChange={(value) => {
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: value,
-                        }));
-                      }}
-                    />
-                  );
-                })}
-
-              {/* Displays all FILE or MANIFEST inputs, one after another */}
-              {pipelineInputs
-                .filter((input) => isFileLikeType(input.type))
-                .map((input) => {
-                  return (
-                    <PipelineFileBasedInput
-                      key={`${input.name}`}
-                      input={input}
-                      uploadState={uploadState[input.name]}
-                      selectedFile={selectedUserInputs[input.name] || null}
-                      setUploadState={setUploadState}
-                      onValidation={(error) => handleInputValidation(input.name, error)}
-                      validationError={validationErrors[input.name]}
-                      onUploadComplete={preparedJobId ? () => onUploadComplete(preparedJobId) : undefined}
-                      onFileSelect={(file) => {
-                        setSelectedUserInputs((prev) => ({
-                          ...prev,
-                          [input.name]: file,
-                        }));
-                      }}
-                      onSharingConfirmationChange={handleSharingConfirmationChange}
-                    />
-                  );
-                })}
-
-              {/* Submit button */}
-              {!submittedJobId && quota && (
-                <>
-                  {!meetsMinimumQuota && (
-                    <div
-                      style={{
-                        marginTop: '1rem',
-                        width: '500px',
-                        border: '1px solid #8f95a0',
-                        borderRadius: '4px',
-                        padding: '1rem',
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                        }}
-                      >
-                        <Icon
-                          icon='warning-standard'
-                          size={36}
-                          style={{ color: colors.danger(), marginRight: '1rem' }}
-                        />
-                        <div>
-                          You do not have enough quota remaining to run this pipeline. Please{' '}
-                          <Link
-                            href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
-                            style={{ color: '#46A3E9', fontWeight: 'bold' }}
-                          >
-                            request a quote
-                          </Link>{' '}
-                          for additional quota.
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <ButtonPrimary
-                    disabled={
-                      isSubmitting ||
-                      !areInputsValid() ||
-                      !meetsMinimumQuota ||
-                      Object.keys(validationErrors).length > 0
+        {!isEmpty(pipelineInputs) && !isLoadingQuota && (
+          <>
+            {/* Displays all STRING inputs, one after another */}
+            {pipelineInputs
+              .filter((input) => input.type === 'STRING')
+              .map((input) => {
+                return (
+                  <PipelineStringInput
+                    input={input}
+                    onChange={(value) =>
+                      setSelectedUserInputs((prev) => ({
+                        ...prev,
+                        [input.name]: value,
+                      }))
                     }
-                    style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
-                    onClick={handleSubmit}
+                    onValidation={(error) => handleInputValidation(input.name, error)}
+                    validationError={validationErrors[input.name]}
+                    value={selectedUserInputs[input.name]}
+                    key={`${input.name}`}
+                  />
+                );
+              })}
+
+            {/* Displays all FLOAT inputs, one after another */}
+            {pipelineInputs
+              .filter((input) => input.type === 'FLOAT')
+              .map((input) => {
+                return (
+                  <PipelineFloatInput
+                    input={input}
+                    onChange={(value) =>
+                      setSelectedUserInputs((prev) => ({
+                        ...prev,
+                        [input.name]: value,
+                      }))
+                    }
+                    onValidation={(error) => handleInputValidation(input.name, error)}
+                    validationError={validationErrors[input.name]}
+                    value={selectedUserInputs[input.name]}
+                    key={`${input.name}`}
+                  />
+                );
+              })}
+
+            {/* Displays optional run description */}
+            {selectedPipeline && <PipelineRunDescription value={runDescription} onChange={setRunDescription} />}
+
+            {/* Displays all BOOLEAN inputs, one after another */}
+            {pipelineInputs
+              .filter((input) => input.type === 'BOOLEAN')
+              .map((input) => {
+                return (
+                  <PipelineBooleanInput
+                    value={selectedUserInputs[input.name]}
+                    input={input}
+                    key={`${input.name}`}
+                    onChange={(value) => {
+                      setSelectedUserInputs((prev) => ({
+                        ...prev,
+                        [input.name]: value,
+                      }));
+                    }}
+                  />
+                );
+              })}
+
+            {/* Displays all FILE or MANIFEST inputs, one after another */}
+            {pipelineInputs
+              .filter((input) => isFileLikeType(input.type))
+              .map((input) => {
+                return (
+                  <PipelineFileBasedInput
+                    key={`${input.name}`}
+                    input={input}
+                    uploadState={uploadState[input.name]}
+                    selectedFile={selectedUserInputs[input.name] || null}
+                    setUploadState={setUploadState}
+                    onValidation={(error) => handleInputValidation(input.name, error)}
+                    validationError={validationErrors[input.name]}
+                    onUploadComplete={preparedJobId ? () => onUploadComplete(preparedJobId) : undefined}
+                    onFileSelect={(file) => {
+                      setSelectedUserInputs((prev) => ({
+                        ...prev,
+                        [input.name]: file,
+                      }));
+                    }}
+                    onSharingConfirmationChange={handleSharingConfirmationChange}
+                  />
+                );
+              })}
+
+            {/* Submit button */}
+            {!submittedJobId && quota && (
+              <>
+                {!meetsMinimumQuota && (
+                  <div
+                    style={{
+                      marginTop: '1rem',
+                      width: '500px',
+                      border: '1px solid #8f95a0',
+                      borderRadius: '4px',
+                      padding: '1rem',
+                    }}
                   >
-                    {isSubmitting ? (
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>
-                        <Spinner />
-                        Submitting...
-                      </div>
-                    ) : (
-                      'Submit'
-                    )}
-                  </ButtonPrimary>
-                </>
-              )}
-              {submittedJobId && (
-                <>
-                  <div>
                     <div
                       style={{
-                        width: 500,
-                        border: '1px solid #8f95a0',
-                        borderRadius: '4px',
-                        padding: '1rem',
-                        marginTop: '1rem',
-                        backgroundColor: '#fff',
                         display: 'flex',
-                        flexDirection: 'row',
                         alignItems: 'center',
                       }}
                     >
-                      <Icon icon='success-standard' size={36} style={{ color: colors.success(), margin: '0 1rem' }} />
+                      <Icon icon='warning-standard' size={36} style={{ color: colors.danger(), marginRight: '1rem' }} />
                       <div>
-                        Your job has been submitted. You can check the status of that job by going to the{' '}
+                        You do not have enough quota remaining to run this pipeline. Please{' '}
                         <Link
-                          style={{ color: '#46A3E9' }}
-                          href={Nav.getLink('pipelines-job-detail', { jobId: submittedJobId })}
+                          href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
+                          style={{ color: '#46A3E9', fontWeight: 'bold' }}
                         >
-                          Job Details
+                          request a quote
                         </Link>{' '}
-                        page.
-                        <div style={{ marginTop: '1rem' }}>
-                          <span style={{ fontWeight: 'bold' }}>Job ID:</span> <code>{submittedJobId}</code>
-                          <ClipboardButton style={{ marginLeft: '0.5rem' }} text={submittedJobId} />
-                        </div>
+                        for additional quota.
                       </div>
                     </div>
                   </div>
-                  <ButtonPrimary
-                    disabled={!selectedPipeline || isSubmitting}
-                    style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
-                    onClick={() => {
-                      resetSelectedUserInputs();
-                      setRunDescription('');
-                      setSubmittedJobId(undefined);
-                      setUploadState({});
+                )}
+                <ButtonPrimary
+                  disabled={
+                    isSubmitting || !areInputsValid() || !meetsMinimumQuota || Object.keys(validationErrors).length > 0
+                  }
+                  style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
+                  onClick={handleSubmit}
+                >
+                  {isSubmitting ? (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', justifyContent: 'center' }}>
+                      <Spinner />
+                      Submitting...
+                    </div>
+                  ) : (
+                    'Submit'
+                  )}
+                </ButtonPrimary>
+              </>
+            )}
+            {submittedJobId && (
+              <>
+                <div>
+                  <div
+                    style={{
+                      width: 500,
+                      border: '1px solid #8f95a0',
+                      borderRadius: '4px',
+                      padding: '1rem',
+                      marginTop: '1rem',
+                      backgroundColor: '#fff',
+                      display: 'flex',
+                      flexDirection: 'row',
+                      alignItems: 'center',
                     }}
                   >
-                    Run another job
-                  </ButtonPrimary>
-                </>
-              )}
-            </>
-          )}
-          {(isLoadingPipelines || isLoadingQuota) && (
-            <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Spinner /> Loading pipeline details...
-            </div>
-          )}
-        </div>
-        <div>
-          <QuotaDetailsWidget selectedPipeline={selectedPipeline} />
-          <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
-          <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
-        </div>
+                    <Icon icon='success-standard' size={36} style={{ color: colors.success(), margin: '0 1rem' }} />
+                    <div>
+                      Your job has been submitted. You can check the status of that job by going to the{' '}
+                      <Link
+                        style={{ color: '#46A3E9' }}
+                        href={Nav.getLink('pipelines-job-detail', { jobId: submittedJobId })}
+                      >
+                        Job Details
+                      </Link>{' '}
+                      page.
+                      <div style={{ marginTop: '1rem' }}>
+                        <span style={{ fontWeight: 'bold' }}>Job ID:</span> <code>{submittedJobId}</code>
+                        <ClipboardButton style={{ marginLeft: '0.5rem' }} text={submittedJobId} />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <ButtonPrimary
+                  disabled={!selectedPipeline || isSubmitting}
+                  style={{ margin: '1rem 0', padding: '1rem', fontSize: '1rem', width: 500 }}
+                  onClick={() => {
+                    resetSelectedUserInputs();
+                    setRunDescription('');
+                    setSubmittedJobId(undefined);
+                    setUploadState({});
+                  }}
+                >
+                  Run another job
+                </ButtonPrimary>
+              </>
+            )}
+          </>
+        )}
+        {(isEmpty(pipelineInputs) || isLoadingQuota) && (
+          <div style={{ marginTop: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <Spinner /> Loading pipeline details...
+          </div>
+        )}
       </div>
-    </FooterWrapper>
+      <div>
+        <QuotaDetailsWidget selectedPipeline={selectedPipeline} />
+        <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
+        <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
+      </div>
+    </div>
   );
+};
+
+export const RunJob = () => {
+  return <PipelinesLayout activeTab='run job' render={({ pipelines }) => <RunJobContent pipelines={pipelines} />} />;
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-875

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Adds a new Service Unavailable page that will automatically display if our service is down. This bridges the gap until we can get a service banner up (and is also just much cleaner than showing a half-broken app)

I decided to just base this off of the getPipelinesList endpoint because it's used on every page, so this seemed like a good proxy for "service is down". I could have tapped into /status, but I didn't want to hit an additional endpoint every time the user loads a tab. This implementation doesn't introduce any extra API calls.

<img width="1814" height="1000" alt="screencapture-localhost-3000-2026-04-16-16_17_01" src="https://github.com/user-attachments/assets/e8df1292-b1f6-4956-b10e-d0fc66a494c1" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
