### PR TITLE
[TSPS-955] Support pre-selecting pipelines with query params

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -32,6 +32,7 @@ jest.mock('src/libs/nav', () => ({
   getPath: jest.fn(() => '/test/'),
   getLink: jest.fn(() => '/#pipelines/terms-of-service?document=termsOfService'),
   useRoute: jest.fn(() => ({ query: {} })),
+  updateSearch: jest.fn(),
 }));
 
 jest.mock('src/libs/notifications', () => ({
@@ -792,7 +793,7 @@ describe('RunJob Component', () => {
       await user.click(select);
       await user.click(screen.getByText('Low Pass Imputation - v1'));
 
-      expect(Nav.updateSearch).toHaveBeenCalledWith({ pipelineName: 'low_pass_imputation', version: 1 });
+      expect(asMockedFn(Nav.updateSearch)).toHaveBeenCalledWith({ pipelineName: 'low_pass_imputation', version: 1 });
     });
   });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -699,7 +699,7 @@ describe('RunJob Component', () => {
       description: 'Test pipeline for low pass imputation v2',
     };
 
-    const multiplePipelines = [mockPipeline, lowPassPipeline, lowPassPipelineV2];
+    const multiplePipelines = [mockPipeline, lowPassPipelineV2, lowPassPipeline];
 
     beforeEach(() => {
       asMockedFn(usePipelinesList).mockReturnValue({
@@ -735,7 +735,7 @@ describe('RunJob Component', () => {
       render(<RunJob />);
 
       await waitFor(() => {
-        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 1);
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 2);
       });
     });
 
@@ -758,9 +758,9 @@ describe('RunJob Component', () => {
 
       render(<RunJob />);
 
-      // Should fall back to v1 (first match) since v99 doesn't exist
+      // Should fall back to v2 (first match) since v99 doesn't exist
       await waitFor(() => {
-        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 1);
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 2);
       });
     });
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -775,6 +775,25 @@ describe('RunJob Component', () => {
         expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
       });
     });
+
+    it('updates the URL when the user manually selects a pipeline from the dropdown', async () => {
+      const user = userEvent.setup();
+      asMockedFn(Nav.useRoute).mockReturnValue({ query: {} } as any);
+
+      render(<RunJob />);
+
+      // Wait for the dropdown to be populated
+      await waitFor(() => {
+        expect(screen.getByText('Array Imputation - v1')).toBeInTheDocument();
+      });
+
+      // Open the pipeline selector dropdown and pick Low Pass Imputation
+      const select = screen.getByRole('combobox');
+      await user.click(select);
+      await user.click(screen.getByText('Low Pass Imputation - v1'));
+
+      expect(Nav.updateSearch).toHaveBeenCalledWith({ pipelineName: 'low_pass_imputation', version: 1 });
+    });
   });
 });
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -31,6 +31,7 @@ jest.mock('src/libs/nav', () => ({
   ...jest.requireActual('src/libs/nav'),
   getPath: jest.fn(() => '/test/'),
   getLink: jest.fn(() => '/#pipelines/terms-of-service?document=termsOfService'),
+  useRoute: jest.fn(() => ({ query: {} })),
 }));
 
 jest.mock('src/libs/notifications', () => ({
@@ -681,6 +682,99 @@ describe('RunJob Component', () => {
       {},
       { document: 'termsOfService' }
     );
+  });
+
+  describe('Query parameter pre-selection', () => {
+    const lowPassPipeline: Pipeline = {
+      pipelineName: 'low_pass_imputation',
+      displayName: 'Low Pass Imputation',
+      pipelineVersion: 1,
+      description: 'Test pipeline for low pass imputation',
+    };
+
+    const lowPassPipelineV2: Pipeline = {
+      pipelineName: 'low_pass_imputation',
+      displayName: 'Low Pass Imputation',
+      pipelineVersion: 2,
+      description: 'Test pipeline for low pass imputation v2',
+    };
+
+    const multiplePipelines = [mockPipeline, lowPassPipeline, lowPassPipelineV2];
+
+    beforeEach(() => {
+      asMockedFn(usePipelinesList).mockReturnValue({
+        pipelines: multiplePipelines,
+        uniquePipelines: [mockPipeline, lowPassPipeline],
+        isLoading: false,
+        error: undefined,
+      });
+      asMockedFn(mockTeaspoonsContract.getPipelineDetails).mockResolvedValue(
+        mockPipelineWithDetails('low_pass_imputation')
+      );
+    });
+
+    it('defaults to the first pipeline when no query params are provided', async () => {
+      asMockedFn(Nav.useRoute).mockReturnValue({ query: {} } as any);
+
+      render(<RunJob />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Array Imputation - v1')).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+      });
+    });
+
+    it('pre-selects a pipeline by pipelineName query param', async () => {
+      asMockedFn(Nav.useRoute).mockReturnValue({
+        query: { pipelineName: 'low_pass_imputation' },
+      } as any);
+
+      render(<RunJob />);
+
+      await waitFor(() => {
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 1);
+      });
+    });
+
+    it('pre-selects the correct version when both pipelineName and version query params are provided', async () => {
+      asMockedFn(Nav.useRoute).mockReturnValue({
+        query: { pipelineName: 'low_pass_imputation', version: '2' },
+      } as any);
+
+      render(<RunJob />);
+
+      await waitFor(() => {
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 2);
+      });
+    });
+
+    it('falls back to the first matching pipeline when the specified version is not found', async () => {
+      asMockedFn(Nav.useRoute).mockReturnValue({
+        query: { pipelineName: 'low_pass_imputation', version: '99' },
+      } as any);
+
+      render(<RunJob />);
+
+      // Should fall back to v1 (first match) since v99 doesn't exist
+      await waitFor(() => {
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('low_pass_imputation', 1);
+      });
+    });
+
+    it('defaults to the first pipeline when pipelineName query param does not match any pipeline', async () => {
+      asMockedFn(Nav.useRoute).mockReturnValue({
+        query: { pipelineName: 'nonexistent_pipeline' },
+      } as any);
+
+      render(<RunJob />);
+
+      await waitFor(() => {
+        expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+      });
+    });
   });
 });
 

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -9,7 +9,7 @@ import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-model
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
-import { useRoute } from 'src/libs/nav';
+import { updateSearch, useRoute } from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
@@ -184,7 +184,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
       // Automatically select the most recent pipeline (default behavior)
       setSelectedPipeline(pipelinesList[0]);
     }
