### PR TITLE
[TSPS-930] Disable pipeline inputs if user lacks sufficient quota

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -685,6 +685,56 @@ describe('RunJob Component', () => {
     );
   });
 
+  it('displays insufficient quota warning and disables all input fields when user lacks quota', async () => {
+    // Mock insufficient quota: user has consumed most of their quota
+    const insufficientQuotaDetails = {
+      pipelineName: 'array_imputation',
+      quotaLimit: 2000,
+      quotaConsumed: 2000, // Only 50 units remaining, but min required is 175
+      quotaUnits: 'units',
+    };
+
+    asMockedFn(mockTeaspoonsContract.getQuotaForPipeline).mockResolvedValue(insufficientQuotaDetails);
+
+    render(<RunJob />);
+
+    // Wait for the component to load and fetch quota
+    await waitFor(() => {
+      expect(screen.getByText('Submit')).toBeInTheDocument();
+    });
+
+    // Verify the insufficient quota warning message is displayed
+    expect(
+      screen.getByText(
+        'You do not have enough quota remaining to run this pipeline. Please request a quote for additional quota.'
+      )
+    ).toBeInTheDocument();
+
+    // Verify input fields are disabled
+    const outputPrefixInput = screen.getByLabelText('output basename text input');
+    expect(outputPrefixInput).toHaveAttribute('aria-disabled', 'true');
+
+    const minDr2Input = screen.getByLabelText('minimum imputation quality for inclusion float input');
+    expect(minDr2Input).toBeDisabled();
+
+    const descriptionTextArea = screen.getByLabelText('description');
+    expect(descriptionTextArea).toBeDisabled();
+
+    const allowChunkFailuresCheckbox = screen.getByLabelText('Allow chunk failures');
+    expect(allowChunkFailuresCheckbox).toBeDisabled();
+
+    const fileInputs = screen.getAllByText(/Select a/);
+    expect(fileInputs.length).toBeGreaterThan(0);
+
+    const submitButton = screen.getByText('Submit');
+    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+
+    const tosCheckbox = screen.getByRole('checkbox', {
+      name: /I have read and agree to the/,
+    });
+    expect(tosCheckbox).toBeDisabled();
+  });
+
   describe('Query parameter pre-selection', () => {
     const lowPassPipeline: Pipeline = {
       pipelineName: 'low_pass_imputation',

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.test.tsx
@@ -690,7 +690,7 @@ describe('RunJob Component', () => {
     const insufficientQuotaDetails = {
       pipelineName: 'array_imputation',
       quotaLimit: 2000,
-      quotaConsumed: 2000, // Only 50 units remaining, but min required is 175
+      quotaConsumed: 2000,
       quotaUnits: 'units',
     };
 
@@ -698,21 +698,20 @@ describe('RunJob Component', () => {
 
     render(<RunJob />);
 
-    // Wait for the component to load and fetch quota
+    await waitFor(() => {
+      expect(mockTeaspoonsContract.getPipelineDetails).toHaveBeenCalledWith('array_imputation', 1);
+    });
+
     await waitFor(() => {
       expect(screen.getByText('Submit')).toBeInTheDocument();
     });
 
-    // Verify the insufficient quota warning message is displayed
-    expect(
-      screen.getByText(
-        'You do not have enough quota remaining to run this pipeline. Please request a quote for additional quota.'
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText('Submit')).toHaveAttribute('aria-disabled', 'true');
 
-    // Verify input fields are disabled
+    expect(screen.getByText(/You do not have enough quota remaining to run this pipeline/)).toBeInTheDocument();
+
     const outputPrefixInput = screen.getByLabelText('output basename text input');
-    expect(outputPrefixInput).toHaveAttribute('aria-disabled', 'true');
+    expect(outputPrefixInput).toBeDisabled();
 
     const minDr2Input = screen.getByLabelText('minimum imputation quality for inclusion float input');
     expect(minDr2Input).toBeDisabled();
@@ -721,18 +720,15 @@ describe('RunJob Component', () => {
     expect(descriptionTextArea).toBeDisabled();
 
     const allowChunkFailuresCheckbox = screen.getByLabelText('Allow chunk failures');
-    expect(allowChunkFailuresCheckbox).toBeDisabled();
+    expect(allowChunkFailuresCheckbox).toHaveAttribute('disabled');
 
     const fileInputs = screen.getAllByText(/Select a/);
     expect(fileInputs.length).toBeGreaterThan(0);
 
-    const submitButton = screen.getByText('Submit');
-    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
-
     const tosCheckbox = screen.getByRole('checkbox', {
       name: /I have read and agree to the/,
     });
-    expect(tosCheckbox).toBeDisabled();
+    expect(tosCheckbox).toHaveAttribute('disabled');
   });
 
   describe('Query parameter pre-selection', () => {

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -309,7 +309,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
               />
             </div>
           )}
-          {!meetsMinimumQuota && (
+          {meetsMinimumQuota === false && (
             <div
               style={{
                 marginTop: '1rem',

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -320,7 +320,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                 return (
                   <PipelineStringInput
                     input={input}
-                    disabled={!meetsMinimumQuota}
+                    disabled={meetsMinimumQuota === false}
                     onChange={(value) =>
                       setSelectedUserInputs((prev) => ({
                         ...prev,
@@ -342,7 +342,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                 return (
                   <PipelineFloatInput
                     input={input}
-                    disabled={!meetsMinimumQuota}
+                    disabled={meetsMinimumQuota === false}
                     onChange={(value) =>
                       setSelectedUserInputs((prev) => ({
                         ...prev,
@@ -362,7 +362,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
               <PipelineRunDescription
                 value={runDescription}
                 onChange={setRunDescription}
-                disabled={!meetsMinimumQuota}
+                disabled={meetsMinimumQuota === false}
               />
             )}
 
@@ -374,7 +374,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                   <PipelineBooleanInput
                     value={selectedUserInputs[input.name]}
                     input={input}
-                    disabled={!meetsMinimumQuota}
+                    disabled={meetsMinimumQuota === false}
                     key={`${input.name}`}
                     onChange={(value) => {
                       setSelectedUserInputs((prev) => ({
@@ -394,7 +394,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                   <PipelineFileBasedInput
                     key={`${input.name}`}
                     input={input}
-                    disabled={!meetsMinimumQuota}
+                    disabled={meetsMinimumQuota === false}
                     uploadState={uploadState[input.name]}
                     selectedFile={selectedUserInputs[input.name] || null}
                     setUploadState={setUploadState}

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -320,6 +320,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                 return (
                   <PipelineStringInput
                     input={input}
+                    disabled={!meetsMinimumQuota}
                     onChange={(value) =>
                       setSelectedUserInputs((prev) => ({
                         ...prev,
@@ -341,6 +342,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                 return (
                   <PipelineFloatInput
                     input={input}
+                    disabled={!meetsMinimumQuota}
                     onChange={(value) =>
                       setSelectedUserInputs((prev) => ({
                         ...prev,
@@ -356,7 +358,13 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
               })}
 
             {/* Displays optional run description */}
-            {selectedPipeline && <PipelineRunDescription value={runDescription} onChange={setRunDescription} />}
+            {selectedPipeline && (
+              <PipelineRunDescription
+                value={runDescription}
+                onChange={setRunDescription}
+                disabled={!meetsMinimumQuota}
+              />
+            )}
 
             {/* Displays all BOOLEAN inputs, one after another */}
             {pipelineInputs
@@ -366,6 +374,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                   <PipelineBooleanInput
                     value={selectedUserInputs[input.name]}
                     input={input}
+                    disabled={!meetsMinimumQuota}
                     key={`${input.name}`}
                     onChange={(value) => {
                       setSelectedUserInputs((prev) => ({
@@ -385,6 +394,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                   <PipelineFileBasedInput
                     key={`${input.name}`}
                     input={input}
+                    disabled={!meetsMinimumQuota}
                     uploadState={uploadState[input.name]}
                     selectedFile={selectedUserInputs[input.name] || null}
                     setUploadState={setUploadState}
@@ -436,7 +446,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
                   </div>
                 )}
                 <div style={{ marginTop: '2rem' }}>
-                  <LabeledCheckbox checked={agreeToTerms} onChange={setAgreeToTerms}>
+                  <LabeledCheckbox checked={agreeToTerms} onChange={setAgreeToTerms} disabled={!meetsMinimumQuota}>
                     <span>
                       {' '}
                       I have read and agree to the{' '}

--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -309,6 +309,37 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
               />
             </div>
           )}
+          {!meetsMinimumQuota && (
+            <div
+              style={{
+                marginTop: '1rem',
+                width: '400px',
+                border: '1px solid #8f95a0',
+                backgroundColor: colors.danger(0.05),
+                borderRadius: '4px',
+                padding: '1rem',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                }}
+              >
+                <Icon icon='warning-standard' size={36} style={{ color: colors.danger(), marginRight: '1rem' }} />
+                <div>
+                  You do not have enough quota remaining to run this pipeline. Please{' '}
+                  <Link
+                    href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
+                    style={{ color: '#46A3E9', fontWeight: 'bold' }}
+                  >
+                    request a quote
+                  </Link>{' '}
+                  for additional quota.
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         {!isEmpty(pipelineInputs) && !isLoadingQuota && (
@@ -415,36 +446,6 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
             {/* Submit button */}
             {!submittedJobId && quota && (
               <>
-                {!meetsMinimumQuota && (
-                  <div
-                    style={{
-                      marginTop: '1rem',
-                      width: '500px',
-                      border: '1px solid #8f95a0',
-                      borderRadius: '4px',
-                      padding: '1rem',
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                      }}
-                    >
-                      <Icon icon='warning-standard' size={36} style={{ color: colors.danger(), marginRight: '1rem' }} />
-                      <div>
-                        You do not have enough quota remaining to run this pipeline. Please{' '}
-                        <Link
-                          href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
-                          style={{ color: '#46A3E9', fontWeight: 'bold' }}
-                        >
-                          request a quote
-                        </Link>{' '}
-                        for additional quota.
-                      </div>
-                    </div>
-                  </div>
-                )}
                 <div style={{ marginTop: '2rem' }}>
                   <LabeledCheckbox checked={agreeToTerms} onChange={setAgreeToTerms} disabled={!meetsMinimumQuota}>
                     <span>

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineRunDescription.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/PipelineRunDescription.tsx
@@ -4,9 +4,10 @@ import { TextArea } from 'src/components/input';
 interface PipelineRunDescriptionProps {
   value: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }
 
-export const PipelineRunDescription: React.FC<PipelineRunDescriptionProps> = ({ value, onChange }) => {
+export const PipelineRunDescription: React.FC<PipelineRunDescriptionProps> = ({ value, onChange, disabled }) => {
   return (
     <>
       <h3 style={{ marginBottom: '0.5rem' }}>Enter description</h3>
@@ -14,6 +15,7 @@ export const PipelineRunDescription: React.FC<PipelineRunDescriptionProps> = ({ 
         rows={4}
         aria-label='description'
         value={value}
+        disabled={disabled}
         placeholder='Enter optional description'
         style={{ width: 500 }}
         onChange={onChange}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/boolean/PipelineBooleanInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/boolean/PipelineBooleanInput.test.tsx
@@ -96,4 +96,25 @@ describe('PipelineBooleanInput', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(false);
   });
+
+  it('renders checkbox as disabled when disabled prop is true', () => {
+    render(<PipelineBooleanInput input={basePipelineInput} value={false} onChange={mockOnChange} disabled />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('disabled');
+  });
+
+  it('renders checkbox as enabled when disabled prop is false', () => {
+    render(<PipelineBooleanInput input={basePipelineInput} value={false} onChange={mockOnChange} disabled={false} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toHaveAttribute('disabled');
+  });
+
+  it('renders checkbox as enabled when disabled prop is not provided', () => {
+    render(<PipelineBooleanInput input={basePipelineInput} value={false} onChange={mockOnChange} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toHaveAttribute('disabled');
+  });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/boolean/PipelineBooleanInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/boolean/PipelineBooleanInput.tsx
@@ -7,9 +7,10 @@ interface PipelineBooleanInputProps {
   input: PipelineInput;
   value: boolean;
   onChange: (value: boolean) => void;
+  disabled?: boolean;
 }
 
-export const PipelineBooleanInput: React.FC<PipelineBooleanInputProps> = ({ input, value, onChange }) => {
+export const PipelineBooleanInput: React.FC<PipelineBooleanInputProps> = ({ input, value, onChange, disabled }) => {
   const { name, displayName, description, defaultValue, isRequired } = input;
 
   return (
@@ -18,6 +19,7 @@ export const PipelineBooleanInput: React.FC<PipelineBooleanInputProps> = ({ inpu
         <LabeledCheckbox
           checked={value ?? defaultValue ?? false}
           width={400}
+          disabled={disabled}
           onChange={(e) => {
             onChange(e);
           }}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.test.tsx
@@ -595,4 +595,222 @@ describe('PipelineFileBasedInput - MANIFEST input type', () => {
     expect(onValidation).toHaveBeenCalledWith(undefined);
     expect(onFileSelect).toHaveBeenCalledWith(validFile);
   });
+
+  describe('FileSourceSelector disabled prop behavior', () => {
+    const mockRequiredFileInput: PipelineInput = {
+      name: 'testFile',
+      displayName: 'test file',
+      type: 'FILE',
+      isRequired: true,
+      fileSuffix: '.txt',
+    };
+
+    it('disables both source buttons when disabled prop is true', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+
+      expect(uploadFileButton).toHaveAttribute('disabled');
+      expect(gcpButton).toHaveAttribute('disabled');
+    });
+
+    it('enables both source buttons when disabled prop is false', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled={false}
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+
+      expect(uploadFileButton).not.toHaveAttribute('disabled');
+      expect(gcpButton).not.toHaveAttribute('disabled');
+    });
+
+    it('enables both source buttons when disabled prop is not provided', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+
+      expect(uploadFileButton).not.toHaveAttribute('disabled');
+      expect(gcpButton).not.toHaveAttribute('disabled');
+    });
+
+    it('applies disabled styling to Upload File button when disabled', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+
+      expect(uploadFileButton).toHaveAttribute('disabled');
+      expect(gcpButton).toHaveAttribute('disabled');
+
+      // Verify disabled styling via computed styles
+      const uploadFileStyles = window.getComputedStyle(uploadFileButton);
+      const gcpStyles = window.getComputedStyle(gcpButton);
+      expect(uploadFileStyles.cursor).toBe('not-allowed');
+      expect(gcpStyles.cursor).toBe('not-allowed');
+    });
+
+    it('applies disabled styling to Google Cloud Storage button when disabled', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled
+        />
+      );
+
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+      expect(gcpButton).toHaveAttribute('disabled');
+
+      // Verify disabled styling via computed styles
+      const gcpStyles = window.getComputedStyle(gcpButton);
+      expect(gcpStyles.cursor).toBe('not-allowed');
+    });
+
+    it('applies enabled styling to Upload File button when enabled', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled={false}
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      expect(uploadFileButton).not.toHaveAttribute('disabled');
+
+      // Verify enabled styling via computed styles
+      const uploadFileStyles = window.getComputedStyle(uploadFileButton);
+      expect(uploadFileStyles.cursor).toBe('pointer');
+    });
+
+    it('applies enabled styling to Google Cloud Storage button when enabled', () => {
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled={false}
+        />
+      );
+
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+      expect(gcpButton).not.toHaveAttribute('disabled');
+
+      // Verify enabled styling via computed styles
+      const gcpStyles = window.getComputedStyle(gcpButton);
+      expect(gcpStyles.cursor).toBe('pointer');
+    });
+
+    it('prevents clicking Upload File button when disabled', async () => {
+      const onFileSelect = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={onFileSelect}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      await user.click(uploadFileButton);
+
+      // The file input should not appear when the button is disabled
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).not.toBeInTheDocument();
+    });
+
+    it('prevents clicking Google Cloud Storage button when disabled', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled
+        />
+      );
+
+      const gcpButton = screen.getByText('Google Cloud Storage').closest('button') as HTMLButtonElement;
+      await user.click(gcpButton);
+
+      // The GCS input should not appear when the button is disabled
+      const gcpInput = screen.queryByText(/Enter a GCS path/i);
+      expect(gcpInput).not.toBeInTheDocument();
+    });
+
+    it('allows clicking Upload File button when enabled', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <PipelineFileBasedInput
+          input={mockRequiredFileInput}
+          selectedFile={null}
+          onFileSelect={jest.fn()}
+          validationError={undefined}
+          onValidation={jest.fn()}
+          disabled={false}
+        />
+      );
+
+      const uploadFileButton = screen.getByText('Upload File').closest('button') as HTMLButtonElement;
+      await user.click(uploadFileButton);
+
+      // The file input should appear when the button is enabled and clicked
+      const fileInput = document.querySelector('input[type="file"]');
+      expect(fileInput).toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.tsx
@@ -16,23 +16,25 @@ export interface PipelineInputFileUploadState {
 
 interface FileSourceSelectorProps {
   onSourceSelect: (source: 'local' | 'cloud') => void;
+  disabled?: boolean;
 }
 
-const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect }) => {
+const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect, disabled }) => {
   return (
     <div style={{ textAlign: 'center' }}>
       <div style={{ marginBottom: '1rem' }}>Select a file source</div>
       <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
         <button
           type='button'
+          disabled
           onClick={() => onSourceSelect('local')}
           style={{
             padding: '1.5rem 1rem',
-            border: '1px solid #46A3E9',
+            border: `1px solid ${disabled ? colors.dark(1) : '#46A3E9'}`,
             borderBottomLeftRadius: '8px',
             borderTopLeftRadius: '8px',
-            background: '#e7f3fb',
-            cursor: 'pointer',
+            background: disabled ? colors.dark(0.04) : '#e7f3fb',
+            cursor: disabled ? 'not-allowed' : 'pointer',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
@@ -43,7 +45,7 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect 
             e.currentTarget.style.background = '#d0e8f7';
           }}
           onMouseLeave={(e) => {
-            e.currentTarget.style.background = '#e7f3fb';
+            e.currentTarget.style.background = disabled ? colors.dark(0.04) : '#e7f3fb';
           }}
         >
           <div style={{ height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -53,14 +55,15 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect 
         </button>
         <button
           type='button'
+          disabled
           onClick={() => onSourceSelect('cloud')}
           style={{
             padding: '1.5rem 1rem',
-            border: '1px solid #46A3E9',
+            border: `1px solid ${disabled ? colors.dark(1) : '#46A3E9'}`,
             borderBottomRightRadius: '8px',
             borderTopRightRadius: '8px',
-            background: '#e7f3fb',
-            cursor: 'pointer',
+            background: disabled ? colors.dark(0.04) : '#e7f3fb',
+            cursor: disabled ? 'not-allowed' : 'pointer',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
@@ -71,7 +74,7 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect 
             e.currentTarget.style.background = '#d0e8f7';
           }}
           onMouseLeave={(e) => {
-            e.currentTarget.style.background = '#e7f3fb';
+            e.currentTarget.style.background = disabled ? colors.dark(0.04) : '#e7f3fb';
           }}
         >
           <div style={{ height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -86,6 +89,7 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect 
 
 interface PipelineInputSelectorProps {
   input: PipelineInput;
+  disabled?: boolean;
   selectedFile: File | string | null;
   uploadState?: PipelineInputFileUploadState;
   onFileSelect: (file: File | string | null) => void;
@@ -98,6 +102,7 @@ interface PipelineInputSelectorProps {
 
 export const PipelineFileBasedInput: React.FC<PipelineInputSelectorProps> = ({
   input,
+  disabled,
   selectedFile,
   uploadState,
   onFileSelect,
@@ -145,7 +150,7 @@ export const PipelineFileBasedInput: React.FC<PipelineInputSelectorProps> = ({
           flexDirection: 'column',
         }}
       >
-        {sourceType === null && <FileSourceSelector onSourceSelect={handleSourceSelect} />}
+        {sourceType === null && <FileSourceSelector onSourceSelect={handleSourceSelect} disabled={disabled} />}
         {sourceType === 'cloud' && (
           <GcsFileInput
             input={input}

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/file/PipelineFileBasedInput.tsx
@@ -26,7 +26,7 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect,
       <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'center' }}>
         <button
           type='button'
-          disabled
+          disabled={disabled}
           onClick={() => onSourceSelect('local')}
           style={{
             padding: '1.5rem 1rem',
@@ -55,7 +55,7 @@ const FileSourceSelector: React.FC<FileSourceSelectorProps> = ({ onSourceSelect,
         </button>
         <button
           type='button'
-          disabled
+          disabled={disabled}
           onClick={() => onSourceSelect('cloud')}
           style={{
             padding: '1.5rem 1rem',

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/float/PipelineFloatInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/float/PipelineFloatInput.test.tsx
@@ -142,6 +142,27 @@ describe('PipelineFloatInput', () => {
     expect(onValidation).not.toHaveBeenCalled();
   });
 
+  it('renders input as disabled when disabled prop is true', () => {
+    render(<PipelineFloatInput {...defaultProps} disabled />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+
+  it('renders input as enabled when disabled prop is false', () => {
+    render(<PipelineFloatInput {...defaultProps} disabled={false} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).not.toBeDisabled();
+  });
+
+  it('renders input as enabled when disabled prop is not provided', () => {
+    render(<PipelineFloatInput {...defaultProps} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).not.toBeDisabled();
+  });
+
   describe('validatePipelineFloatInput', () => {
     it('returns undefined for empty input', () => {
       expect(validatePipelineFloatInput('', 0, 1)).toBeUndefined();

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/float/PipelineFloatInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/float/PipelineFloatInput.tsx
@@ -7,6 +7,7 @@ interface PipelineFloatInputProps {
   input: PipelineInput;
   value: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
   validationError?: ReactNode;
   onValidation(error?: ReactNode): void;
 }
@@ -15,6 +16,7 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
   input,
   value,
   onChange,
+  disabled,
   validationError,
   onValidation,
 }) => {
@@ -29,9 +31,13 @@ export const PipelineFloatInput: React.FC<PipelineFloatInputProps> = ({
         width={400}
         error={validationError}
         inputProps={{
+          style: {
+            backgroundColor: disabled ? colors.dark(0.04) : undefined,
+          },
           'aria-label': `${displayName || name} float input`,
           type: 'text',
           value: value || '',
+          disabled,
           placeholder: defaultValue || `Enter ${displayName || name}`,
           onChange: (e) => {
             onChange(e);

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/string/PipelineStringInput.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/string/PipelineStringInput.test.tsx
@@ -112,5 +112,26 @@ describe('PipelineStringInput', () => {
       expect(defaultProps.onChange).toHaveBeenCalledWith(' validInput ');
       expect(defaultProps.onValidation).toHaveBeenCalledWith(undefined);
     });
+
+    it('renders input as disabled when disabled prop is true', () => {
+      render(<PipelineStringInput {...defaultProps} disabled />);
+
+      const input = screen.getByRole('textbox');
+      expect(input).toBeDisabled();
+    });
+
+    it('renders input as enabled when disabled prop is false', () => {
+      render(<PipelineStringInput {...defaultProps} disabled={false} />);
+
+      const input = screen.getByRole('textbox');
+      expect(input).not.toBeDisabled();
+    });
+
+    it('renders input as enabled when disabled prop is not provided', () => {
+      render(<PipelineStringInput {...defaultProps} />);
+
+      const input = screen.getByRole('textbox');
+      expect(input).not.toBeDisabled();
+    });
   });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/inputs/string/PipelineStringInput.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/inputs/string/PipelineStringInput.tsx
@@ -6,6 +6,7 @@ import colors from 'src/libs/colors';
 interface PipelineStringInputProps {
   input: PipelineInput;
   value: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
   validationError?: ReactNode;
   onValidation(error?: ReactNode): void;
@@ -15,6 +16,7 @@ export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
   input,
   value,
   onChange,
+  disabled,
   validationError,
   onValidation,
 }) => {
@@ -29,9 +31,13 @@ export const PipelineStringInput: React.FC<PipelineStringInputProps> = ({
         width={400}
         error={validationError}
         inputProps={{
+          style: {
+            backgroundColor: disabled ? colors.dark(0.04) : undefined,
+          },
           'aria-label': `${displayName || name} text input`,
           type: 'text',
           value: value || '',
+          disabled,
           placeholder: defaultValue || `Enter ${displayName || name}`,
           onChange: (e) => {
             onChange(e);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-930

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Disables the form elements if a user doesn't have enough quota to actually run the pipeline.

Before
<img width="3024" height="2430" alt="screencapture-bvdp-saturn-dev-appspot-2026-06-08-17_21_19" src="https://github.com/user-attachments/assets/9693e93d-ec5d-49f6-8bfb-925b4067cf07" />


After
<img width="1920" height="1231" alt="screencapture-localhost-3000-2026-06-09-10_35_50" src="https://github.com/user-attachments/assets/09184d56-0e39-4cee-a2a9-ab8bcde93fd6" />

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
