### PR TITLE
[TSPS-1124] Add Stripe links for Low Pass WGS Imputation quota

### DIFF
--- a/src/pages/scientificServices/pipelines/common/purchaseQuotaUtils.test.tsx
+++ b/src/pages/scientificServices/pipelines/common/purchaseQuotaUtils.test.tsx
@@ -34,8 +34,13 @@ describe('purchaseQuotaUtils', () => {
         });
       });
 
-      it('returns undefined for low_pass_imputation (not configured in dev)', () => {
-        expect(getStripePaymentUrls('low_pass_imputation')).toBeUndefined();
+      it('returns correct Stripe URLs for low_pass_imputation', () => {
+        const result = getStripePaymentUrls('low_pass_imputation');
+
+        expect(result).toEqual({
+          academicRate: 'https://buy.stripe.com/test_6oU3cw6Gia5c5cn2aH5wI03',
+          forProfitRate: 'https://buy.stripe.com/test_9B6dRa1lY4KS34f9D95wI04',
+        });
       });
 
       it('returns undefined for unknown pipeline', () => {
@@ -61,8 +66,13 @@ describe('purchaseQuotaUtils', () => {
         });
       });
 
-      it('returns undefined for low_pass_imputation (not configured in prod)', () => {
-        expect(getStripePaymentUrls('low_pass_imputation')).toBeUndefined();
+      it('returns correct Stripe URLs for array_imputation', () => {
+        const result = getStripePaymentUrls('low_pass_imputation');
+
+        expect(result).toEqual({
+          academicRate: 'https://pay.broadclinicallabs.org/b/6oUfZjafw36IasHbyT8k802',
+          forProfitRate: 'https://pay.broadclinicallabs.org/b/7sYbJ3evMePqeIX6ez8k803',
+        });
       });
 
       it('returns undefined for unknown pipeline', () => {

--- a/src/pages/scientificServices/pipelines/common/purchaseQuotaUtils.tsx
+++ b/src/pages/scientificServices/pipelines/common/purchaseQuotaUtils.tsx
@@ -31,12 +31,20 @@ const TEASPOONS_STRIPE_PAYMENT_URLS: Record<Environment, Partial<Record<Pipeline
       academicRate: 'https://buy.stripe.com/test_cNi14o8OqfpwdIT8z55wI01',
       forProfitRate: 'https://buy.stripe.com/test_eVq6oI1lYels6gr4iP5wI02',
     },
+    low_pass_imputation: {
+      academicRate: 'https://buy.stripe.com/test_6oU3cw6Gia5c5cn2aH5wI03',
+      forProfitRate: 'https://buy.stripe.com/test_9B6dRa1lY4KS34f9D95wI04',
+    },
     // add other pipelines here as needed
   },
   prod: {
     array_imputation: {
       academicRate: 'https://pay.broadclinicallabs.org/b/dRm4gBdrIfTu44j7iD8k801',
       forProfitRate: 'https://pay.broadclinicallabs.org/b/4gM14pevMePqasHeL58k800',
+    },
+    low_pass_imputation: {
+      academicRate: 'https://pay.broadclinicallabs.org/b/6oUfZjafw36IasHbyT8k802',
+      forProfitRate: 'https://pay.broadclinicallabs.org/b/7sYbJ3evMePqeIX6ez8k803',
     },
     // add other pipelines here as needed
   },


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TSPS-1124

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- low pass Stripe links for non-prod and prod

Tested that the new query param pre-fill logic still works for low pass.

### Why
-

### Testing strategy
<!-- Note that changes impacting components in Storybook stories can be viewed at
https://www.chromatic.com/library?appId=65fc89c9335768720ff8605a&branch=<branch>
The branch corresponding to this PR is selected, and changes can be reviewed by commit. --->

- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
