### PR TITLE
[TSPS-954] Add new colors for future pipeline badges

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -313,7 +313,7 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
 
         {!isEmpty(pipelineInputs) && !isLoadingQuota && (
           <>
-            {/* Displays all STRING inputs, one after another */}
+            {/* Displays all STRING inputs, one after another. */}
             {pipelineInputs
               .filter((input) => input.type === 'STRING')
               .map((input) => {

--- a/src/pages/scientificServices/pipelines/utils/pipeline-style-utils.tsx
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-style-utils.tsx
@@ -37,6 +37,8 @@ export const getPipelineColor = (pipelineRun: PipelineRun): string => {
       return '#4D72AA4D';
     case 'low_pass_imputation':
       return '#AA4D8B4D';
+    case 'sv_imputation':
+      return '#C1683A4D';
     default:
       return '#8FBC8A4D';
   }

--- a/src/pages/scientificServices/pipelines/utils/pipeline-style-utils.tsx
+++ b/src/pages/scientificServices/pipelines/utils/pipeline-style-utils.tsx
@@ -35,7 +35,9 @@ export const getPipelineColor = (pipelineRun: PipelineRun): string => {
   switch (pipelineRun.pipelineName) {
     case 'array_imputation':
       return '#4D72AA4D';
-    default:
+    case 'low_pass_imputation':
       return '#AA4D8B4D';
+    default:
+      return '#8FBC8A4D';
   }
 };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-954

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Sets the current fallback color to low_pass_imputation, adds a new color for sv_imputation, and adds a new fallback color for future pipelines like GVS (we don't know what that one will be named yet exactly)


<img width="419" height="308" alt="Screenshot 2026-06-09 at 11 48 35 AM" src="https://github.com/user-attachments/assets/10c0d1ee-4a16-4610-831a-dc26168753fe" />



### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
