### PR TITLE
[TSPS-888] Add Teaspoons ToS and Acceptable Use Policies [take 2]

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -18,7 +18,7 @@
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
-  "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
+  "teaspoonsUrlRoot": "http://localhost:8080",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/config/dev.json
+++ b/config/dev.json
@@ -18,7 +18,7 @@
   "leoUrlRoot": "https://leonardo.dsde-dev.broadinstitute.org",
   "orchestrationUrlRoot": "https://firecloud-orchestration.dsde-dev.broadinstitute.org",
   "rawlsUrlRoot": "https://rawls.dsde-dev.broadinstitute.org",
-  "teaspoonsUrlRoot": "http://localhost:8080",
+  "teaspoonsUrlRoot": "https://teaspoons.dsde-dev.broadinstitute.org",
   "samUrlRoot": "https://sam.dsde-dev.broadinstitute.org",
   "shibbolethUrlRoot": "https://broad-shibboleth-prod.appspot.com/dev",
   "workspaceManagerUrlRoot": "https://workspace.dsde-dev.broadinstitute.org",

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -75,7 +75,16 @@ const FooterWrapper = ({ children, alwaysShow = false, fixedHeight = false }) =>
     h(Link, { href: Nav.getLink('root') }, [footerLogo()]),
     a({ href: Nav.getLink('privacy'), style: styles.item }, 'Privacy Policy'),
     div({ style: styles.item }, '|'),