-  }, [pipelinesList, query]);
+  }, [pipelinesList]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSubmit = async () => {
     if (!selectedPipeline) {
@@ -292,6 +292,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                     return;
                   }
                   setSelectedPipeline(r.value);
+                  updateSearch({ pipelineName: r.value.pipelineName, version: r.value.pipelineVersion });
                 }}
                 menuPortalTarget={getPopupRoot()}
               />

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -9,6 +9,7 @@ import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-model
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
+import { useRoute } from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
@@ -152,6 +153,8 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
     }
   }, [pipelineDetails]);
 
+  const { query } = useRoute();
+
   useEffect(() => {
     if (pipelinesList && pipelinesList.length > 0) {
       const options = pipelinesList.map((pipeline) => ({
@@ -161,10 +164,27 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
 
       setPipelineVersionOptions(options);
 
-      // Automatically select the most recent pipeline
+      // If query params are provided, try to find the matching pipeline
+      const { pipelineName, version } = query as { pipelineName?: string; version?: string };
+      if (pipelineName) {
+        const matchingPipelines = pipelinesList.filter((p) => p.pipelineName === pipelineName);
+        if (matchingPipelines.length > 0) {
+          if (version) {
+            const versionNumber = parseInt(version);
+            const exactMatch = matchingPipelines.find((p) => p.pipelineVersion === versionNumber);
+            setSelectedPipeline(exactMatch ?? matchingPipelines[0]);
+          } else {
+            // Default to the first match (assumed to be the latest version)
+            setSelectedPipeline(matchingPipelines[0]);
+          }
+          return;
+        }
+      }
+
+      // Automatically select the most recent pipeline (default behavior)
       setSelectedPipeline(pipelinesList[0]);
     }
-  }, [pipelinesList]);
+  }, [pipelinesList, query]);
 
   const handleSubmit = async () => {
     if (!selectedPipeline) {

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -170,7 +170,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
         const matchingPipelines = pipelinesList.filter((p) => p.pipelineName === pipelineName);
         if (matchingPipelines.length > 0) {
           if (version) {
-            const versionNumber = parseInt(version);
+            const versionNumber = Number.parseInt(version);
             const exactMatch = matchingPipelines.find((p) => p.pipelineVersion === versionNumber);
             setSelectedPipeline(exactMatch ?? matchingPipelines[0]);
           } else {

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -9,7 +9,7 @@ import { Pipeline, PipelineInput } from 'src/libs/ajax/teaspoons/teaspoons-model
 import colors from 'src/libs/colors';
 import Events from 'src/libs/events';
 import * as Nav from 'src/libs/nav';
-import { updateSearch, useRoute } from 'src/libs/nav';
+import { useRoute } from 'src/libs/nav';
 import { notify } from 'src/libs/notifications';
 import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
@@ -292,7 +292,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                     return;
                   }
                   setSelectedPipeline(r.value);
-                  updateSearch({ pipelineName: r.value.pipelineName, version: r.value.pipelineVersion });
+                  Nav.updateSearch({ pipelineName: r.value.pipelineName, version: r.value.pipelineVersion });
                 }}
                 menuPortalTarget={getPopupRoot()}
               />


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-955

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
Allows for preselected pipelines using the `pipelineName` and `version` query params, i.e. `http://localhost:3000/#pipelines/imputation/run?pipelineName=array_imputation&version=2`

Behavior:
If the version specified does not exist, then the latest version will be selected
If a version is not specified, the latest version of that pipeline will be selected
If no query params are specified at all, then it uses the existing behavior.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
