### PR TITLE
CTM-495 Standardize success to round icon

### DIFF
--- a/src/components/job-common.js
+++ b/src/components/job-common.js
@@ -16,7 +16,7 @@ export const statusType = {
   succeeded: {
     id: 'succeeded', // Must match variable name for collection unpacking.
     label: () => 'Succeeded',
-    icon: (style) => icon('check', { size: iconSize, style: { color: colors.success(), ...style } }),
+    icon: (style) => icon('success-standard', { size: iconSize, style: { color: colors.success(), ...style } }),
   },
   failed: {
     id: 'failed', // Must match variable name for collection unpacking.


### PR DESCRIPTION
"Success" icon now more closely matches the rest of the round icons.

Before:

<img width="600" alt="Screenshot 2026-05-14 at 14 57 24" src="https://github.com/user-attachments/assets/8608eb24-dcc1-43e5-a5b4-1addd1fa7738" />

After:

<img width="600"  alt="Screenshot 2026-05-14 at 14 57 37" src="https://github.com/user-attachments/assets/c274d7df-4ffd-4c37-b28a-2a3116cc816d" />