### PR TITLE
[TSPS-975] Show max samples allowed per job and refactor loading behavior

### DIFF
--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -31,7 +31,7 @@ export interface PipelineQuota {
   pipelineName: string;
   defaultQuota: number;
   minQuotaConsumed: number;
-  maxQuotaConsumed: number;
+  maxQuotaConsumed?: number;
   quotaUnits: string;
 }
 

--- a/src/libs/ajax/teaspoons/teaspoons-models.ts
+++ b/src/libs/ajax/teaspoons/teaspoons-models.ts
@@ -31,6 +31,7 @@ export interface PipelineQuota {
   pipelineName: string;
   defaultQuota: number;
   minQuotaConsumed: number;
+  maxQuotaConsumed: number;
   quotaUnits: string;
 }
 

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
@@ -21,7 +21,7 @@ describe('QuotaDetailsWidget', () => {
   it('displays the correct remaining and used quota', async () => {
     renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
 
-    await waitFor(() => expect(screen.getByText('1250', { exact: false })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('1,250', { exact: false })).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('750', { exact: false })).toBeInTheDocument());
   });
 
@@ -39,7 +39,7 @@ describe('QuotaDetailsWidget', () => {
     renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
 
     await waitFor(() =>
-      expect(screen.getByText('There is a maximum of 5250 things allowed per job.')).toBeInTheDocument()
+      expect(screen.getByText('There is a maximum of 5,250 things allowed per job.')).toBeInTheDocument()
     );
   });
 

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
@@ -6,6 +6,7 @@ import {
   mockPipelineWithDetails,
   mockUserPipelineQuotaDetails,
 } from 'src/pages/scientificServices/pipelines/utils/mock-utils';
+import { renderWithAppContexts } from 'src/testing/test-utils';
 
 import { QuotaDetailsWidget } from './QuotaDetailsWidget';
 
@@ -18,20 +19,28 @@ jest.mock('src/libs/ajax/teaspoons/Teaspoons', () => ({
 
 describe('QuotaDetailsWidget', () => {
   it('displays the correct remaining and used quota', async () => {
-    render(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
 
     await waitFor(() => expect(screen.getByText('1250', { exact: false })).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('750', { exact: false })).toBeInTheDocument());
   });
 
   it('displays the minimum quota consumed for the pipeline', async () => {
-    render(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
 
     await waitFor(() => expect(screen.getByText(/every submitted job will consume at least/i)).toBeInTheDocument());
 
     await expect(
       screen.getByText('Every submitted job will consume at least 175 things from your quota.', { exact: false })
     ).toBeInTheDocument();
+  });
+
+  it('displays the maximum allowed quota for the pipeline', async () => {
+    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+
+    await waitFor(() =>
+      expect(screen.getByText('There is a maximum of 5250 things allowed per job.')).toBeInTheDocument()
+    );
   });
 
   it('displays a message when no pipeline is selected', () => {

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@terra-ui-packages/components';
 import React from 'react';
 import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
@@ -9,11 +10,26 @@ import { useUserQuota } from 'src/pages/scientificServices/pipelines/hooks/useUs
 import { PipelineWidgetContainer } from './PipelineWidgetContainer';
 
 export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pipeline }) => {
-  const { quota, pipelineDetails, meetsMinimumQuota } = useUserQuota(selectedPipeline);
+  const { quota, pipelineDetails, meetsMinimumQuota, isLoading } = useUserQuota(selectedPipeline);
 
   return (
     <PipelineWidgetContainer title='Quota Details' marginBottom='1rem'>
       {cond(
+        [
+          isLoading,
+          () => (
+            <div
+              style={{
+                marginTop: '1rem',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+              }}
+            >
+              <Spinner size={16} /> Loading quota details...
+            </div>
+          ),
+        ],
         [!selectedPipeline, () => <div style={{ marginTop: '1rem' }}>Select a pipeline to see quota</div>],
         [
           !!quota,
@@ -23,6 +39,7 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
               // has no idea what cond is doing, so we sadly need the extra type guard
               return <div style={{ marginTop: '1rem' }}>No quota information available for this pipeline.</div>;
             }
+
             return (
               <div style={{ marginTop: '1rem' }}>
                 <div
@@ -60,33 +77,54 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
                   </div>
                 </div>
                 {pipelineDetails && (
-                  <div style={{ marginTop: '1rem' }}>
-                    <span style={{ fontWeight: 600 }}>
-                      {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
-                    </span>
-                  </div>
+                  <>
+                    <div style={{ marginTop: '1rem' }}>
+                      <span style={{ fontWeight: 600 }}>
+                        {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
+                      </span>
+                    </div>
+                    <div style={{ marginTop: '1rem' }}>
+                      <span style={{ fontWeight: 600 }}>
+                        {`There is a maximum of ${pipelineDetails.pipelineQuota?.maxQuotaConsumed} ${quota.quotaUnits} allowed per job.`}
+                      </span>
+                    </div>
+                  </>
                 )}
+                <div style={{ marginTop: '1rem' }}>
+                  <a
+                    href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
+                    style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
+                  >
+                    Request a quote
+                  </a>
+                  &nbsp;for quota.
+                </div>
+                <div style={{ marginTop: '1rem' }}>
+                  <ZendeskLink docsKey={DocsKey.QUOTA_DETAILS} additionalStyle={{ fontWeight: 'bold' }}>
+                    Get help
+                  </ZendeskLink>
+                  &nbsp;with quota.
+                </div>
               </div>
             );
           },
         ],
-        [DEFAULT, () => <div style={{ marginTop: '1rem' }}>Loading quota...</div>]
+        [
+          DEFAULT,
+          () => (
+            <div
+              style={{
+                marginTop: '1rem',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+              }}
+            >
+              <Spinner size={16} /> Loading quota details...
+            </div>
+          ),
+        ]
       )}
-      <div style={{ marginTop: '1rem' }}>
-        <a
-          href={`mailto:${SCIENTIFIC_SERVICES_SUPPORT_EMAIL}?subject=Request%20a%20quote%20for%20quota`}
-          style={{ color: '#46A3E9', textDecoration: 'underline', fontWeight: 'bold' }}
-        >
-          Request a quote
-        </a>
-        &nbsp;for quota.
-      </div>
-      <div style={{ marginTop: '1rem' }}>
-        <ZendeskLink docsKey={DocsKey.QUOTA_DETAILS} additionalStyle={{ fontWeight: 'bold' }}>
-          Get help
-        </ZendeskLink>
-        &nbsp;with quota.
-      </div>
     </PipelineWidgetContainer>
   );
 };

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
@@ -56,7 +56,9 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
                         alignItems: 'flex-start',
                       }}
                     >
-                      <div style={{ fontWeight: 'bold', fontSize: 16 }}>{quota.quotaLimit - quota.quotaConsumed}</div>
+                      <div style={{ fontWeight: 'bold', fontSize: 16 }}>
+                        {(quota.quotaLimit - quota.quotaConsumed).toLocaleString()}
+                      </div>
                       <div style={{ color: '#6B6C6E', marginTop: '0.125rem', fontSize: 13 }}>
                         {quota.quotaUnits} remaining
                       </div>
@@ -69,7 +71,7 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
                         alignItems: 'flex-start',
                       }}
                     >
-                      <div style={{ fontWeight: 'bold', fontSize: 16 }}>{quota.quotaConsumed}</div>
+                      <div style={{ fontWeight: 'bold', fontSize: 16 }}>{quota.quotaConsumed.toLocaleString()}</div>
                       <div style={{ color: '#6B6C6E', marginTop: '0.125rem', fontSize: 13 }}>
                         {quota.quotaUnits} used
                       </div>
@@ -80,13 +82,17 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
                   <>
                     <div style={{ marginTop: '1rem' }}>
                       <span style={{ fontWeight: 600 }}>
-                        {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
+                        {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed.toLocaleString()} ${
+                          quota.quotaUnits
+                        } from your quota.`}
                       </span>
                     </div>
                     {pipelineDetails.pipelineQuota?.maxQuotaConsumed && (
                       <div style={{ marginTop: '1rem' }}>
                         <span style={{ fontWeight: 600 }}>
-                          {`There is a maximum of ${pipelineDetails.pipelineQuota.maxQuotaConsumed} ${quota.quotaUnits} allowed per job.`}
+                          {`There is a maximum of ${pipelineDetails.pipelineQuota.maxQuotaConsumed.toLocaleString()} ${
+                            quota.quotaUnits
+                          } allowed per job.`}
                         </span>
                       </div>
                     )}

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
@@ -83,11 +83,13 @@ export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pi
                         {`Every submitted job will consume at least ${pipelineDetails.pipelineQuota?.minQuotaConsumed} ${quota.quotaUnits} from your quota.`}
                       </span>
                     </div>
-                    <div style={{ marginTop: '1rem' }}>
-                      <span style={{ fontWeight: 600 }}>
-                        {`There is a maximum of ${pipelineDetails.pipelineQuota?.maxQuotaConsumed} ${quota.quotaUnits} allowed per job.`}
-                      </span>
-                    </div>
+                    {pipelineDetails.pipelineQuota?.maxQuotaConsumed && (
+                      <div style={{ marginTop: '1rem' }}>
+                        <span style={{ fontWeight: 600 }}>
+                          {`There is a maximum of ${pipelineDetails.pipelineQuota.maxQuotaConsumed} ${quota.quotaUnits} allowed per job.`}
+                        </span>
+                      </div>
+                    )}
                   </>
                 )}
                 <div style={{ marginTop: '1rem' }}>

--- a/src/pages/scientificServices/pipelines/utils/mock-utils.ts
+++ b/src/pages/scientificServices/pipelines/utils/mock-utils.ts
@@ -90,6 +90,7 @@ export function mockPipelineWithDetails(name: string): PipelineWithDetails {
       pipelineName: name,
       defaultQuota: 2500,
       minQuotaConsumed: 175,
+      maxQuotaConsumed: 5250,
       quotaUnits: 'units',
     },
   };


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-975

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

* Adds the max allowed number of samples per job
* Refactors the loading behavior of the quota details widget to show spinners and hide certain content while it's still loading, to avoid jarring reload behavior when switching the selected pipeline

<img width="423" height="352" alt="Screenshot 2026-06-15 at 3 21 24 PM" src="https://github.com/user-attachments/assets/f77d27ed-597e-4c45-a455-24aaf2ab038c" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