-    a({ href: Nav.getLink('terms-of-service'), style: styles.item }, 'Terms of Service'),
+    ...(isScientificServices()
+      ? [
+          a({ href: Nav.getLink('scientific-services-terms-of-service', { docType: 'termsOfService' }), style: styles.item }, 'Terms of Service'),
+          div({ style: styles.item }, '|'),
+          a(
+            { href: Nav.getLink('scientific-services-terms-of-service', { docType: 'acceptableUsePolicy' }), style: styles.item },
+            'Acceptable Use Policy'
+          ),
+        ]
+      : [a({ href: Nav.getLink('terms-of-service'), style: styles.item }, 'Terms of Service')]),
     popoutItem({
       link: 'https://support.terra.bio/hc/en-us/articles/360030793091-Terra-FireCloud-Security-Posture',
       displayName: 'Security',

--- a/src/components/FooterWrapper.js
+++ b/src/components/FooterWrapper.js
@@ -77,10 +77,13 @@ const FooterWrapper = ({ children, alwaysShow = false, fixedHeight = false }) =>
     div({ style: styles.item }, '|'),
     ...(isScientificServices()
       ? [
-          a({ href: Nav.getLink('scientific-services-terms-of-service', { docType: 'termsOfService' }), style: styles.item }, 'Terms of Service'),
+          a(
+            { href: Nav.getLink('scientific-services-terms-of-service', {}, { document: 'termsOfService' }), style: styles.item },
+            'Terms of Service'
+          ),
           div({ style: styles.item }, '|'),
           a(
-            { href: Nav.getLink('scientific-services-terms-of-service', { docType: 'acceptableUsePolicy' }), style: styles.item },
+            { href: Nav.getLink('scientific-services-terms-of-service', {}, { document: 'acceptableUsePolicy' }), style: styles.item },
             'Acceptable Use Policy'
           ),
         ]

--- a/src/libs/ajax/ajax-common.ts
+++ b/src/libs/ajax/ajax-common.ts
@@ -41,6 +41,12 @@ export const fetchTeaspoons = _.flow(
   withRetryAfterReloadingExpiredAuthToken
 )(fetchOk);
 
+export const fetchTeaspoonsPublic = _.flow(
+  withUrlPrefix(`${getConfig().teaspoonsUrlRoot}/`),
+  withAppIdentifier,
+  withRetryAfterReloadingExpiredAuthToken
+)(fetchOk);
+
 export const fetchDataRepo = _.flow(
   withUrlPrefix(`${getConfig().dataRepoUrlRoot}/api/`),
   withRetryAfterReloadingExpiredAuthToken

--- a/src/libs/ajax/teaspoons/Teaspoons.ts
+++ b/src/libs/ajax/teaspoons/Teaspoons.ts
@@ -2,7 +2,7 @@ import { jsonBody } from '@terra-ui-packages/data-client-core';
 import _ from 'lodash/fp';
 import * as qs from 'qs';
 import { authOpts } from 'src/auth/auth-session';
-import { fetchTeaspoons } from 'src/libs/ajax/ajax-common';
+import { fetchTeaspoons, fetchTeaspoonsPublic } from 'src/libs/ajax/ajax-common';
 import {
   DataDeliveryJobReport,
   GetPipelineRunsResponse,
@@ -134,9 +134,9 @@ export const Teaspoons = (signal?: AbortSignal) => ({
     return res.json();
   },
 
-  getDocs: async (docKey: TeaspoonsDocType): Promise<{ content: string }> => {
-    const res = await fetchTeaspoons(`docs/v1/${docKey}`, _.merge(authOpts(), { signal }));
-    return res.json();
+  getDocs: async (docKey: TeaspoonsDocType): Promise<string> => {
+    const res = await fetchTeaspoonsPublic(`docs?docType=${docKey}`, { signal });
+    return res.text();
   },
 });
 

--- a/src/libs/ajax/teaspoons/Teaspoons.ts
+++ b/src/libs/ajax/teaspoons/Teaspoons.ts
@@ -12,6 +12,7 @@ import {
   PipelineWithDetails,
   PreparePipelineRunResponse,
   StartPipelineResponse,
+  TeaspoonsDocType,
   UserPipelineQuotaDetails,
 } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import { FilterValues } from 'src/pages/scientificServices/pipelines/tabs/history/controls/TableFilters';
@@ -130,6 +131,11 @@ export const Teaspoons = (signal?: AbortSignal) => ({
       ])
     );
 
+    return res.json();
+  },
+
+  getDocs: async (docKey: TeaspoonsDocType): Promise<{ content: string }> => {
+    const res = await fetchTeaspoons(`docs/v1/${docKey}`, _.merge(authOpts(), { signal }));
     return res.json();
   },
 });

--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -167,3 +167,5 @@ export interface PipelineRunOutputSignedUrlsResponse {
 }
 
 export type PipelineRunStatus = 'PREPARING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
+
+export type TeaspoonsDocType = 'termsOfService' | 'acceptableUsePolicy';

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -4,6 +4,7 @@ import { About } from 'src/pages/scientificServices/pipelines/tabs/about/About';
 import { JobDetails } from 'src/pages/scientificServices/pipelines/tabs/history/details/JobDetails';
 import { JobHistory } from 'src/pages/scientificServices/pipelines/tabs/history/JobHistory';
 import { RunJob } from 'src/pages/scientificServices/pipelines/tabs/run/RunJob';
+import { ScientificServicesTermsOfServicePage } from 'src/pages/scientificServices/termsOfService/TermsOfServicePage';
 
 export const navPaths = [
   // For now, redirect /pipelines to the Imputation home page
@@ -49,5 +50,12 @@ export const navPaths = [
     path: '/pipelines/account',
     component: AccountAndQuotas,
     title: 'Account & Quotas',
+  },
+  {
+    name: 'scientific-services-terms-of-service',
+    path: '/pipelines/terms-of-service',
+    component: ScientificServicesTermsOfServicePage,
+    public: true,
+    title: 'Terms of Service',
   },
 ];

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.test.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.test.tsx
@@ -1,0 +1,126 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Teaspoons, TeaspoonsContract } from 'src/libs/ajax/teaspoons/Teaspoons';
+import * as Nav from 'src/libs/nav';
+import { asMockedFn, partial, renderWithAppContexts as render } from 'src/testing/test-utils';
+
+import { ScientificServicesTermsOfServicePage } from './TermsOfServicePage';
+
+jest.mock('src/libs/ajax/teaspoons/Teaspoons');
+
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getLink: jest.fn(() => '/'),
+  goToPath: jest.fn(),
+  useRoute: jest.fn().mockReturnValue({ params: {}, query: {} }),
+}));
+
+const mockTermsOfServiceContent = '# Terms of Service\n\nThese are the terms of service.';
+const mockAcceptableUsePolicyContent = '# Acceptable Use Policy\n\nThis is the acceptable use policy.';
+
+const mockGetDocs = jest.fn((docKey: string) => {
+  if (docKey === 'termsOfService') return Promise.resolve(mockTermsOfServiceContent);
+  if (docKey === 'acceptableUsePolicy') return Promise.resolve(mockAcceptableUsePolicyContent);
+  return Promise.reject(new Error('Unknown doc key'));
+});
+
+beforeEach(() => {
+  asMockedFn(Teaspoons).mockReturnValue(
+    partial<TeaspoonsContract>({
+      getDocs: mockGetDocs,
+    })
+  );
+});
+
+describe('ScientificServicesTermsOfServicePage', () => {
+  describe('initial render', () => {
+    it('renders the view with expected elements', async () => {
+      render(<ScientificServicesTermsOfServicePage />);
+      expect(screen.getByText('Scientific Services Legal Documents')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Terms of Service' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Acceptable Use Policy' })).toBeInTheDocument();
+    });
+
+    it('defaults to the Terms of Service tab when no query param is provided', async () => {
+      render(<ScientificServicesTermsOfServicePage />);
+      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      expect(tosTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('loads and displays the Terms of Service content by default', async () => {
+      render(<ScientificServicesTermsOfServicePage />);
+      expect(await screen.findByText('Terms of Service', { selector: 'h1, h2, h3' })).toBeInTheDocument();
+      expect(mockGetDocs).toHaveBeenCalledWith('termsOfService');
+    });
+  });
+
+  describe('query param routing', () => {
+    it('selects the Terms of Service tab when queryParams.document is termsOfService', async () => {
+      render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'termsOfService' }} />);
+      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      expect(tosTab).toHaveAttribute('aria-selected', 'true');
+      expect(mockGetDocs).toHaveBeenCalledWith('termsOfService');
+    });
+
+    it('selects the Acceptable Use Policy tab when queryParams.document is acceptableUsePolicy', async () => {
+      render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'acceptableUsePolicy' }} />);
+      const aupTab = screen.getByRole('tab', { name: 'Acceptable Use Policy' });
+      expect(aupTab).toHaveAttribute('aria-selected', 'true');
+      expect(mockGetDocs).toHaveBeenCalledWith('acceptableUsePolicy');
+    });
+
+    it('falls back to Terms of Service for an invalid queryParams.document value', async () => {
+      render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'notAValidDoc' }} />);
+      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      expect(tosTab).toHaveAttribute('aria-selected', 'true');
+      expect(mockGetDocs).toHaveBeenCalledWith('termsOfService');
+    });
+  });
+
+  describe('tab switching', () => {
+    it('switches to the Acceptable Use Policy tab and loads its content when clicked', async () => {
+      const user = userEvent.setup();
+      render(<ScientificServicesTermsOfServicePage />);
+
+      await screen.findByText('Terms of Service', { selector: 'h1, h2, h3' });
+
+      await user.click(screen.getByRole('tab', { name: 'Acceptable Use Policy' }));
+
+      expect(await screen.findByText('Acceptable Use Policy', { selector: 'h1, h2, h3' })).toBeInTheDocument();
+      expect(mockGetDocs).toHaveBeenCalledWith('acceptableUsePolicy');
+    });
+
+    it('updates the URL query param when switching tabs', async () => {
+      const user = userEvent.setup();
+      render(<ScientificServicesTermsOfServicePage />);
+
+      await screen.findByText('Terms of Service', { selector: 'h1, h2, h3' });
+
+      await user.click(screen.getByRole('tab', { name: 'Acceptable Use Policy' }));
+
+      expect(Nav.goToPath).toHaveBeenCalledWith(
+        'scientific-services-terms-of-service',
+        {},
+        { document: 'acceptableUsePolicy' }
+      );
+    });
+  });
+
+  describe('error state', () => {
+    beforeEach(() => {
+      asMockedFn(Teaspoons).mockReturnValue(
+        partial<TeaspoonsContract>({
+          getDocs: jest.fn().mockRejectedValue(new Error('bla bla error')),
+        })
+      );
+    });
+
+    it('displays an inline error message when the doc fails to load', async () => {
+      render(<ScientificServicesTermsOfServicePage />);
+      await screen.findByText('Could not load Terms of Service');
+      const emailLink = screen.getByRole('link', { name: /scientific-services-support@broadinstitute\.org/ });
+      expect(emailLink).toHaveAttribute('href', 'mailto:scientific-services-support@broadinstitute.org');
+    });
+  });
+});

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.test.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.test.tsx
@@ -38,13 +38,13 @@ describe('ScientificServicesTermsOfServicePage', () => {
     it('renders the view with expected elements', async () => {
       render(<ScientificServicesTermsOfServicePage />);
       expect(screen.getByText('Scientific Services Legal Documents')).toBeInTheDocument();
-      expect(screen.getByRole('tab', { name: 'Terms of Service' })).toBeInTheDocument();
+      expect(await screen.findByRole('tab', { name: 'Terms of Service' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Acceptable Use Policy' })).toBeInTheDocument();
     });
 
     it('defaults to the Terms of Service tab when no query param is provided', async () => {
       render(<ScientificServicesTermsOfServicePage />);
-      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      const tosTab = await screen.findByRole('tab', { name: 'Terms of Service' });
       expect(tosTab).toHaveAttribute('aria-selected', 'true');
     });
 
@@ -58,21 +58,21 @@ describe('ScientificServicesTermsOfServicePage', () => {
   describe('query param routing', () => {
     it('selects the Terms of Service tab when queryParams.document is termsOfService', async () => {
       render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'termsOfService' }} />);
-      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      const tosTab = await screen.findByRole('tab', { name: 'Terms of Service' });
       expect(tosTab).toHaveAttribute('aria-selected', 'true');
       expect(mockGetDocs).toHaveBeenCalledWith('termsOfService');
     });
 
     it('selects the Acceptable Use Policy tab when queryParams.document is acceptableUsePolicy', async () => {
       render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'acceptableUsePolicy' }} />);
-      const aupTab = screen.getByRole('tab', { name: 'Acceptable Use Policy' });
+      const aupTab = await screen.findByRole('tab', { name: 'Acceptable Use Policy' });
       expect(aupTab).toHaveAttribute('aria-selected', 'true');
       expect(mockGetDocs).toHaveBeenCalledWith('acceptableUsePolicy');
     });
 
     it('falls back to Terms of Service for an invalid queryParams.document value', async () => {
       render(<ScientificServicesTermsOfServicePage queryParams={{ document: 'notAValidDoc' }} />);
-      const tosTab = screen.getByRole('tab', { name: 'Terms of Service' });
+      const tosTab = await screen.findByRole('tab', { name: 'Terms of Service' });
       expect(tosTab).toHaveAttribute('aria-selected', 'true');
       expect(mockGetDocs).toHaveBeenCalledWith('termsOfService');
     });

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
@@ -1,24 +1,41 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { spinnerOverlay } from 'src/components/common';
 import FooterWrapper from 'src/components/FooterWrapper';
+import { MarkdownViewer, newWindowLinkRenderer } from 'src/components/markdown';
 import { SimpleTabBar } from 'src/components/tabBars';
 import { TopBar } from 'src/components/TopBar';
 import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
 import { TeaspoonsDocType } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
-import { RemoteMarkdown } from 'src/libs/util/RemoteMarkdown';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 
-type DocTab = 'termsOfService' | 'acceptableUsePolicy';
-
-const TABS: { key: DocTab; title: string; docKey: TeaspoonsDocType }[] = [
-  { key: 'termsOfService', title: 'Terms of Service', docKey: 'termsOfService' },
-  { key: 'acceptableUsePolicy', title: 'Acceptable Use Policy', docKey: 'acceptableUsePolicy2' },
+const TABS: { key: TeaspoonsDocType; title: string }[] = [
+  { key: 'termsOfService', title: 'Terms of Service' },
+  { key: 'acceptableUsePolicy', title: 'Acceptable Use Policy' },
 ];
 
+type LoadState = { status: 'loading' } | { status: 'ready'; content: string } | { status: 'error' };
+
 export const ScientificServicesTermsOfServicePage = () => {
-  const [activeTab, setActiveTab] = useState<DocTab>('termsOfService');
+  const [activeTab, setActiveTab] = useState<TeaspoonsDocType>('termsOfService');
+  const [loadState, setLoadState] = useState<LoadState>({ status: 'loading' });
 
   const currentTab = TABS.find((t) => t.key === activeTab)!;
+
+  const loadDoc = useCallback(async () => {
+    setLoadState({ status: 'loading' });
+    try {
+      const content = await Teaspoons().getDocs(activeTab);
+      setLoadState({ status: 'ready', content });
+    } catch {
+      setLoadState({ status: 'error' });
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    loadDoc();
+  }, [loadDoc]);
 
   return (
     <FooterWrapper alwaysShow>
@@ -28,34 +45,47 @@ export const ScientificServicesTermsOfServicePage = () => {
         <SimpleTabBar
           aria-label='legal documents'
           value={activeTab}
-          onChange={(key) => setActiveTab(key as DocTab)}
+          onChange={(key) => setActiveTab(key as TeaspoonsDocType)}
           tabs={TABS.map(({ key, title }) => ({ key, title }))}
         >
           {null}
         </SimpleTabBar>
         <div style={{ marginTop: '1.5rem' }}>
-          <RemoteMarkdown
-            key={activeTab}
-            style={{ lineHeight: 1.6 }}
-            getRemoteText={() =>
-              Teaspoons()
-                .getDocs(currentTab.docKey)
-                .then((r) => r)
-            }
-            failureMessage={`Could not load ${currentTab.title}. Please refresh the page or contact ${SCIENTIFIC_SERVICES_SUPPORT_EMAIL} for assistance.`}
-          />
+          {loadState.status === 'loading' && spinnerOverlay}
+          {loadState.status === 'error' && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '4rem 2rem',
+                textAlign: 'center',
+              }}
+            >
+              <h2 style={{ marginBottom: '0.75rem', color: colors.dark() }}>Could not load {currentTab.title}</h2>
+              <p style={{ color: colors.dark(0.7) }}>
+                Please try refreshing the page. If the problem persists, contact us at{' '}
+                <a href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}`} style={{ color: '#46A3E9' }}>
+                  {SCIENTIFIC_SERVICES_SUPPORT_EMAIL}
+                </a>
+                .
+              </p>
+            </div>
+          )}
+          {loadState.status === 'ready' && (
+            <MarkdownViewer
+              renderers={{
+                link: newWindowLinkRenderer,
+                heading: (text: string, level: number) => `<h${level} style="margin-bottom: 0">${text}</h${level}>`,
+              }}
+              style={{ lineHeight: 1.6, marginBottom: '3rem' }}
+            >
+              {loadState.content}
+            </MarkdownViewer>
+          )}
         </div>
       </div>
     </FooterWrapper>
   );
 };
-
-export const navPaths = [
-  {
-    name: 'scientific-services-terms-of-service',
-    path: '/pipelines/terms-of-service',
-    component: ScientificServicesTermsOfServicePage,
-    public: true,
-    title: 'Terms of Service',
-  },
-];

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
@@ -17,8 +17,16 @@ const TABS: { key: TeaspoonsDocType; title: string }[] = [
 
 type LoadState = { status: 'loading' } | { status: 'ready'; content: string } | { status: 'error' };
 
-export const ScientificServicesTermsOfServicePage = () => {
-  const [activeTab, setActiveTab] = useState<TeaspoonsDocType>('termsOfService');
+const isValidDocType = (key: unknown): key is TeaspoonsDocType => TABS.some((t) => t.key === key);
+
+interface ScientificServicesTermsOfServicePageProps {
+  queryParams?: { document?: string };
+}
+
+export const ScientificServicesTermsOfServicePage = ({ queryParams }: ScientificServicesTermsOfServicePageProps) => {
+  const initialTab =
+    isValidDocType(queryParams?.document) && queryParams?.document ? queryParams.document : 'termsOfService';
+  const [activeTab, setActiveTab] = useState<TeaspoonsDocType>(initialTab);
   const [loadState, setLoadState] = useState<LoadState>({ status: 'loading' });
 
   const currentTab = TABS.find((t) => t.key === activeTab)!;
@@ -37,6 +45,12 @@ export const ScientificServicesTermsOfServicePage = () => {
     loadDoc();
   }, [loadDoc]);
 
+  const handleTabChange = (key: string) => {
+    const docType = key as TeaspoonsDocType;
+    setActiveTab(docType);
+    Nav.goToPath('scientific-services-terms-of-service', {}, { document: docType });
+  };
+
   return (
     <FooterWrapper alwaysShow>
       <TopBar title='' href={Nav.getLink('root')} />
@@ -45,7 +59,7 @@ export const ScientificServicesTermsOfServicePage = () => {
         <SimpleTabBar
           aria-label='legal documents'
           value={activeTab}
-          onChange={(key) => setActiveTab(key as TeaspoonsDocType)}
+          onChange={handleTabChange}
           tabs={TABS.map(({ key, title }) => ({ key, title }))}
         >
           {null}

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import FooterWrapper from 'src/components/FooterWrapper';
+import { SimpleTabBar } from 'src/components/tabBars';
+import { TopBar } from 'src/components/TopBar';
+import { Teaspoons } from 'src/libs/ajax/teaspoons/Teaspoons';
+import { TeaspoonsDocType } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import * as Nav from 'src/libs/nav';
+import { RemoteMarkdown } from 'src/libs/util/RemoteMarkdown';
+import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
+
+type DocTab = 'termsOfService' | 'acceptableUsePolicy';
+
+const TABS: { key: DocTab; title: string; docKey: TeaspoonsDocType }[] = [
+  { key: 'termsOfService', title: 'Terms of Service', docKey: 'termsOfService' },
+  { key: 'acceptableUsePolicy', title: 'Acceptable Use Policy', docKey: 'acceptableUsePolicy2' },
+];
+
+export const ScientificServicesTermsOfServicePage = () => {
+  const [activeTab, setActiveTab] = useState<DocTab>('termsOfService');
+
+  const currentTab = TABS.find((t) => t.key === activeTab)!;
+
+  return (
+    <FooterWrapper alwaysShow>
+      <TopBar title='' href={Nav.getLink('root')} />
+      <div style={{ padding: '2rem', maxWidth: '900px', margin: '0 auto' }}>
+        <h1 style={{ fontSize: 28, fontWeight: 500, marginBottom: '2.5rem' }}>Scientific Services Legal Documents</h1>
+        <SimpleTabBar
+          aria-label='legal documents'
+          value={activeTab}
+          onChange={(key) => setActiveTab(key as DocTab)}
+          tabs={TABS.map(({ key, title }) => ({ key, title }))}
+        >
+          {null}
+        </SimpleTabBar>
+        <div style={{ marginTop: '1.5rem' }}>
+          <RemoteMarkdown
+            key={activeTab}
+            style={{ lineHeight: 1.6 }}
+            getRemoteText={() =>
+              Teaspoons()
+                .getDocs(currentTab.docKey)
+                .then((r) => r)
+            }
+            failureMessage={`Could not load ${currentTab.title}. Please refresh the page or contact ${SCIENTIFIC_SERVICES_SUPPORT_EMAIL} for assistance.`}
+          />
+        </div>
+      </div>
+    </FooterWrapper>
+  );
+};
+
+export const navPaths = [
+  {
+    name: 'scientific-services-terms-of-service',
+    path: '/pipelines/terms-of-service',
+    component: ScientificServicesTermsOfServicePage,
+    public: true,
+    title: 'Terms of Service',
+  },
+];


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-888

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

**_Note that this is the 2nd attempt at this PR, to be merged after the chart updates in https://github.com/broadinstitute/terra-helmfile/pull/6431 are deployed up through production._**

### What
- Adds Teaspoons Terms of Service and Acceptable Use Policy to a routable page in the UI

The documents are routable very path query params, so while he main view defaults to showing the Terms of Service, it's possible to send them to the Acceptable Use Policy directly by going to `https://services.terra.bio/#pipelines/terms-of-service?document=acceptableUsePolicy` 

<img width="3024" height="4716" alt="screencapture-localhost-3000-2026-04-29-22_29_57" src="https://github.com/user-attachments/assets/acc04c6e-96a2-4b44-ad97-81a9b6563a60" />


<img width="3024" height="2324" alt="screencapture-localhost-3000-2026-04-29-22_28_42" src="https://github.com/user-attachments/assets/817b6b66-a1dd-4956-a9a1-ccd63c33cf7e" />



Error state: (this last one doesn't have the updated footer content- refer to previous screenshots for that)
<img width="3024" height="1600" alt="screencapture-localhost-3000-2026-04-29-18_20_29" src="https://github.com/user-attachments/assets/a93444cf-6ce3-44a9-a54f-81ab4a57f4fd" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
