### PR TITLE
[TSPS-964] Split Account & Quotas view into two separate pages

### DIFF
--- a/src/components/TopBar.test.ts
+++ b/src/components/TopBar.test.ts
@@ -76,7 +76,8 @@ describe('TopBar', () => {
     fireEvent.click(screen.getByText('Loading...')); // username is shown as Loading... while user info is being fetched
 
     // Assert
-    expect(screen.queryByText('Account & Quotas')).toBeInTheDocument();
+    expect(screen.queryByText('Profile')).toBeInTheDocument();
+    expect(screen.queryByText('Quotas')).toBeInTheDocument();
     expect(screen.queryByText('Sign Out')).toBeInTheDocument();
   });
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -214,9 +214,14 @@ export const TopBar = (props: TopBarProps): ReactNode => {
                   </>
                 )}
                 {isScientificServices() && (
-                  <DropDownSubItem href={Nav.getLink('account')} onClick={hideNav}>
-                    Account & Quotas
-                  </DropDownSubItem>
+                  <>
+                    <DropDownSubItem href={Nav.getLink('pipelines-profile')} onClick={hideNav}>
+                      Profile
+                    </DropDownSubItem>
+                    <DropDownSubItem href={Nav.getLink('pipelines-quotas')} onClick={hideNav}>
+                      Quotas
+                    </DropDownSubItem>
+                  </>
                 )}
                 <DropDownSubItem onClick={() => signOut('requested')}>Sign Out</DropDownSubItem>
               </DropDownSection>

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -1,5 +1,6 @@
 import { CliAuth } from 'src/pages/scientificServices/cli-auth/CliAuth';
-import { AccountAndQuotas } from 'src/pages/scientificServices/pipelines/account/AccountAndQuotas';
+import { ProfileView } from 'src/pages/scientificServices/pipelines/account/ProfileView';
+import { QuotasView } from 'src/pages/scientificServices/pipelines/account/QuotasView';
 import { About } from 'src/pages/scientificServices/pipelines/tabs/about/About';
 import { JobDetails } from 'src/pages/scientificServices/pipelines/tabs/history/details/JobDetails';
 import { JobHistory } from 'src/pages/scientificServices/pipelines/tabs/history/JobHistory';
@@ -45,11 +46,24 @@ export const navPaths = [
     title: 'Sign in to the terralab CLI',
     public: true,
   },
