### PR TITLE
[CTM-441] Update marketing preference box on registration page

### DIFF
--- a/src/registration/Register.test.ts
+++ b/src/registration/Register.test.ts
@@ -102,14 +102,11 @@ describe('Register', () => {
     });
   });
 
-  describe('Marketing Communications checkbox', () => {
-    it('defaults the marketing communications checkbox to true', async () => {
-      // Arrange
-      // Act
+  describe('Marketing Communications', () => {
+    it('renders a link to manage marketing preferences', () => {
       render(h(Register));
-      // Assert
-      const commsCheckbox = screen.getByLabelText(/Marketing communications.*/);
-      expect(commsCheckbox.getAttribute('aria-checked')).toBe('true');
+      const link = screen.getByRole('link', { name: 'manage your preferences' });
+      expect(link).toHaveAttribute('href', 'https://mailchi.mp/terra.bio/terra-subscriber-preferences');
     });
   });
 
@@ -184,10 +181,8 @@ describe('Register', () => {
       // Arrange
       const registerWithProfile: MockedFn<UserContract['registerWithProfile']> = jest.fn();
       registerWithProfile.mockResolvedValue(partial<SamUserResponse>({}));
-      const setUserAttributes: MockedFn<UserContract['setUserAttributes']> = jest.fn();
-      setUserAttributes.mockResolvedValue({ marketingConsent: false });
       const getUserAttributes: MockedFn<UserContract['getUserAttributes']> = jest.fn();
-      getUserAttributes.mockResolvedValue({ marketingConsent: false });
+      getUserAttributes.mockResolvedValue({});
       const userProfileGet: MockedFn<UserProfileContract['get']> = jest.fn();
       userProfileGet.mockResolvedValue(partial<TerraUserProfile>({}));
 
@@ -196,13 +191,11 @@ describe('Register', () => {
 
       fillInPersonalInfo();
       fillInOrgInfo();
-      fireEvent.click(screen.getByLabelText(/Marketing communications.*/));
       acceptTermsOfService();
 
       asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent: jest.fn() }));
       asMockedFn(User).mockReturnValue(
         partial<UserContract>({
-          setUserAttributes,
           getUserAttributes,
           registerWithProfile,
           profile: partial<UserProfileContract>({ get: userProfileGet }),
@@ -227,7 +220,6 @@ describe('Register', () => {
         interestInTerra: '',
       });
 
-      expect(setUserAttributes).toHaveBeenCalledWith({ marketingConsent: false });
       expect(loadTerraUserFn).toHaveBeenCalled();
     });
     it('logs the user out if they cancel registration', async () => {

--- a/src/registration/Register.test.ts
+++ b/src/registration/Register.test.ts
@@ -181,8 +181,6 @@ describe('Register', () => {
       // Arrange
       const registerWithProfile: MockedFn<UserContract['registerWithProfile']> = jest.fn();
       registerWithProfile.mockResolvedValue(partial<SamUserResponse>({}));
-      const getUserAttributes: MockedFn<UserContract['getUserAttributes']> = jest.fn();
-      getUserAttributes.mockResolvedValue({});
       const userProfileGet: MockedFn<UserProfileContract['get']> = jest.fn();
       userProfileGet.mockResolvedValue(partial<TerraUserProfile>({}));
 
@@ -196,7 +194,6 @@ describe('Register', () => {
       asMockedFn(Metrics).mockReturnValue(partial<MetricsContract>({ captureEvent: jest.fn() }));
       asMockedFn(User).mockReturnValue(
         partial<UserContract>({
-          getUserAttributes,
           registerWithProfile,
           profile: partial<UserProfileContract>({ get: userProfileGet }),
         })

--- a/src/registration/Register.test.ts
+++ b/src/registration/Register.test.ts
@@ -105,7 +105,7 @@ describe('Register', () => {
   describe('Marketing Communications', () => {
     it('renders a link to manage marketing preferences', () => {
       render(h(Register));
-      const link = screen.getByRole('link', { name: 'manage your preferences' });
+      const link = screen.getByRole('link', { name: 'Manage preferences' });
       expect(link).toHaveAttribute('href', 'https://mailchi.mp/terra.bio/terra-subscriber-preferences');
     });
   });

--- a/src/registration/Register.tsx
+++ b/src/registration/Register.tsx
@@ -205,10 +205,8 @@ export const Register = (): ReactNode => {
       <FormLabel style={{ marginTop: '2rem' }}>Communication Preferences</FormLabel>
       <RegistrationPageCheckbox title='Necessary communications related to platform operations' checked />
       <div style={{ marginTop: '0.5rem' }}>
-        Sign up for marketing communications, including upcoming workshops and new flagship dataset additions:{' '}
-        <ExternalLink href='https://mailchi.mp/terra.bio/terra-subscriber-preferences'>
-          manage your preferences
-        </ExternalLink>
+        <ExternalLink href='https://mailchi.mp/terra.bio/terra-subscriber-preferences'>Manage preferences</ExternalLink>{' '}
+        for marketing communications, including upcoming workshops and new flagship dataset additions.
       </div>
       <hr style={{ marginTop: '2rem', marginBottom: '2rem', color: colors.dark(0.2) }} />
       <h1 style={headerStyle('1rem')}>Terra Terms of Service</h1>

--- a/src/registration/Register.tsx
+++ b/src/registration/Register.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@terra-ui-packages/components';
+import { ExternalLink, Modal } from '@terra-ui-packages/components';
 import React, { ReactNode, useState } from 'react';
 import { signOut } from 'src/auth/signout/sign-out';
 import { loadTerraUser } from 'src/auth/user-profile/user';
@@ -52,8 +52,6 @@ export const Register = (): ReactNode => {
   const [title, setTitle] = useState('');
   const [department, setDepartment] = useState('');
   const [interestInTerra, setInterestInTerra] = useState('');
-  const [marketingConsent, setMarketingConsent] = useState(true);
-
   const [showTermsOfService, setShowTermsOfService] = useState(false);
   const [termsOfServiceSeen, setTermsOfServiceSeen] = useState(false);
   const [termsOfServiceAccepted, setTermsOfServiceAccepted] = useState(false);
@@ -78,7 +76,6 @@ export const Register = (): ReactNode => {
         interestInTerra,
         ...orgFields,
       });
-      await User().setUserAttributes({ marketingConsent });
       await loadTerraUser();
       const rootElement = document.getElementById('root');
       if (rootElement) {
@@ -207,11 +204,12 @@ export const Register = (): ReactNode => {
       )}
       <FormLabel style={{ marginTop: '2rem' }}>Communication Preferences</FormLabel>
       <RegistrationPageCheckbox title='Necessary communications related to platform operations' checked />
-      <RegistrationPageCheckbox
-        title='Marketing communications including notifications for upcoming workshops and new flagship dataset additions'
-        checked={marketingConsent}
-        onChange={setMarketingConsent}
-      />
+      <div style={{ marginTop: '0.5rem' }}>
+        Sign up for marketing communications, including upcoming workshops and new flagship dataset additions:{' '}
+        <ExternalLink href='https://mailchi.mp/terra.bio/terra-subscriber-preferences'>
+          manage your preferences
+        </ExternalLink>
+      </div>
       <hr style={{ marginTop: '2rem', marginBottom: '2rem', color: colors.dark(0.2) }} />
       <h1 style={headerStyle('1rem')}>Terra Terms of Service</h1>
       <h2 style={{ fontSize: '14px' }}>Please accept the Terms of Service to Continue</h2>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/CTM-441

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Changes the marketing communication opt-in checkbox on the user registration page to a link to mailing preferences.

Before
<img width="929" height="434" alt="Screenshot 2026-04-28 at 2 06 04 PM" src="https://github.com/user-attachments/assets/294ace00-8cb8-4b85-a049-5211131ff883" />

After
<img width="950" height="431" alt="Screenshot 2026-04-28 at 2 59 27 PM" src="https://github.com/user-attachments/assets/63498b43-8960-49e6-b7b9-ace357c3ca45" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
