### PR TITLE
[TSPS-1028] Refactor API calls to /quotas endpoint

### DIFF
--- a/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/RunJob.tsx
@@ -533,7 +533,13 @@ const RunJobContent = ({ pipelines: pipelinesList }: RunJobContentProps) => {
         )}
       </div>
       <div>
-        <QuotaDetailsWidget selectedPipeline={selectedPipeline} />
+        <QuotaDetailsWidget
+          selectedPipeline={selectedPipeline}
+          quota={quota}
+          pipelineDetails={pipelineDetails}
+          meetsMinimumQuota={meetsMinimumQuota}
+          isLoading={isLoadingQuota}
+        />
         <PipelineOutputsWidget selectedPipelineDetails={pipelineDetails} />
         <HelpfulTipsWidget selectedPipeline={selectedPipeline} />
       </div>

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.test.tsx
@@ -1,5 +1,5 @@
 import { expect } from '@storybook/test';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import {
   mockPipeline,
@@ -15,52 +15,83 @@ jest.mock('src/libs/nav', () => ({
   getLink: jest.fn(() => '/pipelines/quotas'),
 }));
 
-jest.mock('src/libs/ajax/teaspoons/Teaspoons', () => ({
-  Teaspoons: () => ({
-    getQuotaForPipeline: jest.fn().mockResolvedValue(mockUserPipelineQuotaDetails('test_pipeline')),
-    getPipelineDetails: jest.fn().mockResolvedValue(mockPipelineWithDetails('test_pipeline')),
-  }),
-}));
+const mockQuota = mockUserPipelineQuotaDetails('test_pipeline');
+const mockPipelineDetails = mockPipelineWithDetails('test_pipeline');
 
 describe('QuotaDetailsWidget', () => {
-  it('displays the correct remaining and used quota', async () => {
-    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+  it('displays the correct remaining and used quota', () => {
+    renderWithAppContexts(
+      <QuotaDetailsWidget
+        selectedPipeline={mockPipeline('test_pipeline')}
+        quota={mockQuota}
+        pipelineDetails={mockPipelineDetails}
+        meetsMinimumQuota
+        isLoading={false}
+      />
+    );
 
-    await waitFor(() => expect(screen.getByText('1,250', { exact: false })).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('750', { exact: false })).toBeInTheDocument());
+    expect(screen.getByText('1,250', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('750', { exact: false })).toBeInTheDocument();
   });
 
-  it('displays the minimum quota consumed for the pipeline', async () => {
-    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+  it('displays the minimum quota consumed for the pipeline', () => {
+    renderWithAppContexts(
+      <QuotaDetailsWidget
+        selectedPipeline={mockPipeline('test_pipeline')}
+        quota={mockQuota}
+        pipelineDetails={mockPipelineDetails}
+        meetsMinimumQuota
+        isLoading={false}
+      />
+    );
 
-    await waitFor(() => expect(screen.getByText(/every submitted job will consume at least/i)).toBeInTheDocument());
-
-    await expect(
+    expect(screen.getByText(/every submitted job will consume at least/i)).toBeInTheDocument();
+    expect(
       screen.getByText('Every submitted job will consume at least 175 things from your quota.', { exact: false })
     ).toBeInTheDocument();
   });
 
-  it('displays the maximum allowed quota for the pipeline', async () => {
-    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
-
-    await waitFor(() =>
-      expect(screen.getByText('There is a maximum of 5,250 things allowed per job.')).toBeInTheDocument()
+  it('displays the maximum allowed quota for the pipeline', () => {
+    renderWithAppContexts(
+      <QuotaDetailsWidget
+        selectedPipeline={mockPipeline('test_pipeline')}
+        quota={mockQuota}
+        pipelineDetails={mockPipelineDetails}
+        meetsMinimumQuota
+        isLoading={false}
+      />
     );
+
+    expect(screen.getByText('There is a maximum of 5,250 things allowed per job.')).toBeInTheDocument();
   });
 
   it('displays a message when no pipeline is selected', () => {
-    render(<QuotaDetailsWidget selectedPipeline={undefined} />);
+    render(
+      <QuotaDetailsWidget
+        selectedPipeline={undefined}
+        quota={undefined}
+        pipelineDetails={undefined}
+        meetsMinimumQuota={undefined}
+        isLoading={false}
+      />
+    );
 
     expect(screen.getByText('Select a pipeline to see quota')).toBeInTheDocument();
   });
 
-  it('displays "Purchase quota" link with correct href', async () => {
-    renderWithAppContexts(<QuotaDetailsWidget selectedPipeline={mockPipeline('test_pipeline')} />);
+  it('displays "Purchase quota" link with correct href', () => {
+    renderWithAppContexts(
+      <QuotaDetailsWidget
+        selectedPipeline={mockPipeline('test_pipeline')}
+        quota={mockQuota}
+        pipelineDetails={mockPipelineDetails}
+        meetsMinimumQuota
+        isLoading={false}
+      />
+    );
 
-    await waitFor(() => {
-      const purchaseLink = screen.getByText('Purchase');
-      expect(purchaseLink).toBeInTheDocument();
-      expect(purchaseLink).toHaveAttribute('href', '/pipelines/quotas');
-    });
+    const purchaseLink = screen.getByText('Purchase');
+    expect(purchaseLink).toBeInTheDocument();
+    expect(purchaseLink).toHaveAttribute('href', '/pipelines/quotas');
   });
 });

--- a/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
+++ b/src/pages/scientificServices/pipelines/tabs/run/widgets/QuotaDetailsWidget.tsx
@@ -1,17 +1,28 @@
 import { Link, Spinner } from '@terra-ui-packages/components';
 import React from 'react';
-import { Pipeline } from 'src/libs/ajax/teaspoons/teaspoons-models';
+import { Pipeline, PipelineWithDetails, UserPipelineQuotaDetails } from 'src/libs/ajax/teaspoons/teaspoons-models';
 import colors from 'src/libs/colors';
 import * as Nav from 'src/libs/nav';
 import { cond, DEFAULT } from 'src/libs/utils';
 import { DocsKey, ZendeskLink } from 'src/pages/scientificServices/pipelines/common/zendeskUtils';
-import { useUserQuota } from 'src/pages/scientificServices/pipelines/hooks/useUserQuota';
 
 import { PipelineWidgetContainer } from './PipelineWidgetContainer';
 
-export const QuotaDetailsWidget = ({ selectedPipeline }: { selectedPipeline?: Pipeline }) => {
-  const { quota, pipelineDetails, meetsMinimumQuota, isLoading } = useUserQuota(selectedPipeline);
+interface QuotaDetailsWidgetProps {
+  selectedPipeline?: Pipeline;
+  quota?: UserPipelineQuotaDetails;
+  pipelineDetails?: PipelineWithDetails;
+  meetsMinimumQuota?: boolean;
+  isLoading: boolean;
+}
 
+export const QuotaDetailsWidget = ({
+  selectedPipeline,
+  quota,
+  pipelineDetails,
+  meetsMinimumQuota,
+  isLoading,
+}: QuotaDetailsWidgetProps) => {
   return (
     <PipelineWidgetContainer title='Quota Details' marginBottom='1rem'>
       {cond(


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-1028

## Summary of changes:
This PR refactors the QuotaDetailsWidget to receive the quota and pipeline information as props from its parent component. This eliminates the need to duplicate API calls to /quotas and /pipelines endpoints.


### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [x] unit tests
- [x] manual testing

### Visual Aids
**Before**
4 API calls - 2 to /quotas and 2 to /pipelines endpoints
<img width="1498" height="724" alt="Screenshot 2026-07-10 at 4 04 17 PM" src="https://github.com/user-attachments/assets/14213e2d-f11d-4479-99e8-4b344acbfde5" />

**After**
2 API calls - 1 to /quotas and 1 to /pipelines endpoints
<img width="1499" height="687" alt="Screenshot 2026-07-10 at 4 06 07 PM" src="https://github.com/user-attachments/assets/7e7fe618-93e8-4e8c-939c-d2cd6fd728b2" />