+  // DEPRECATED: this is here to avoid breaking any existing links. The pipelines-profile route is preferred.
   {
-    name: 'account',
+    name: 'pipelines-account',
+    path: '/pipelines/profile',
+    component: ProfileView,
+    title: 'Profile',
+  },
+  {
+    name: 'pipelines-profile',
     path: '/pipelines/account',
-    component: AccountAndQuotas,
-    title: 'Account & Quotas',
+    component: ProfileView,
+    title: 'Profile',
+  },
+  {
+    name: 'pipelines-quotas',
+    path: '/pipelines/quotas',
+    component: QuotasView,
+    title: 'Quotas',
   },
   {
     name: 'scientific-services-terms-of-service',

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import * as Nav from 'src/libs/nav';
 import { CliAuth } from 'src/pages/scientificServices/cli-auth/CliAuth';
 import { ProfileView } from 'src/pages/scientificServices/pipelines/account/ProfileView';
 import { QuotasView } from 'src/pages/scientificServices/pipelines/account/QuotasView';
@@ -52,13 +54,13 @@ export const navPaths = [
     component: ProfileView,
     title: 'Profile',
   },
-  // DEPRECATED: this path is here to avoid breaking any existing links to /account.
+  // DEPRECATED: this redirect is here to avoid breaking any existing links to /pipelines/account.
   // The pipelines-profile path should be used going forward.
   {
-    name: 'pipelines-profile-deprecated',
+    name: 'pipelines-account',
     path: '/pipelines/account',
-    component: ProfileView,
-    title: 'Profile',
+    component: (props) => <Nav.Redirector pathname={Nav.getPath('pipelines-profile', props)} search='' />,
+    title: 'Account',
   },
   {
     name: 'pipelines-quotas',

--- a/src/pages/scientificServices/NavPaths.tsx
+++ b/src/pages/scientificServices/NavPaths.tsx
@@ -46,15 +46,16 @@ export const navPaths = [
     title: 'Sign in to the terralab CLI',
     public: true,
   },
-  // DEPRECATED: this is here to avoid breaking any existing links. The pipelines-profile route is preferred.
   {
-    name: 'pipelines-account',
+    name: 'pipelines-profile',
     path: '/pipelines/profile',
     component: ProfileView,
     title: 'Profile',
   },
+  // DEPRECATED: this path is here to avoid breaking any existing links to /account.
+  // The pipelines-profile path should be used going forward.
   {
-    name: 'pipelines-profile',
+    name: 'pipelines-profile-deprecated',
     path: '/pipelines/account',
     component: ProfileView,
     title: 'Profile',

--- a/src/pages/scientificServices/pipelines/account/ProfileView.test.tsx
+++ b/src/pages/scientificServices/pipelines/account/ProfileView.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import React from 'react';
-import { AccountAndQuotas } from 'src/pages/scientificServices/pipelines/account/AccountAndQuotas';
+import { ProfileView } from 'src/pages/scientificServices/pipelines/account/ProfileView';
 import { renderWithAppContexts } from 'src/testing/test-utils';
 
 // Mock page navigation functions
@@ -17,15 +17,6 @@ jest.mock('src/libs/state', () => ({
   }),
 }));
 
-jest.mock('src/profile/personal-info/useProxyGroup', () => ({
-  useProxyGroup: () => ({
-    proxyGroup: {
-      status: 'Ready' as const,
-      state: 'PROXY_1234567890@example.com',
-    },
-  }),
-}));
-
 jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList', () => ({
   usePipelinesList: jest.fn(() => ({
     pipelines: [],
@@ -35,13 +26,20 @@ jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList', () =>
   })),
 }));
 
