### PR TITLE
[TSPS-957] Show file sizes of output files

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/JobDetailsHeader.tsx
@@ -70,7 +70,9 @@ export const JobDetailsHeader = ({ pipelineRunResult }: JobDetailsHeaderProps) =
               )}
             </h2>
             {!isLoadingPipelineDetails && pipelineDetails?.description && (
-              <div style={{ margin: '1rem 0rem', color: colors.dark(0.8) }}>{pipelineDetails.description}</div>
+              <div style={{ margin: '1rem 0rem', color: colors.dark(0.8) }}>
+                <AoUStylizedString text={pipelineDetails.description} />
+              </div>
             )}
           </div>
 

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
@@ -360,7 +360,6 @@ describe('JobOutputsView', () => {
     render(<JobOutputsView outputDefinitions={mockOutputDefinitions} pipelineRunResult={mockResult} />);
 
     await waitFor(() => {
-      // File size should be displayed in parentheses next to the filename
       expect(screen.queryByText('1.00 MiB', { exact: false })).toBeInTheDocument();
     });
   });
@@ -380,7 +379,6 @@ describe('JobOutputsView', () => {
 
     await waitFor(() => {
       expect(screen.getByText('gs://bucket/output.vcf')).toBeInTheDocument();
-      // Should not display any file size information
       expect(screen.queryByText(/MiB/)).not.toBeInTheDocument();
       expect(screen.queryByText(/KiB/)).not.toBeInTheDocument();
       expect(screen.queryByText(/GiB/)).not.toBeInTheDocument();

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.test.tsx
@@ -345,4 +345,45 @@ describe('JobOutputsView', () => {
       expect(modal).toHaveTextContent('gs://bucket/my-output.vcf');
     });
   });
+
+  it('displays file size next to filename when sizeInBytes is available', async () => {
+    const mockResult = {
+      ...mockPipelineRunResponse('SUCCEEDED'),
+      pipelineRunReport: {
+        ...mockPipelineRunResponse('SUCCEEDED').pipelineRunReport,
+        outputs: {
+          imputedMultiSampleVcf: { value: 'gs://bucket/output.vcf', metadata: { sizeInBytes: 1048576 } }, // 1 MiB
+        },
+      },
+    };
+
+    render(<JobOutputsView outputDefinitions={mockOutputDefinitions} pipelineRunResult={mockResult} />);
+
+    await waitFor(() => {
+      // File size should be displayed in parentheses next to the filename
+      expect(screen.queryByText('1.00 MiB', { exact: false })).toBeInTheDocument();
+    });
+  });
+
+  it('does not display file size when sizeInBytes is not available', async () => {
+    const mockResult = {
+      ...mockPipelineRunResponse('SUCCEEDED'),
+      pipelineRunReport: {
+        ...mockPipelineRunResponse('SUCCEEDED').pipelineRunReport,
+        outputs: {
+          imputedMultiSampleVcf: { value: 'gs://bucket/output.vcf' }, // No metadata
+        },
+      },
+    };
+
+    render(<JobOutputsView outputDefinitions={mockOutputDefinitions} pipelineRunResult={mockResult} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('gs://bucket/output.vcf')).toBeInTheDocument();
+      // Should not display any file size information
+      expect(screen.queryByText(/MiB/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/KiB/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/GiB/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/history/details/sections/io/JobOutputsView.tsx
@@ -2,6 +2,7 @@ import { Icon, TooltipTrigger } from '@terra-ui-packages/components';
 import React, { useState } from 'react';
 import { PipelineOutput, PipelineRunResponse } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
+import { formatBytes } from 'src/libs/utils';
 import { PipelineErrorMessage } from 'src/pages/scientificServices/pipelines/common/PipelineErrorMessage';
 import { SCIENTIFIC_SERVICES_SUPPORT_EMAIL } from 'src/pages/scientificServices/pipelines/common/scientific-services-common';
 import { OutputDetailsModal } from 'src/pages/scientificServices/pipelines/tabs/history/details/modals/OutputDetailsModal';
@@ -126,6 +127,7 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
           {Object.entries(outputs).map(([key, outputValue]) => {
             const outputDefinition = outputDefinitions.find((output) => output.name === key);
             const fileName = outputValue.value;
+            const sizeInBytes = outputValue.metadata?.sizeInBytes;
 
             return (
               <div
@@ -144,6 +146,7 @@ export const JobOutputsView = ({ outputDefinitions, pipelineRunResult }: JobOutp
                   outputType={outputDefinition?.type || 'Unknown'}
                   tooltip={outputDefinition?.description || 'No description available for this output'}
                   fileName={fileName}
+                  sizeInBytes={sizeInBytes}
                   disabled={!isSucceeded || !!outputsExpired}
                   onSelect={() => setSelectedOutput({ key, fileName })}
                 />
@@ -177,6 +180,7 @@ const OutputItem = ({
   fileName,
   tooltip,
   outputType,
+  sizeInBytes,
   disabled,
   onSelect,
 }: {
@@ -184,6 +188,7 @@ const OutputItem = ({
   fileName: string;
   tooltip: string;
   outputType: string;
+  sizeInBytes?: number;
   disabled?: boolean;
   onSelect: () => void;
 }) => {
@@ -206,7 +211,10 @@ const OutputItem = ({
         }}
       >
         <code style={{ maxWidth: '70%' }} title={fileName}>
-          {fileName}
+          {fileName}{' '}
+          {sizeInBytes !== undefined && (
+            <span style={{ fontStyle: 'italic', fontWeight: 'lighter' }}>({formatBytes(sizeInBytes)})</span>
+          )}
         </code>
         {!disabled && (
           <div style={{ minWidth: '120px', display: 'flex', justifyContent: 'flex-end', alignItems: 'center' }}>


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-957

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What

Adds file sizes back to the outputs view.

<img width="468" height="419" alt="Screenshot 2026-07-01 at 3 32 45 PM" src="https://github.com/user-attachments/assets/76c8e584-3254-4b79-8198-f10aee274231" />


### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