-describe('AccountAndQuotas', () => {
-  it('renders the page with appropriate sections', () => {
-    renderWithAppContexts(<AccountAndQuotas />);
+jest.mock('src/profile/personal-info/useProxyGroup', () => ({
+  useProxyGroup: () => ({
+    proxyGroup: {
+      status: 'Ready' as const,
+      state: 'PROXY_1234567890@example.com',
+    },
+  }),
+}));
 
-    expect(screen.getByText('Account & Quotas')).toBeInTheDocument();
-    expect(screen.getByText('Account Info')).toBeInTheDocument();
+describe('ProfileView', () => {
+  it('renders the page with appropriate sections', async () => {
+    renderWithAppContexts(<ProfileView />);
+
+    expect(screen.getByText('Account Information')).toBeInTheDocument();
     expect(screen.getByText('Proxy Group')).toBeInTheDocument();
-    expect(screen.getByText('Pipeline Quotas')).toBeInTheDocument();
   });
 });

--- a/src/pages/scientificServices/pipelines/account/ProfileView.tsx
+++ b/src/pages/scientificServices/pipelines/account/ProfileView.tsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import { BasicAccountInfoDisplay } from 'src/pages/scientificServices/pipelines/account/sections/BasicAccountInfoDisplay';
-import { PipelineQuotaDisplay } from 'src/pages/scientificServices/pipelines/account/sections/PipelineQuotaDisplay';
 import { ProxyGroupDisplay } from 'src/pages/scientificServices/pipelines/account/sections/ProxyGroupDisplay';
 import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
 import { PipelineWidgetContainer } from 'src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineWidgetContainer';
 
-export const AccountAndQuotas = () => {
+export const ProfileView = () => {
   return (
     <PipelinesLayout>
       <div style={{ margin: '1rem 2rem' }}>
-        <h3>Account & Quotas</h3>
-
-        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>
-          <PipelineWidgetContainer title='Account Info' width='50%' marginTop='0' marginBottom='0'>
+        <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem', flexDirection: 'column' }}>
+          <PipelineWidgetContainer title='Account Information' width='50%' marginTop='0' marginBottom='0'>
             <BasicAccountInfoDisplay />
           </PipelineWidgetContainer>
 
@@ -20,10 +17,6 @@ export const AccountAndQuotas = () => {
             <ProxyGroupDisplay />
           </PipelineWidgetContainer>
         </div>
-
-        <PipelineWidgetContainer title='Pipeline Quotas' width='100%'>
-          <PipelineQuotaDisplay />
-        </PipelineWidgetContainer>
       </div>
     </PipelinesLayout>
   );

--- a/src/pages/scientificServices/pipelines/account/QuotasView.test.tsx
+++ b/src/pages/scientificServices/pipelines/account/QuotasView.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react';
+import React from 'react';
+import { QuotasView } from 'src/pages/scientificServices/pipelines/account/QuotasView';
+import { renderWithAppContexts } from 'src/testing/test-utils';
+
+// Mock page navigation functions
+jest.mock('src/libs/nav', () => ({
+  ...jest.requireActual('src/libs/nav'),
+  getPath: jest.fn(() => '/test/'),
+  getLink: jest.fn(() => '/'),
+}));
+
+jest.mock('src/pages/scientificServices/pipelines/hooks/usePipelinesList', () => ({
+  usePipelinesList: jest.fn(() => ({
+    pipelines: [],
+    uniquePipelines: [],
+    isLoading: false,
+    error: undefined,
+  })),
+}));
+
+describe('QuotasView', () => {
+  it('renders the page with appropriate sections', () => {
+    renderWithAppContexts(<QuotasView />);
+
+    expect(screen.getByText('Pipeline Quotas')).toBeInTheDocument();
+  });
+});

--- a/src/pages/scientificServices/pipelines/account/QuotasView.tsx
+++ b/src/pages/scientificServices/pipelines/account/QuotasView.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { PipelineQuotaDisplay } from 'src/pages/scientificServices/pipelines/account/sections/PipelineQuotaDisplay';
+import { PipelinesLayout } from 'src/pages/scientificServices/pipelines/common/PipelinesLayout';
+import { PipelineWidgetContainer } from 'src/pages/scientificServices/pipelines/tabs/run/widgets/PipelineWidgetContainer';
+
+export const QuotasView = () => {
+  return (
+    <PipelinesLayout>
+      <div style={{ margin: '1rem 2rem' }}>
+        <PipelineWidgetContainer title='Pipeline Quotas' width='100%'>
+          <PipelineQuotaDisplay />
+        </PipelineWidgetContainer>
+      </div>
+    </PipelinesLayout>
+  );
+};

--- a/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
+++ b/src/pages/scientificServices/termsOfService/TermsOfServicePage.tsx
@@ -19,7 +19,7 @@ type LoadState = { status: 'loading' } | { status: 'ready'; content: string } | 
 
 const isValidDocType = (key: unknown): key is TeaspoonsDocType => TABS.some((t) => t.key === key);
 
-interface ScientificServicesTermsOfServicePageProps {
+export interface ScientificServicesTermsOfServicePageProps {
   queryParams?: { document?: string };
 }
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-964

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Splits the Account & Quotas page into two separate pages to set us up for the future vision for billing.

Existing links to /account will be redirected to the new /profile page

<img width="3024" height="1616" alt="screencapture-localhost-3000-2026-06-03-13_54_19" src="https://github.com/user-attachments/assets/22b43d93-a04b-42f8-a5b6-3843f0fb10df" />
<img width="3024" height="1616" alt="screencapture-localhost-3000-2026-06-03-13_54_25" src="https://github.com/user-attachments/assets/a38debb4-f6ed-4d11-ae7b-c8132f8cdc53" />
<img width="3024" height="1616" alt="screencapture-localhost-3000-2026-06-03-13_54_31" src="https://github.com/user-attachments/assets/69832776-a57a-4ea4-82d9-cea19670faa8" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
